### PR TITLE
Preset search with LCSC number if just one number is selected, fix for #47

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -402,7 +402,19 @@ class JLCBCBTools(wx.Dialog):
     def select_part(self, e):
         """Select and assign a LCSC Part number to a footprint via modal dialog."""
         self.update_library()
-        dialog = PartSelectorDialog(self)
+        # Figure out what LCSC numbers are selected
+        selection = []
+        lcsc = ""
+        for item in self.footprint_list.GetSelections():
+            row = self.footprint_list.ItemToRow(item)
+            _lcsc = self.footprint_list.GetTextValue(row, 3)
+            if not _lcsc in selection:
+                selection.append(_lcsc)
+        # if we have not selected more than one LCSC number, pass it to the selection dialog
+        # as search preset
+        if len(selection) == 1:
+            lcsc = selection[0]
+        dialog = PartSelectorDialog(self, lcsc)
         result = dialog.ShowModal()
         if result == wx.ID_OK:
             for item in self.footprint_list.GetSelections():

--- a/partselector.py
+++ b/partselector.py
@@ -6,7 +6,7 @@ from .partdetails import PartDetailsDialog
 
 
 class PartSelectorDialog(wx.Dialog):
-    def __init__(self, parent):
+    def __init__(self, parent, lcsc_selection=""):
         wx.Dialog.__init__(
             self,
             parent,
@@ -44,7 +44,7 @@ class PartSelectorDialog(wx.Dialog):
         self.keyword = wx.TextCtrl(
             self,
             wx.ID_ANY,
-            wx.EmptyString,
+            lcsc_selection,
             wx.DefaultPosition,
             (300, -1),
             wx.TE_PROCESS_ENTER,


### PR DESCRIPTION
Preset the search with the LCSC number of one or more selected footprints if the have a LCSC number or share the same in case of multiple selected footprints.