### PR TITLE
minor bugfix: don't overwrite duplicate column name

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -244,7 +244,7 @@ class JLCPCBTools(wx.Dialog):
             align=wx.ALIGN_CENTER,
             flags=wx.dataview.DATAVIEW_COL_RESIZABLE,
         )
-        self.lcsc = self.footprint_list.AppendTextColumn(
+        self.type_column = self.footprint_list.AppendTextColumn(
             "Type",
             mode=wx.dataview.DATAVIEW_CELL_INERT,
             width=int(self.scale_factor * 100),


### PR DESCRIPTION
- line 247 incorrectly overwrites self.lcsc with a new column named 'Type', erasing it. line 240 is in the right here
- to fix, we just store this in a different variable
- this wasn't affecting anything because it wasn't used by anything but, was confusing and maybe someday could cause some future developer some heartache