### PR TITLE
Fix for renaming issue

### DIFF
--- a/library.py
+++ b/library.py
@@ -378,8 +378,10 @@ class Library:
                 self.state = LibraryState.INITIALIZED
                 self.create_tables(["placeholder_invalid_column_fix_errors"])
                 return
-        # rename existing parts.db
+        # rename existing parts.db to parts.db.bak, delete already existing bak file if neccesary
         if os.path.exists(self.dbfile):
+            if os.path.exists(f"{self.dbfile}.bak"):
+                os.remove(f"{self.dbfile}.bak")
             os.rename(self.dbfile, f"{self.dbfile}.bak")
         # unzip downloaded parts.zip
         with zipfile.ZipFile(os.path.join(self.datadir, "parts.zip"), "r") as z:


### PR DESCRIPTION
Renaimg parts.db is not possible if the parts.db.bak file already exists. If so, delte the already existing bak file