### PR TITLE
Fix loading of static bitmap in partdetails

### DIFF
--- a/partdetails.py
+++ b/partdetails.py
@@ -69,11 +69,7 @@ class PartDetailsDialog(wx.Dialog):
         self.image = wx.StaticBitmap(
             self,
             wx.ID_ANY,
-            loadBitmapScaled(
-                "placeholder.png",
-                self.parent.scale_factor,
-                static=True
-            ),
+            loadBitmapScaled("placeholder.png", self.parent.scale_factor, static=True),
             wx.DefaultPosition,
             HighResWxSize(parent.window, wx.Size(200, 200)),
             0,

--- a/partdetails.py
+++ b/partdetails.py
@@ -72,6 +72,7 @@ class PartDetailsDialog(wx.Dialog):
             loadBitmapScaled(
                 "placeholder.png",
                 self.parent.scale_factor,
+                static=True
             ),
             wx.DefaultPosition,
             HighResWxSize(parent.window, wx.Size(200, 200)),


### PR DESCRIPTION
This is a fix for #190, the `static=True` got missing in one of the last changes for the Bitmap/BitmapBundle mess ...