### PR TITLE
Restore orientation compatibility between various KiCAD versions

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -60,9 +60,10 @@ class Fabrication:
     def fix_rotation(self, footprint):
         """Fix the rotation of footprints in order to be correct for JLCPCB."""
         original = footprint.GetOrientation()
-        if is_nightly(GetBuildVersion()):
+        # `.AsDegrees()` added in KiCAD 6.99
+        try:
             rotation = original.AsDegrees()
-        else:
+        except AttributeError:
             # we need to divide by 10 to get 180 out of 1800 for example.
             # This might be a bug in 5.99 / 6.0 RC
             rotation = original / 10


### PR DESCRIPTION
https://github.com/Bouni/kicad-jlcpcb-tools/issues/294

For some reason, my 6.0.4 KiCAD is returning an object, not a float, even though that supposedly was only added in 6.99.  This PR removes the assumption that the change is based on version, and instead just tries the new way, and falls back to the old way if it's not available yet.