### PR TITLE
Update create_pcm_archive.sh

### DIFF
--- a/PCM/create_pcm_archive.sh
+++ b/PCM/create_pcm_archive.sh
@@ -17,6 +17,7 @@ echo "Copy files to destination"
 cp VERSION PCM/archive/plugins
 cp *.py PCM/archive/plugins
 cp *.png PCM/archive/plugins
+cp settings.json PCM/archive/plugins
 cp -r icons PCM/archive/plugins
 cp PCM/icon.png PCM/archive/resources
 cp PCM/metadata.template.json PCM/archive/metadata.json


### PR DESCRIPTION
select parts button in JLCPCB tools does not work.
```
  File "C:\Users\Takahiro\Documents\KiCad\6.0\3rdparty\plugins\com_github_bouni_kicad-jlcpcb-tools\plugin.py", line 22, in Run
    dialog = JLCPCBTools(None)
  File "C:\Users\Takahiro\Documents\KiCad\6.0\3rdparty\plugins\com_github_bouni_kicad-jlcpcb-tools\mainwindow.py", line 519, in __init__
    self.logger.info(f"kicad-jlcpcb-tools version {getVersion()}")
Message: 'kicad-jlcpcb-tools version 2022.04.01\n'
```

To solve this problem, update create_pcm_archives.sh to include settings.json to release 
