### PR TITLE
Fix silkscreen on vias

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 import requests
 from pcbnew import (
     EXCELLON_WRITER,
+    PCB_PLOT_PARAMS,
     PLOT_CONTROLLER,
     PLOT_FORMAT_GERBER,
     B_Cu,
@@ -160,6 +161,8 @@ class JLCPCBFabrication:
         popt.SetUseGerberX2format(True)
         popt.SetIncludeGerberNetlistInfo(True)
         popt.SetDisableGerberMacros(False)
+
+        popt.SetDrillMarksType(PCB_PLOT_PARAMS.NO_DRILL_SHAPE)
 
         popt.SetPlotFrameRef(False)
         popt.SetExcludeEdgeLayer(True)


### PR DESCRIPTION
This is a fix for #57 
The option `SetDrillMarksType` has to be set explicitly to `PCB_PLOT_PARAMS.NO_DRILL_SHAPE` to be equal to the KiCAD Gerber Plot setting `Drill marks: None`

![image](https://user-images.githubusercontent.com/948965/139042788-3f1442fe-ac27-458b-888a-a74efcc6bdcd.png)
 