### PR TITLE
escape footprint names when using them to make a regex

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -979,7 +979,7 @@ class JLCPCBTools(wx.Dialog):
                 return
             footp = self.footprint_list.GetTextValue(row, 2)
             if footp != "":
-                RotationManagerDialog(self, "^" + footp).ShowModal()
+                RotationManagerDialog(self, "^" + re.escape(footp)).ShowModal()
 
     def save_all_mappings(self, e):
         for r in range(self.footprint_list.GetItemCount()):


### PR DESCRIPTION
Footprints with names like Connector(2-pin) will generate regexes that don't actually match the footprint name when you click "Add Rotation". This fixes that by escaping the special characters, at least for the connector in my layout.