### PR TITLE
Allow missing LCSC property in BOM/CPL, fix for #65

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -316,11 +316,6 @@ class JLCPCBFabrication:
                     )
                     continue
                 lcsc = self.parts.get(footprint.GetReference(), {}).get("lcsc", "")
-                if not lcsc:
-                    self.logger.error(
-                        f"{footprint.GetReference()} has no LCSC attribute and is skipped!"
-                    )
-                    continue
                 if not lcsc in footprints:
                     footprints[lcsc] = {
                         "comment": footprint.GetValue(),


### PR DESCRIPTION
This allows having parts in BOM/CPL that have no LCSC property for automatic completion from JLC's webservice as requestet in #65 by @t123yh