### PR TITLE
Added zone refill with user prompt

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -11,6 +11,8 @@ from pcbnew import (
     PCB_PLOT_PARAMS,
     PLOT_CONTROLLER,
     PLOT_FORMAT_GERBER,
+    ZONE_FILLER,
+    Refresh,
     B_Cu,
     B_Mask,
     B_SilkS,
@@ -54,6 +56,13 @@ class JLCPCBFabrication:
         Path(self.assemblydir).mkdir(parents=True, exist_ok=True)
         self.gerberdir = os.path.join(self.path, "jlcpcb", "gerber")
         Path(self.gerberdir).mkdir(parents=True, exist_ok=True)
+
+    def fill_zones(self):
+        """Refill copper zones following user prompt."""
+        filler = ZONE_FILLER(self.board)
+        zones = self.board.Zones()
+        filler.Fill(zones)
+        Refresh()
 
     def load_part_assigments(self):
         # Read all footprints and their maybe set LCSC property

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -476,6 +476,13 @@ class JLCBCBTools(wx.Dialog):
 
     def generate_fabrication_data(self, e):
         """Generate Fabrication data."""
+        response = wx.MessageBox(
+            "Do you wish to refill zones?",
+            "Refill Zones?",
+            style=wx.YES | wx.NO | wx.ICON_WARNING,
+        )
+        if response == wx.YES:
+            self.fabrication.fill_zones()
         layer_selection = self.layer_selection.GetSelection()
         if layer_selection != 0:
             layer_count = int(self.layer_selection.GetString(layer_selection)[:1])


### PR DESCRIPTION
This PR prompts the user if they wish to refill zones when they generate assembly files (This is the behavior I got used to with the built in plot gerber tool and I got burnt badly when I switched to this plugin).

I couldn't find a way to detect if an update of the zones is needed, so this will always prompt the user. 

Using filler.Fill(zones, True) does generate a prompt if it detects the zones aren't up to date, however the cancel button on that doesn't appear to stop the zones filling. I'm not sure how to implement this, or if it is just a bug in the PCBnew API.