### PR TITLE
Rename output placement file to CPL instead of POS

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -229,13 +229,13 @@ class Fabrication:
                     zipfile.write(filePath, os.path.basename(filePath))
         self.logger.info(f"Finished generating ZIP file")
 
-    def generate_pos(self):
-        """Generate placement file (POS)."""
-        posname = f"POS-{self.filename.split('.')[0]}.csv"
+    def generate_cpl(self):
+        """Generate placement file (CPL)."""
+        cplname = f"CPL-{self.filename.split('.')[0]}.csv"
         self.corrections = self.parent.library.get_all_correction_data()
         aux_orgin = self.board.GetDesignSettings().GetAuxOrigin()
         with open(
-            os.path.join(self.assemblydir, posname), "w", newline="", encoding="utf-8"
+            os.path.join(self.assemblydir, cplname), "w", newline="", encoding="utf-8"
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(
@@ -257,7 +257,7 @@ class Fabrication:
                             "top" if fp.GetLayer() == 0 else "bottom",
                         ]
                     )
-        self.logger.info(f"Finished generating POS file")
+        self.logger.info(f"Finished generating CPL file")
 
     def generate_bom(self):
         """Generate BOM file."""

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -942,7 +942,7 @@ class JLCPCBTools(wx.Dialog):
         self.fabrication.generate_geber(layer_count)
         self.fabrication.generate_excellon()
         self.fabrication.zip_gerber_excellon()
-        self.fabrication.generate_pos()
+        self.fabrication.generate_cpl()
         self.fabrication.generate_bom()
 
     def copy_part_lcsc(self, e):


### PR DESCRIPTION
KiCAD refers to the placment as POS where JLC uses CPL. At least the filename should match JLCs used term to make it clearer.