### PR TITLE
Write the POS file as utf8

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -212,7 +212,8 @@ class Fabrication:
         """Generate placement file (POS)."""
         posname = f"POS-{self.filename.split('.')[0]}.csv"
         self.corrections = self.parent.library.get_all_correction_data()
-        with open(os.path.join(self.assemblydir, posname), "w", newline="") as csvfile:
+
+        with open(os.path.join(self.assemblydir, posname), "w", newline="", encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(
                 ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]


### PR DESCRIPTION
Before this change, parts that have a description containing non-ascii symbols, such as a +- or a µ would cause writing of the .pos file to silently fail.