### PR TITLE
Make part selector assign multiple parts at once

### DIFF
--- a/events.py
+++ b/events.py
@@ -3,5 +3,5 @@ from wx.lib.newevent import NewEvent
 ResetGaugeEvent, EVT_RESET_GAUGE_EVENT = NewEvent()
 UpdateGaugeEvent, EVT_UPDATE_GAUGE_EVENT = NewEvent()
 MessageEvent, EVT_MESSAGE_EVENT = NewEvent()
-AssignPartEvent, EVT_ASSIGN_PART_EVENT = NewEvent()
+AssignPartsEvent, EVT_ASSIGN_PARTS_EVENT = NewEvent()
 PopulateFootprintListEvent, EVT_POPULATE_FOOTPRINT_LIST_EVENT = NewEvent()

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -9,7 +9,7 @@ import wx.dataview
 from pcbnew import GetBoard, GetBuildVersion
 
 from .events import (
-    EVT_ASSIGN_PART_EVENT,
+    EVT_ASSIGN_PARTS_EVENT,
     EVT_MESSAGE_EVENT,
     EVT_POPULATE_FOOTPRINT_LIST_EVENT,
     EVT_RESET_GAUGE_EVENT,
@@ -557,7 +557,7 @@ class JLCPCBTools(wx.Dialog):
         self.Bind(EVT_RESET_GAUGE_EVENT, self.reset_gauge)
         self.Bind(EVT_UPDATE_GAUGE_EVENT, self.update_gauge)
         self.Bind(EVT_MESSAGE_EVENT, self.display_message)
-        self.Bind(EVT_ASSIGN_PART_EVENT, self.assign_part)
+        self.Bind(EVT_ASSIGN_PARTS_EVENT, self.assign_parts)
         self.Bind(EVT_POPULATE_FOOTPRINT_LIST_EVENT, self.populate_footprint_list)
 
         self.enable_toolbar_buttons(False)
@@ -599,10 +599,11 @@ class JLCPCBTools(wx.Dialog):
         """Update the gauge"""
         self.gauge.SetValue(int(e.value))
 
-    def assign_part(self, e):
-        """Assign a selected LCSC number to a part"""
-        self.store.set_lcsc(e.reference, e.lcsc)
-        self.store.set_stock(e.reference, e.stock)
+    def assign_parts(self, e):
+        """Assign a selected LCSC number to parts"""
+        for reference in e.references:
+            self.store.set_lcsc(reference, e.lcsc)
+            self.store.set_stock(reference, e.stock)
         self.populate_footprint_list()
 
     def display_message(self, e):

--- a/partselector.py
+++ b/partselector.py
@@ -5,7 +5,7 @@ from sys import path
 
 import wx
 
-from .events import AssignPartEvent
+from .events import AssignPartsEvent
 from .helpers import PLUGIN_PATH, HighResWxSize, loadBitmapScaled
 from .partdetails import PartDetailsDialog
 
@@ -627,15 +627,14 @@ class PartSelectorDialog(wx.Dialog):
             return
         selection = self.part_list.GetTextValue(row, 0)
         stock = self.part_list.GetTextValue(row, 8)
-        for reference in self.parts.keys():
-            wx.PostEvent(
-                self.parent,
-                AssignPartEvent(
-                    lcsc=selection,
-                    stock=stock,
-                    reference=reference,
-                ),
-            )
+        wx.PostEvent(
+            self.parent,
+            AssignPartsEvent(
+                lcsc=selection,
+                stock=stock,
+                references=self.parts.keys(),
+            ),
+        )
         self.EndModal(wx.ID_OK)
 
     def get_part_details(self, e):


### PR DESCRIPTION
Small improvement that fixes long freezes caused by running method `populate_footprint_list` for every assigned part.