### PR TITLE
[Fix] Bottom rotation angle

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -69,6 +69,9 @@ class Fabrication:
             # we need to divide by 10 to get 180 out of 1800 for example.
             # This might be a bug in 5.99 / 6.0 RC
             rotation = original / 10
+        if footprint.GetLayer() != 0:
+            # bottom angles need to be mirrored on Y-axis
+            rotation = (180 - rotation) % 360
         for regex, correction in self.corrections:
             if re.search(regex, str(footprint.GetFPID().GetLibItemName())):
                 if footprint.GetLayer() == 0:


### PR DESCRIPTION
See also issue #159

This fixes the rotation of parts on the bottom/back layer. Some(!) testing has been done.

One possible issue could be existing projects where the rotation correction feature of the plugin has been used for bottom parts. Those correction values will now most likely be incorrect. I am not sure if an automatic correction of those values is possible or even desireable; in my (limited) testing it was easiest to delete all corrections and start again...