### PR TITLE
No more wildcard imports

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -6,7 +6,25 @@ from pathlib import Path
 from zipfile import ZipFile
 
 import requests
-from pcbnew import *
+from pcbnew import (
+    EXCELLON_WRITER,
+    PLOT_CONTROLLER,
+    PLOT_FORMAT_GERBER,
+    B_Cu,
+    B_Mask,
+    B_SilkS,
+    Edge_Cuts,
+    F_Cu,
+    F_Mask,
+    F_SilkS,
+    GetBoard,
+    In1_Cu,
+    In2_Cu,
+    In3_Cu,
+    In4_Cu,
+    ToMM,
+    wxPoint,
+)
 
 from .helpers import (
     get_exclude_from_bom,

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -5,7 +5,7 @@ import sys
 
 import wx
 import wx.dataview
-from pcbnew import *
+from pcbnew import GetBoard
 
 from .fabrication import JLCPCBFabrication
 from .helpers import (
@@ -444,6 +444,7 @@ class JLCBCBTools(wx.Dialog):
         part = self.footprint_list.GetTextValue(row, 3)
         if part != "":
             dialog = PartDetailsDialog(self, part)
+
             dialog.Show()
 
     def init_logger(self):

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,6 @@
 import os
 
-from pcbnew import *
+from pcbnew import ActionPlugin
 
 from .mainwindow import JLCBCBTools
 


### PR DESCRIPTION
Replaced the wildcard imports from pcbnew with just the classes etc. that are actually used.