### PR TITLE
Attempt to fix wxWidgets < 3.1 issue with HighDPI capabilities

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -12,7 +12,15 @@ EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 NOT_IN_SCHEMATIC = 4
 
+def GetScaleFactor(window):
+    """Workaround if wxWidgets Version does not support GetDPIScaleFactor"""
+    if hasattr(window, "GetDPIScaleFactor"):
+        return window.GetDPIScaleFactor()
+    else:
+        return 1.0
+
 def HighResWxSize(window, size):
+    """Workaround if wxWidgets Version does not support FromDIP"""
     if hasattr(window, "FromDIP"):
         return window.FromDIP(size)
     else:

--- a/helpers.py
+++ b/helpers.py
@@ -12,6 +12,11 @@ EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 NOT_IN_SCHEMATIC = 4
 
+def HighResWxSize(window, size):
+    if hasattr(window, "FromDIP"):
+        return window.FromDIP(size)
+    else:
+        return size
 
 def loadBitmapScaled(path, scale=1.0):
     """Load a scaled bitmap"""

--- a/helpers.py
+++ b/helpers.py
@@ -12,6 +12,7 @@ EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 NOT_IN_SCHEMATIC = 4
 
+
 def GetScaleFactor(window):
     """Workaround if wxWidgets Version does not support GetDPIScaleFactor"""
     if hasattr(window, "GetDPIScaleFactor"):
@@ -19,12 +20,14 @@ def GetScaleFactor(window):
     else:
         return 1.0
 
+
 def HighResWxSize(window, size):
     """Workaround if wxWidgets Version does not support FromDIP"""
     if hasattr(window, "FromDIP"):
         return window.FromDIP(size)
     else:
         return size
+
 
 def loadBitmapScaled(path, scale=1.0):
     """Load a scaled bitmap"""

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -17,6 +17,7 @@ from .events import (
 from .fabrication import Fabrication
 from .helpers import (
     PLUGIN_PATH,
+    GetScaleFactor,
     HighResWxSize,
     get_footprint_by_ref,
     loadBitmapScaled,
@@ -46,7 +47,7 @@ class JLCPCBTools(wx.Dialog):
         )
         self.window = wx.GetTopLevelParent(self)
         self.SetSize(HighResWxSize(self.window, wx.Size(1300, 800)))
-        self.scale_factor = self.window.GetDPIScaleFactor()
+        self.scale_factor = GetScaleFactor(self.window)
         self.project_path = os.path.split(GetBoard().GetFileName())[0]
         self.hide_bom_parts = False
         self.hide_pos_parts = False
@@ -491,9 +492,12 @@ class JLCPCBTools(wx.Dialog):
         self.init_fabrication()
         if self.library.state == LibraryState.UPDATE_NEEDED:
             self.library.update()
+<<<<<<< HEAD
         self.init_store()
 
         
+=======
+>>>>>>> add another workaround for missing GetDPIScaleFactor in wxWidgets < 3.1.4
 
     def quit_dialog(self, e):
         self.Destroy()

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -17,6 +17,7 @@ from .events import (
 from .fabrication import Fabrication
 from .helpers import (
     PLUGIN_PATH,
+    HighResWxSize,
     get_footprint_by_ref,
     loadBitmapScaled,
     toggle_exclude_from_bom,
@@ -44,7 +45,7 @@ class JLCPCBTools(wx.Dialog):
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
         )
         self.window = wx.GetTopLevelParent(self)
-        self.SetSize(self.window.FromDIP(wx.Size(1300, 800)))
+        self.SetSize(HighResWxSize(self.window, wx.Size(1300, 800)))
         self.scale_factor = self.window.GetDPIScaleFactor()
         self.project_path = os.path.split(GetBoard().GetFileName())[0]
         self.hide_bom_parts = False
@@ -75,7 +76,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Generate fabrication files",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(200, 38)),
+            HighResWxSize(self.window,wx.Size(200, 38)),
             0,
         )
 
@@ -87,7 +88,7 @@ class JLCPCBTools(wx.Dialog):
                 os.path.join(PLUGIN_PATH, "icons", "mdi-layers-triple-outline.png"),
                 self.scale_factor,
             ),
-            size=self.window.FromDIP(wx.Size(24, 36)),
+            size=HighResWxSize(self.window,wx.Size(24, 36)),
         )
         self.layer_selection = wx.Choice(
             self,
@@ -112,7 +113,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Manage rotations",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
 
@@ -121,7 +122,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Update library",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
 
@@ -182,7 +183,7 @@ class JLCPCBTools(wx.Dialog):
         # ----------------------- Footprint List ------------------------------
         # ---------------------------------------------------------------------
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        table_sizer.SetMinSize(self.window.FromDIP(wx.Size(-1, 600)))
+        table_sizer.SetMinSize(HighResWxSize(self.window,wx.Size(-1, 600)))
         self.footprint_list = wx.dataview.DataViewListCtrl(
             self,
             wx.ID_ANY,
@@ -190,7 +191,7 @@ class JLCPCBTools(wx.Dialog):
             wx.DefaultSize,
             style=wx.dataview.DV_MULTIPLE,
         )
-        self.footprint_list.SetMinSize(self.window.FromDIP(wx.Size(750, 400)))
+        self.footprint_list.SetMinSize(HighResWxSize(self.window,wx.Size(750, 400)))
         self.reference = self.footprint_list.AppendTextColumn(
             "Reference",
             mode=wx.dataview.DATAVIEW_CELL_INERT,
@@ -273,7 +274,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Select part",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.remove_part_button = wx.Button(
@@ -281,7 +282,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Remove part",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.select_alike_button = wx.Button(
@@ -289,7 +290,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Select alike",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.toggle_bom_pos_button = wx.Button(
@@ -297,7 +298,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Toggle BOM/POS",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.toggle_bom_button = wx.Button(
@@ -305,7 +306,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Toggle BOM",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.toggle_pos_button = wx.Button(
@@ -313,7 +314,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Toggle POS",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.part_details_button = wx.Button(
@@ -321,7 +322,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Show part details",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         # self.part_costs_button = wx.Button(
@@ -332,7 +333,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Hide excluded BOM",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
         self.hide_pos_button = wx.Button(
@@ -340,7 +341,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Hide excluded POS",
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(175, 38)),
+            HighResWxSize(self.window,wx.Size(175, 38)),
             0,
         )
 
@@ -446,23 +447,23 @@ class JLCPCBTools(wx.Dialog):
             wx.DefaultSize,
             wx.TE_MULTILINE | wx.TE_READONLY,
         )
-        self.logbox.SetMinSize(self.window.FromDIP(wx.Size(-1, 150)))
+        self.logbox.SetMinSize(HighResWxSize(self.window,wx.Size(-1, 150)))
         self.gauge = wx.Gauge(
             self,
             wx.ID_ANY,
             100,
             wx.DefaultPosition,
-            self.window.FromDIP(wx.Size(100, -1)),
+            HighResWxSize(self.window,wx.Size(100, -1)),
             wx.GA_HORIZONTAL,
         )
         self.gauge.SetValue(0)
-        self.gauge.SetMinSize(self.window.FromDIP(wx.Size(-1, 5)))
+        self.gauge.SetMinSize(HighResWxSize(self.window,wx.Size(-1, 5)))
 
         # ---------------------------------------------------------------------
         # ---------------------- Main Layout Sizer ----------------------------
         # ---------------------------------------------------------------------
 
-        self.SetSizeHints(self.window.FromDIP(wx.Size(1000, -1)), wx.DefaultSize)
+        self.SetSizeHints(HighResWxSize(self.window,wx.Size(1000, -1)), wx.DefaultSize)
         layout = wx.BoxSizer(wx.VERTICAL)
         layout.Add(top_button_sizer, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(table_sizer, 20, wx.ALL | wx.EXPAND, 5)
@@ -491,6 +492,8 @@ class JLCPCBTools(wx.Dialog):
         if self.library.state == LibraryState.UPDATE_NEEDED:
             self.library.update()
         self.init_store()
+
+        
 
     def quit_dialog(self, e):
         self.Destroy()

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -77,7 +77,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Generate fabrication files",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(200, 38)),
+            HighResWxSize(self.window, wx.Size(200, 38)),
             0,
         )
 
@@ -89,7 +89,7 @@ class JLCPCBTools(wx.Dialog):
                 os.path.join(PLUGIN_PATH, "icons", "mdi-layers-triple-outline.png"),
                 self.scale_factor,
             ),
-            size=HighResWxSize(self.window,wx.Size(24, 36)),
+            size=HighResWxSize(self.window, wx.Size(24, 36)),
         )
         self.layer_selection = wx.Choice(
             self,
@@ -114,7 +114,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Manage rotations",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
 
@@ -123,7 +123,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Update library",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
 
@@ -184,7 +184,7 @@ class JLCPCBTools(wx.Dialog):
         # ----------------------- Footprint List ------------------------------
         # ---------------------------------------------------------------------
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        table_sizer.SetMinSize(HighResWxSize(self.window,wx.Size(-1, 600)))
+        table_sizer.SetMinSize(HighResWxSize(self.window, wx.Size(-1, 600)))
         self.footprint_list = wx.dataview.DataViewListCtrl(
             self,
             wx.ID_ANY,
@@ -192,7 +192,7 @@ class JLCPCBTools(wx.Dialog):
             wx.DefaultSize,
             style=wx.dataview.DV_MULTIPLE,
         )
-        self.footprint_list.SetMinSize(HighResWxSize(self.window,wx.Size(750, 400)))
+        self.footprint_list.SetMinSize(HighResWxSize(self.window, wx.Size(750, 400)))
         self.reference = self.footprint_list.AppendTextColumn(
             "Reference",
             mode=wx.dataview.DATAVIEW_CELL_INERT,
@@ -275,7 +275,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Select part",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.remove_part_button = wx.Button(
@@ -283,7 +283,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Remove part",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.select_alike_button = wx.Button(
@@ -291,7 +291,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Select alike",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.toggle_bom_pos_button = wx.Button(
@@ -299,7 +299,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Toggle BOM/POS",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.toggle_bom_button = wx.Button(
@@ -307,7 +307,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Toggle BOM",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.toggle_pos_button = wx.Button(
@@ -315,7 +315,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Toggle POS",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.part_details_button = wx.Button(
@@ -323,7 +323,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Show part details",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         # self.part_costs_button = wx.Button(
@@ -334,7 +334,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Hide excluded BOM",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
         self.hide_pos_button = wx.Button(
@@ -342,7 +342,7 @@ class JLCPCBTools(wx.Dialog):
             wx.ID_ANY,
             "Hide excluded POS",
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(175, 38)),
+            HighResWxSize(self.window, wx.Size(175, 38)),
             0,
         )
 
@@ -448,23 +448,23 @@ class JLCPCBTools(wx.Dialog):
             wx.DefaultSize,
             wx.TE_MULTILINE | wx.TE_READONLY,
         )
-        self.logbox.SetMinSize(HighResWxSize(self.window,wx.Size(-1, 150)))
+        self.logbox.SetMinSize(HighResWxSize(self.window, wx.Size(-1, 150)))
         self.gauge = wx.Gauge(
             self,
             wx.ID_ANY,
             100,
             wx.DefaultPosition,
-            HighResWxSize(self.window,wx.Size(100, -1)),
+            HighResWxSize(self.window, wx.Size(100, -1)),
             wx.GA_HORIZONTAL,
         )
         self.gauge.SetValue(0)
-        self.gauge.SetMinSize(HighResWxSize(self.window,wx.Size(-1, 5)))
+        self.gauge.SetMinSize(HighResWxSize(self.window, wx.Size(-1, 5)))
 
         # ---------------------------------------------------------------------
         # ---------------------- Main Layout Sizer ----------------------------
         # ---------------------------------------------------------------------
 
-        self.SetSizeHints(HighResWxSize(self.window,wx.Size(1000, -1)), wx.DefaultSize)
+        self.SetSizeHints(HighResWxSize(self.window, wx.Size(1000, -1)), wx.DefaultSize)
         layout = wx.BoxSizer(wx.VERTICAL)
         layout.Add(top_button_sizer, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(table_sizer, 20, wx.ALL | wx.EXPAND, 5)
@@ -492,12 +492,7 @@ class JLCPCBTools(wx.Dialog):
         self.init_fabrication()
         if self.library.state == LibraryState.UPDATE_NEEDED:
             self.library.update()
-<<<<<<< HEAD
         self.init_store()
-
-        
-=======
->>>>>>> add another workaround for missing GetDPIScaleFactor in wxWidgets < 3.1.4
 
     def quit_dialog(self, e):
         self.Destroy()

--- a/partdetails.py
+++ b/partdetails.py
@@ -6,7 +6,7 @@ import webbrowser
 import requests
 import wx
 
-from .helpers import PLUGIN_PATH, loadBitmapScaled
+from .helpers import PLUGIN_PATH, HighResWxSize, loadBitmapScaled
 
 
 class PartDetailsDialog(wx.Dialog):
@@ -17,7 +17,7 @@ class PartDetailsDialog(wx.Dialog):
             id=wx.ID_ANY,
             title="JLCPCB Part Details",
             pos=wx.DefaultPosition,
-            size=parent.window.FromDIP(wx.Size(1000, 800)),
+            size=HighResWxSize(parent.window,wx.Size(1000, 800)),
             style=wx.DEFAULT_DIALOG_STYLE | wx.STAY_ON_TOP,
         )
 
@@ -74,7 +74,7 @@ class PartDetailsDialog(wx.Dialog):
                 parent.scale_factor,
             ),
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 200)),
+            HighResWxSize(parent.window,wx.Size(200, 200)),
             0,
         )
         self.openpdf_button = wx.Button(

--- a/partdetails.py
+++ b/partdetails.py
@@ -17,7 +17,7 @@ class PartDetailsDialog(wx.Dialog):
             id=wx.ID_ANY,
             title="JLCPCB Part Details",
             pos=wx.DefaultPosition,
-            size=HighResWxSize(parent.window,wx.Size(1000, 800)),
+            size=HighResWxSize(parent.window, wx.Size(1000, 800)),
             style=wx.DEFAULT_DIALOG_STYLE | wx.STAY_ON_TOP,
         )
 
@@ -74,7 +74,7 @@ class PartDetailsDialog(wx.Dialog):
                 parent.scale_factor,
             ),
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 200)),
+            HighResWxSize(parent.window, wx.Size(200, 200)),
             0,
         )
         self.openpdf_button = wx.Button(

--- a/partselector.py
+++ b/partselector.py
@@ -5,7 +5,7 @@ from sys import path
 import wx
 
 from .events import AssignPartEvent
-from .helpers import PLUGIN_PATH, loadBitmapScaled
+from .helpers import PLUGIN_PATH, HighResWxSize, loadBitmapScaled
 from .partdetails import PartDetailsDialog
 
 
@@ -17,7 +17,7 @@ class PartSelectorDialog(wx.Dialog):
             id=wx.ID_ANY,
             title="JLCPCB Library",
             pos=wx.DefaultPosition,
-            size=parent.window.FromDIP(wx.Size(1300, 800)),
+            size=HighResWxSize(parent.window,wx.Size(1300, 800)),
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
         )
 
@@ -44,14 +44,14 @@ class PartSelectorDialog(wx.Dialog):
         # ---------------------------------------------------------------------
 
         keyword_label = wx.StaticText(
-            self, wx.ID_ANY, "Keyword", size=parent.window.FromDIP(wx.Size(150, 15))
+            self, wx.ID_ANY, "Keyword", size=HighResWxSize(parent.window,wx.Size(150, 15))
         )
         self.keyword = wx.TextCtrl(
             self,
             wx.ID_ANY,
             lcsc_selection,
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.keyword.SetHint("e.g. 10k 0603")
@@ -60,53 +60,53 @@ class PartSelectorDialog(wx.Dialog):
             self,
             wx.ID_ANY,
             "Manufacturer",
-            size=parent.window.FromDIP(wx.Size(150, 15)),
+            size=HighResWxSize(parent.window,wx.Size(150, 15)),
         )
         self.manufacturer = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.manufacturer.SetHint("e.g. Vishay")
 
         package_label = wx.StaticText(
-            self, wx.ID_ANY, "Package", size=parent.window.FromDIP(wx.Size(150, 15))
+            self, wx.ID_ANY, "Package", size=HighResWxSize(parent.window,wx.Size(150, 15))
         )
         self.package = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.package.SetHint("e.g. 0603")
 
         category_label = wx.StaticText(
-            self, wx.ID_ANY, "Category", size=parent.window.FromDIP(wx.Size(150, 15))
+            self, wx.ID_ANY, "Category", size=HighResWxSize(parent.window,wx.Size(150, 15))
         )
         self.category = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.category.SetHint("e.g. Resistor")
 
         part_no_label = wx.StaticText(
-            self, wx.ID_ANY, "Part number", size=parent.window.FromDIP(wx.Size(150, 15))
+            self, wx.ID_ANY, "Part number", size=HighResWxSize(parent.window,wx.Size(150, 15))
         )
         self.part_no = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.part_no.SetHint("e.g. DS2411")
@@ -115,14 +115,14 @@ class PartSelectorDialog(wx.Dialog):
             self,
             wx.ID_ANY,
             "Solder joints",
-            size=parent.window.FromDIP(wx.Size(150, 15)),
+            size=HighResWxSize(parent.window,wx.Size(150, 15)),
         )
         self.solder_joints = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.solder_joints.SetHint("e.g. 2")
@@ -131,42 +131,42 @@ class PartSelectorDialog(wx.Dialog):
             self,
             wx.ID_ANY,
             "Include basic parts",
-            size=parent.window.FromDIP(wx.Size(150, 15)),
+            size=HighResWxSize(parent.window,wx.Size(150, 15)),
         )
         self.basic_checkbox = wx.CheckBox(
             self,
             wx.ID_ANY,
             "Basic",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             0,
         )
         extended_label = wx.StaticText(
             self,
             wx.ID_ANY,
             "Include extended parts",
-            size=parent.window.FromDIP(wx.Size(150, 15)),
+            size=HighResWxSize(parent.window,wx.Size(150, 15)),
         )
         self.extended_checkbox = wx.CheckBox(
             self,
             wx.ID_ANY,
             "Extended",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             0,
         )
         stock_label = wx.StaticText(
             self,
             wx.ID_ANY,
             "Only show parts in stock",
-            size=parent.window.FromDIP(wx.Size(150, 15)),
+            size=HighResWxSize(parent.window,wx.Size(150, 15)),
         )
         self.assert_stock_checkbox = wx.CheckBox(
             self,
             wx.ID_ANY,
             "in Stock",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
             0,
         )
 
@@ -178,7 +178,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Help",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(100, -1)),
+            HighResWxSize(parent.window,wx.Size(100, -1)),
             0,
         )
 
@@ -187,7 +187,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Search",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(100, -1)),
+            HighResWxSize(parent.window,wx.Size(100, -1)),
             0,
         )
 
@@ -396,7 +396,7 @@ class PartSelectorDialog(wx.Dialog):
             flags=wx.dataview.DATAVIEW_COL_RESIZABLE,
         )
 
-        self.part_list.SetMinSize(parent.window.FromDIP(wx.Size(1050, 500)))
+        self.part_list.SetMinSize(HighResWxSize(parent.window,wx.Size(1050, 500)))
 
         self.part_list.Bind(
             wx.dataview.EVT_DATAVIEW_COLUMN_HEADER_CLICK, self.OnSortPartList
@@ -407,7 +407,7 @@ class PartSelectorDialog(wx.Dialog):
         )
 
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        table_sizer.SetMinSize(parent.window.FromDIP(wx.Size(-1, 400)))
+        table_sizer.SetMinSize(HighResWxSize(parent.window,wx.Size(-1, 400)))
         table_sizer.Add(self.part_list, 20, wx.ALL | wx.EXPAND, 5)
 
         # ---------------------------------------------------------------------
@@ -419,7 +419,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Select part",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(150, -1)),
+            HighResWxSize(parent.window,wx.Size(150, -1)),
             0,
         )
         self.part_details_button = wx.Button(
@@ -427,7 +427,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Show part details",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(150, -1)),
+            HighResWxSize(parent.window,wx.Size(150, -1)),
             0,
         )
 

--- a/partselector.py
+++ b/partselector.py
@@ -17,7 +17,7 @@ class PartSelectorDialog(wx.Dialog):
             id=wx.ID_ANY,
             title="JLCPCB Library",
             pos=wx.DefaultPosition,
-            size=HighResWxSize(parent.window,wx.Size(1300, 800)),
+            size=HighResWxSize(parent.window, wx.Size(1300, 800)),
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
         )
 
@@ -44,14 +44,17 @@ class PartSelectorDialog(wx.Dialog):
         # ---------------------------------------------------------------------
 
         keyword_label = wx.StaticText(
-            self, wx.ID_ANY, "Keyword", size=HighResWxSize(parent.window,wx.Size(150, 15))
+            self,
+            wx.ID_ANY,
+            "Keyword",
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.keyword = wx.TextCtrl(
             self,
             wx.ID_ANY,
             lcsc_selection,
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.keyword.SetHint("e.g. 10k 0603")
@@ -60,53 +63,62 @@ class PartSelectorDialog(wx.Dialog):
             self,
             wx.ID_ANY,
             "Manufacturer",
-            size=HighResWxSize(parent.window,wx.Size(150, 15)),
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.manufacturer = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.manufacturer.SetHint("e.g. Vishay")
 
         package_label = wx.StaticText(
-            self, wx.ID_ANY, "Package", size=HighResWxSize(parent.window,wx.Size(150, 15))
+            self,
+            wx.ID_ANY,
+            "Package",
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.package = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.package.SetHint("e.g. 0603")
 
         category_label = wx.StaticText(
-            self, wx.ID_ANY, "Category", size=HighResWxSize(parent.window,wx.Size(150, 15))
+            self,
+            wx.ID_ANY,
+            "Category",
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.category = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.category.SetHint("e.g. Resistor")
 
         part_no_label = wx.StaticText(
-            self, wx.ID_ANY, "Part number", size=HighResWxSize(parent.window,wx.Size(150, 15))
+            self,
+            wx.ID_ANY,
+            "Part number",
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.part_no = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.part_no.SetHint("e.g. DS2411")
@@ -115,14 +127,14 @@ class PartSelectorDialog(wx.Dialog):
             self,
             wx.ID_ANY,
             "Solder joints",
-            size=HighResWxSize(parent.window,wx.Size(150, 15)),
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.solder_joints = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             wx.TE_PROCESS_ENTER,
         )
         self.solder_joints.SetHint("e.g. 2")
@@ -131,42 +143,42 @@ class PartSelectorDialog(wx.Dialog):
             self,
             wx.ID_ANY,
             "Include basic parts",
-            size=HighResWxSize(parent.window,wx.Size(150, 15)),
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.basic_checkbox = wx.CheckBox(
             self,
             wx.ID_ANY,
             "Basic",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             0,
         )
         extended_label = wx.StaticText(
             self,
             wx.ID_ANY,
             "Include extended parts",
-            size=HighResWxSize(parent.window,wx.Size(150, 15)),
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.extended_checkbox = wx.CheckBox(
             self,
             wx.ID_ANY,
             "Extended",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             0,
         )
         stock_label = wx.StaticText(
             self,
             wx.ID_ANY,
             "Only show parts in stock",
-            size=HighResWxSize(parent.window,wx.Size(150, 15)),
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.assert_stock_checkbox = wx.CheckBox(
             self,
             wx.ID_ANY,
             "in Stock",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
             0,
         )
 
@@ -178,7 +190,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Help",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(100, -1)),
+            HighResWxSize(parent.window, wx.Size(100, -1)),
             0,
         )
 
@@ -187,7 +199,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Search",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(100, -1)),
+            HighResWxSize(parent.window, wx.Size(100, -1)),
             0,
         )
 
@@ -396,7 +408,7 @@ class PartSelectorDialog(wx.Dialog):
             flags=wx.dataview.DATAVIEW_COL_RESIZABLE,
         )
 
-        self.part_list.SetMinSize(HighResWxSize(parent.window,wx.Size(1050, 500)))
+        self.part_list.SetMinSize(HighResWxSize(parent.window, wx.Size(1050, 500)))
 
         self.part_list.Bind(
             wx.dataview.EVT_DATAVIEW_COLUMN_HEADER_CLICK, self.OnSortPartList
@@ -407,7 +419,7 @@ class PartSelectorDialog(wx.Dialog):
         )
 
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        table_sizer.SetMinSize(HighResWxSize(parent.window,wx.Size(-1, 400)))
+        table_sizer.SetMinSize(HighResWxSize(parent.window, wx.Size(-1, 400)))
         table_sizer.Add(self.part_list, 20, wx.ALL | wx.EXPAND, 5)
 
         # ---------------------------------------------------------------------
@@ -419,7 +431,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Select part",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(150, -1)),
+            HighResWxSize(parent.window, wx.Size(150, -1)),
             0,
         )
         self.part_details_button = wx.Button(
@@ -427,7 +439,7 @@ class PartSelectorDialog(wx.Dialog):
             wx.ID_ANY,
             "Show part details",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(150, -1)),
+            HighResWxSize(parent.window, wx.Size(150, -1)),
             0,
         )
 

--- a/rotations.py
+++ b/rotations.py
@@ -16,7 +16,7 @@ class RotationManagerDialog(wx.Dialog):
             id=wx.ID_ANY,
             title="Rotations Manager",
             pos=wx.DefaultPosition,
-            size=HighResWxSize(parent.window,wx.Size(800, 800)),
+            size=HighResWxSize(parent.window, wx.Size(800, 800)),
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
         )
 
@@ -43,14 +43,17 @@ class RotationManagerDialog(wx.Dialog):
         # ---------------------------------------------------------------------
 
         regex_label = wx.StaticText(
-            self, wx.ID_ANY, "Regex", size=HighResWxSize(parent.window,wx.Size(150, 15))
+            self,
+            wx.ID_ANY,
+            "Regex",
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.regex = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
         )
 
         sizer_left = wx.BoxSizer(wx.VERTICAL)
@@ -63,14 +66,17 @@ class RotationManagerDialog(wx.Dialog):
         )
 
         correction_label = wx.StaticText(
-            self, wx.ID_ANY, "Correction", size=HighResWxSize(parent.window,wx.Size(150, 15))
+            self,
+            wx.ID_ANY,
+            "Correction",
+            size=HighResWxSize(parent.window, wx.Size(150, 15)),
         )
         self.correction = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(200, 24)),
+            HighResWxSize(parent.window, wx.Size(200, 24)),
         )
 
         sizer_right = wx.BoxSizer(wx.VERTICAL)
@@ -114,14 +120,14 @@ class RotationManagerDialog(wx.Dialog):
             align=wx.ALIGN_LEFT,
         )
 
-        self.rotations_list.SetMinSize(HighResWxSize(parent.window,wx.Size(600, 500)))
+        self.rotations_list.SetMinSize(HighResWxSize(parent.window, wx.Size(600, 500)))
 
         self.rotations_list.Bind(
             wx.dataview.EVT_DATAVIEW_SELECTION_CHANGED, self.on_correction_selected
         )
 
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        table_sizer.SetMinSize(HighResWxSize(parent.window,wx.Size(-1, 400)))
+        table_sizer.SetMinSize(HighResWxSize(parent.window, wx.Size(-1, 400)))
         table_sizer.Add(self.rotations_list, 20, wx.ALL | wx.EXPAND, 5)
 
         # ---------------------------------------------------------------------
@@ -133,7 +139,7 @@ class RotationManagerDialog(wx.Dialog):
             wx.ID_ANY,
             "Save",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(150, -1)),
+            HighResWxSize(parent.window, wx.Size(150, -1)),
             0,
         )
         self.delete_button = wx.Button(
@@ -141,7 +147,7 @@ class RotationManagerDialog(wx.Dialog):
             wx.ID_ANY,
             "Delete",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(150, -1)),
+            HighResWxSize(parent.window, wx.Size(150, -1)),
             0,
         )
         self.update_button = wx.Button(
@@ -149,7 +155,7 @@ class RotationManagerDialog(wx.Dialog):
             wx.ID_ANY,
             "Update",
             wx.DefaultPosition,
-            HighResWxSize(parent.window,wx.Size(150, -1)),
+            HighResWxSize(parent.window, wx.Size(150, -1)),
             0,
         )
         self.import_button = wx.Button(

--- a/rotations.py
+++ b/rotations.py
@@ -5,7 +5,7 @@ import os
 import requests
 import wx
 
-from .helpers import PLUGIN_PATH, loadBitmapScaled
+from .helpers import PLUGIN_PATH, HighResWxSize, loadBitmapScaled
 
 
 class RotationManagerDialog(wx.Dialog):
@@ -16,7 +16,7 @@ class RotationManagerDialog(wx.Dialog):
             id=wx.ID_ANY,
             title="Rotations Manager",
             pos=wx.DefaultPosition,
-            size=parent.window.FromDIP(wx.Size(800, 800)),
+            size=HighResWxSize(parent.window,wx.Size(800, 800)),
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
         )
 
@@ -43,14 +43,14 @@ class RotationManagerDialog(wx.Dialog):
         # ---------------------------------------------------------------------
 
         regex_label = wx.StaticText(
-            self, wx.ID_ANY, "Regex", size=parent.window.FromDIP(wx.Size(150, 15))
+            self, wx.ID_ANY, "Regex", size=HighResWxSize(parent.window,wx.Size(150, 15))
         )
         self.regex = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
         )
 
         sizer_left = wx.BoxSizer(wx.VERTICAL)
@@ -63,14 +63,14 @@ class RotationManagerDialog(wx.Dialog):
         )
 
         correction_label = wx.StaticText(
-            self, wx.ID_ANY, "Correction", size=parent.window.FromDIP(wx.Size(150, 15))
+            self, wx.ID_ANY, "Correction", size=HighResWxSize(parent.window,wx.Size(150, 15))
         )
         self.correction = wx.TextCtrl(
             self,
             wx.ID_ANY,
             "",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(200, 24)),
+            HighResWxSize(parent.window,wx.Size(200, 24)),
         )
 
         sizer_right = wx.BoxSizer(wx.VERTICAL)
@@ -114,14 +114,14 @@ class RotationManagerDialog(wx.Dialog):
             align=wx.ALIGN_LEFT,
         )
 
-        self.rotations_list.SetMinSize(parent.window.FromDIP(wx.Size(600, 500)))
+        self.rotations_list.SetMinSize(HighResWxSize(parent.window,wx.Size(600, 500)))
 
         self.rotations_list.Bind(
             wx.dataview.EVT_DATAVIEW_SELECTION_CHANGED, self.on_correction_selected
         )
 
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        table_sizer.SetMinSize(parent.window.FromDIP(wx.Size(-1, 400)))
+        table_sizer.SetMinSize(HighResWxSize(parent.window,wx.Size(-1, 400)))
         table_sizer.Add(self.rotations_list, 20, wx.ALL | wx.EXPAND, 5)
 
         # ---------------------------------------------------------------------
@@ -133,7 +133,7 @@ class RotationManagerDialog(wx.Dialog):
             wx.ID_ANY,
             "Save",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(150, -1)),
+            HighResWxSize(parent.window,wx.Size(150, -1)),
             0,
         )
         self.delete_button = wx.Button(
@@ -141,7 +141,7 @@ class RotationManagerDialog(wx.Dialog):
             wx.ID_ANY,
             "Delete",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(150, -1)),
+            HighResWxSize(parent.window,wx.Size(150, -1)),
             0,
         )
         self.update_button = wx.Button(
@@ -149,7 +149,7 @@ class RotationManagerDialog(wx.Dialog):
             wx.ID_ANY,
             "Update",
             wx.DefaultPosition,
-            parent.window.FromDIP(wx.Size(150, -1)),
+            HighResWxSize(parent.window,wx.Size(150, -1)),
             0,
         )
         self.import_button = wx.Button(


### PR DESCRIPTION
This is a hacky attempt to fix #118.

It seems linux versions of KiCAD use wxWidgets 3.0.4 while Windows uses 3.1.5.
In order to support HighDPI Displays I introduced the use of the FromDIP method which, unfortunately is supported from wxWidgets 3.1.0 onwards.

This means that at the moment there's no High DPI support for linux after this PR has been merged but at least the plugin is usable again in linux.