### PR TITLE
Show main window as modeless dialog instead of modal

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -19,5 +19,4 @@ class JLCPCBPlugin(ActionPlugin):
     def Run(self):
         dialog = JLCBCBTools(None)
         dialog.Center()
-        dialog.ShowModal()
-        dialog.Destroy()
+        dialog.Show()


### PR DESCRIPTION
When verifying my BOM before generating the various fabrication files I often find myself wanting to 
view other KiCad windows, like eeschema, which I cannot do while the JLC tools modal is open. With this change it's possible to cycle through other KiCad windows while this plugin's dialog is open.

This may be a personal preference thing, so feel free to disregard; it's an easy change to make and I don't mind patching my own version, but I figured other people would find this helpful as well!

Thanks again for this wonderful plugin, it has saved me so much time!