### PR TITLE
Replace JLCPCB CSV download with Fallback sqlite db download

### DIFF
--- a/library.py
+++ b/library.py
@@ -11,6 +11,7 @@ from enum import Enum
 from ntpath import join
 from pathlib import Path
 from threading import Thread
+import zipfile 
 
 import requests
 import wx

--- a/library.py
+++ b/library.py
@@ -372,7 +372,7 @@ class Library:
                     MessageEvent(
                         title="Download Error",
                         text=f"Failed to download the JLCPCB database, {e}",
-                        style="error"
+                        style="error",
                     ),
                 )
                 self.state = LibraryState.INITIALIZED
@@ -393,7 +393,7 @@ class Library:
                     MessageEvent(
                         title="Download Error",
                         text=f"Failed to download the JLCPCB database, db was not extracted from zip",
-                        style="error"
+                        style="error",
                     ),
                 )
                 self.state = LibraryState.INITIALIZED


### PR DESCRIPTION
As long as JLCPCB doesn't com up with a new way to download their parts catalog we download the last state from 2022-11-23 and use that.