### PR TITLE
Fix for #165 by making part details dialog a modal

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -767,7 +767,7 @@ class JLCPCBTools(wx.Dialog):
                 self.busy_cursor = wx.BusyCursor()
                 dialog = PartDetailsDialog(self, part)
                 del self.busy_cursor
-                dialog.Show()
+                dialog.ShowModal()
 
     def update_library(self, e=None):
         """Update the library from the JLCPCB CSV file."""

--- a/partselector.py
+++ b/partselector.py
@@ -592,7 +592,7 @@ class PartSelectorDialog(wx.Dialog):
             self.busy_cursor = wx.BusyCursor()
             dialog = PartDetailsDialog(self.parent, part)
             del self.busy_cursor
-            dialog.Show()
+            dialog.ShowModal()
 
     def help(self, e):
         """Show message box with help instructions"""


### PR DESCRIPTION
Finally I found a working solution for #165.
I had to change the call from `dialog.Show()` into `dialog.ShowModal()` in order to resolve the issue.
Maybe not optimal but I wasn't able to figure out another way 🤷🏽 