### PR TITLE
improve error handling in PartsDetail modal dialog box

### DIFF
--- a/partdetails.py
+++ b/partdetails.py
@@ -139,11 +139,11 @@ class PartDetailsDialog(wx.Dialog):
             headers=headers,
         )
         if r.status_code != requests.codes.ok:
-            self.report_part_data_fetch_error("no JSON data returned")
+            self.report_part_data_fetch_error("non-OK HTTP response status")
 
         data = r.json()
         if not data.get("data"):
-            self.report_part_data_fetch_error("no JSON data returned")
+            self.report_part_data_fetch_error("returned JSON data does not have expected 'data' attribute")
 
         parameters = {
             "componentCode": "Component code",

--- a/partdetails.py
+++ b/partdetails.py
@@ -139,20 +139,12 @@ class PartDetailsDialog(wx.Dialog):
             headers=headers,
         )
         if r.status_code != requests.codes.ok:
-            wx.MessageBox(
-                "Failed to download part detail from JLCPCB's API",
-                "Error",
-                style=wx.ICON_ERROR,
-            )
-            self.EndModal()
+            self.report_part_data_fetch_error("no JSON data returned")
+
         data = r.json()
         if not data.get("data"):
-            wx.MessageBox(
-                "Failed to download part detail from JLCPCB's API",
-                "Error",
-                style=wx.ICON_ERROR,
-            )
-            self.EndModal()
+            self.report_part_data_fetch_error("no JSON data returned")
+
         parameters = {
             "componentCode": "Component code",
             "firstTypeNameEn": "Primary category",
@@ -232,3 +224,12 @@ class PartDetailsDialog(wx.Dialog):
                 )
             )
         self.pdfurl = data.get("data", {}).get("dataManualUrl")
+
+    def report_part_data_fetch_error(self, reason):
+        wx.MessageBox(
+            f'Failed to download part detail from the JLCPCB API ({reason})\r\n'
+            f'We looked for a part named:\r\n{self.part}\r\n[hint: did you fill in the LCSC field correctly?]',
+            "Error",
+            style=wx.ICON_ERROR,
+        )
+        self.EndModal(-1)


### PR DESCRIPTION
1. exception fix: self.EndModal() requires a return value to be passed in
2. refactor duplicated error message handler to drop some better hints about how to fix issues with incorrect or missing LCSC part#s