### PR TITLE
Use utf-8 encoding for BOM and CPL file

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -271,7 +271,7 @@ class JLCPCBFabrication:
     def generate_cpl(self):
         """Generate placement file (CPL)."""
         cplname = f"CPL-{self.filename.split('.')[0]}.csv"
-        with open(os.path.join(self.assemblydir, cplname), "w", newline="") as csvfile:
+        with open(os.path.join(self.assemblydir, cplname), "w", newline="", encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(
                 ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
@@ -305,7 +305,7 @@ class JLCPCBFabrication:
     def generate_bom(self):
         """Generate BOM file."""
         bomname = f"BOM-{self.filename.split('.')[0]}.csv"
-        with open(os.path.join(self.assemblydir, bomname), "w", newline="") as csvfile:
+        with open(os.path.join(self.assemblydir, bomname), "w", newline="", encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(["Comment", "Designator", "Footprint", "LCSC"])
             footprints = {}


### PR DESCRIPTION
Generate fabricate files will stop at half **silently** if there are non-ASCII characters in footprint's fields. Using utf-8 encoding for CPL and BOM file seems to settle this problem. BTW, It would be better if we print a log when something went wrong.