### PR TITLE
Offset drill file to Aux origin to match other fabrication files

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -205,10 +205,7 @@ class Fabrication:
         drlwriter = EXCELLON_WRITER(self.board)
         mirror = False
         minimalHeader = False
-        if "6.99" in GetBuildVersion():
-            offset = VECTOR2I(0, 0)
-        else:
-            offset = wxPoint(0, 0)
+        offset = self.board.GetDesignSettings().GetAuxOrigin()
         mergeNPTH = False
         drlwriter.SetOptions(mirror, minimalHeader, offset, mergeNPTH)
         drlwriter.SetFormat(False)


### PR DESCRIPTION
When Aux origin is set, generated drill files don't match gerbers and position files. This inconsistency happens due to offset calculation. Gerbers and position files use Aux origin for offset, while drill files use fixed (0, 0) for all cases.

This can be easily seen on the screenshot (aux origin is set to lower left corner of the PCB):

![image](https://user-images.githubusercontent.com/1215136/188970424-b1451f9f-356b-44fd-8715-1bc35e0b87dd.png)

The pull-request makes offset for drill files identical to gerbers and position files.
