### PR TITLE
Utilize contextmanger to prevent non closed db handles

### DIFF
--- a/library.py
+++ b/library.py
@@ -55,15 +55,13 @@ class JLCPCBLibrary:
 
     def load(self):
         """Connect to JLCPCB library DB"""
-        # self.dbh = sqlite3.connect(self.dbfn)
-
         self.partcount, self.filename, self.size = self.get_info()
         self.logger.info(
             f"Loaded %s with {self.partcount} parts", os.path.basename(self.dbfn)
         )
         self.loaded = True
 
-    def get_info(self, dbh=None):
+    def get_info(self):
         """Get info about the state of the database"""
         partcount = 0
         filename = ""


### PR DESCRIPTION
As described in #42 in some situations the db file cannot be deleted because the file is blocked by the other thread.
In order to prevent this, I refactored the library part to utilize contextmanger.

@DanielO would you mind taking a look at what I did and test it?