### PR TITLE
Handle part select function when multiple rows are selected (no crash anymore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ dev
 
 # vscode ignore
 .vscode/
+
+# OS cruft
+.DS_Store

--- a/fabrication.py
+++ b/fabrication.py
@@ -183,8 +183,8 @@ class Fabrication:
             pctl.SetLayer(layer_info[1])
             pctl.OpenPlotfile(layer_info[0], PLOT_FORMAT_GERBER, layer_info[2])
             if pctl.PlotLayer() == False:
-                self.logger.error(f"Error ploting {layer_info[2]}")
-            self.logger.info(f"Successfully ploted {layer_info[2]}")
+                self.logger.error(f"Error plotting {layer_info[2]}")
+            self.logger.info(f"Successfully plotted {layer_info[2]}")
         pctl.ClosePlot()
 
     def generate_excellon(self):

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -706,15 +706,11 @@ class JLCPCBTools(wx.Dialog):
     def select_alike(self, e):
         """Select all parts that have the same value and footprint."""
         num_sel = self.footprint_list.GetSelectedItemsCount() # could have selected more than 1 item (by mistake?)
-        if num_sel == 0:
-            return
-        elif num_sel == 1:
+        if num_sel == 1:
             item = self.footprint_list.GetSelection()
         else:
-            item = self.footprint_list.GetSelections()[0] # just pick the first one in the list
-            for extra in self.footprint_list.GetSelections()[1:]:
-                self.footprint_list.Unselect(extra) # unselect everything else as it could be a different value/footprint?
-        
+            self.logger.warning(f"Select only one component, please.")
+            return
         row = self.footprint_list.ItemToRow(item)
         ref = self.footprint_list.GetValue(row, 0)
         part = self.store.get_part(ref)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -703,7 +703,16 @@ class JLCPCBTools(wx.Dialog):
 
     def select_alike(self, e):
         """Select all parts that have the same value and footprint."""
-        item = self.footprint_list.GetSelection()
+        num_sel = self.footprint_list.GetSelectedItemsCount() # could have selected more than 1 item (by mistake?)
+        if num_sel == 0:
+            return
+        elif num_sel == 1:
+            item = self.footprint_list.GetSelection()
+        else:
+            item = self.footprint_list.GetSelections()[0] # just pick the first one in the list
+            for extra in self.footprint_list.GetSelections()[1:]:
+                self.footprint_list.Unselect(extra) # unselect everything else as it could be a different value/footprint?
+        
         row = self.footprint_list.ItemToRow(item)
         ref = self.footprint_list.GetValue(row, 0)
         part = self.store.get_part(ref)
@@ -715,16 +724,16 @@ class JLCPCBTools(wx.Dialog):
 
     def get_part_details(self, e):
         """Fetch part details from LCSC and show them in a modal."""
-        item = self.footprint_list.GetSelection()
-        row = self.footprint_list.ItemToRow(item)
-        if row == -1:
-            return
-        part = self.footprint_list.GetTextValue(row, 3)
-        if part != "":
-            self.busy_cursor = wx.BusyCursor()
-            dialog = PartDetailsDialog(self, part)
-            del self.busy_cursor
-            dialog.Show()
+        for item in self.footprint_list.GetSelections():
+            row = self.footprint_list.ItemToRow(item)
+            if row == -1:
+                return
+            part = self.footprint_list.GetTextValue(row, 3)
+            if part != "":
+                self.busy_cursor = wx.BusyCursor()
+                dialog = PartDetailsDialog(self, part)
+                del self.busy_cursor
+                dialog.Show()
 
     def update_library(self, e=None):
         """Update the library from the JLCPCB CSV file."""


### PR DESCRIPTION
I have seen a nasty crash of Kicad when multiple rows are selected and then the "Select Alike" button is pressed. Now the code just reports that you need to select only one row. 