### PR TITLE
Fix check for nightly versions

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -34,7 +34,7 @@ from pcbnew import (
     wxPoint,
 )
 
-from .helpers import get_exclude_from_pos, get_footprint_by_ref
+from .helpers import get_exclude_from_pos, get_footprint_by_ref, is_nightly
 
 
 class Fabrication:
@@ -63,7 +63,7 @@ class Fabrication:
     def fix_rotation(self, footprint):
         """Fix the rotation of footprints in order to be correct for JLCPCB."""
         original = footprint.GetOrientation()
-        if "6.99" in GetBuildVersion():
+        if is_nightly(GetBuildVersion()):
             rotation = original.AsDegrees()
         else:
             # we need to divide by 10 to get 180 out of 1800 for example.
@@ -134,7 +134,7 @@ class Fabrication:
 
         popt.SetDisableGerberMacros(False)
 
-        if "6.99" in GetBuildVersion():
+        if is_nightly(GetBuildVersion()):
             from pcbnew import DRILL_MARKS_NO_DRILL_SHAPE
 
             popt.SetDrillMarksType(DRILL_MARKS_NO_DRILL_SHAPE)

--- a/helpers.py
+++ b/helpers.py
@@ -12,6 +12,7 @@ EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 NOT_IN_SCHEMATIC = 4
 
+
 def is_nightly(version: str) -> bool:
     """Check if version is a Nightly build"""
     return any(v in version for v in ("6.99", "7.0"))

--- a/helpers.py
+++ b/helpers.py
@@ -12,6 +12,10 @@ EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 NOT_IN_SCHEMATIC = 4
 
+def is_nightly(version: str) -> bool:
+    """Check if version is a Nightly build"""
+    return any(v in version for v in ("6.99", "7.0"))
+
 
 def getWxWidgetsVersion():
     v = re.search(r"wxWidgets\s([\d\.]+)", wx.version())


### PR DESCRIPTION
As Version 7.0 was released recently, the handling of differences in the KiCAD API in some places is broken because we only checked for 6.99. This adds 7.0 as nightly version ...