### PR TITLE
add script to convert jlcparts db to plugin style db

### DIFF
--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -1,0 +1,55 @@
+name: "Update parts database"
+on:
+  push:
+  pull_request:
+  schedule: # 2 hours after jlcparts updates their database
+    - cron: "0 5 * * *"
+jobs:
+  build_and_update:
+    name: "Update component database and frontend"
+    runs-on: ubuntu-20.04
+    environment: github-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3 python3-pip wget zip unzip p7zip-full
+      - name: Update database
+        run: |
+          set -x
+
+          wget -q https://yaqwsx.github.io/jlcparts/data/cache.zip
+          for seq in $(seq 1 9); do
+            wget -q https://yaqwsx.github.io/jlcparts/data/cache.z0$seq || true
+          done
+
+          7z x cache.zip
+          rm -rf cache.z*
+
+          python3 jlcparts_db_convert.py
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parts_db_zip_files
+          path: db_build/parts.db.zip.*
+  deploy:
+    name: "Deploy"
+    runs-on: ubuntu-20.04
+    needs: build_and_update
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout # Required for GH-pages deployment
+        uses: actions/checkout@v2
+      - name: "Download DB zips"
+        uses: actions/download-artifact@v2
+        with:
+          name: parts_db_zip_files
+      - name: Deploy to GH Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: gh-pages
+          folder: data
+          single-commit: true

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -44,6 +44,8 @@ jobs:
     name: "Deploy"
     runs-on: ubuntu-20.04
     needs: build_and_update
+    permissions:
+      id-token: write
     if: github.ref == 'refs/heads/main'
     steps:
       # - name: Checkout # Required for GH-pages deployment

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -35,11 +35,14 @@ jobs:
           ls -lah
           cd ..
           python3 jlcparts_db_convert.py
+          touch index.html
 
       - uses: actions/upload-artifact@v3
         with:
           name: parts_db_zip_files
-          path: db_build/parts.db.zip.*
+          path: |
+            db_build/parts.db.zip.*
+            index.html
   deploy:
     name: "Deploy"
     runs-on: ubuntu-20.04

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -56,7 +56,7 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v1
         with:
-      artifact_name: parts_db_zip_files
+          artifact_name: parts_db_zip_files
       # delete-artifact
       - name: Clean
         uses: geekyeggo/delete-artifact@v2

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -37,7 +37,7 @@ jobs:
           cd ..
           # creates the converted database in 80M split-zip files in folder db_build
           python3 jlcparts_db_convert.py
-          # remove the source db, as we don't wnat to package that one
+          # remove the source db, as we don't want to package that one
           rm db_build/cache.sqlite3
           # some info output for sanity check
           ls -lah db_build

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -44,6 +44,10 @@ jobs:
     name: "Deploy"
     runs-on: ubuntu-20.04
     needs: build_and_update
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     if: github.ref == 'refs/heads/main'
     steps:
       # - name: Checkout # Required for GH-pages deployment

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -33,7 +33,7 @@ jobs:
           rm -rf cache.z*
 
           ls -lah
-
+          cd ..
           python3 jlcparts_db_convert.py
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -44,8 +44,6 @@ jobs:
     name: "Deploy"
     runs-on: ubuntu-20.04
     needs: build_and_update
-    permissions:
-      id-token: write
     if: github.ref == 'refs/heads/main'
     steps:
       # - name: Checkout # Required for GH-pages deployment

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -21,6 +21,9 @@ jobs:
         run: |
           set -x
 
+          mkdir -p db_build
+          cd db_build
+
           wget -q https://yaqwsx.github.io/jlcparts/data/cache.zip
           for seq in $(seq 1 9); do
             wget -q https://yaqwsx.github.io/jlcparts/data/cache.z0$seq || true

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -29,6 +29,8 @@ jobs:
           7z x cache.zip
           rm -rf cache.z*
 
+          ls -lah
+
           python3 jlcparts_db_convert.py
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -46,15 +46,19 @@ jobs:
     needs: build_and_update
     if: github.ref == 'refs/heads/main'
     steps:
-      - name: Checkout # Required for GH-pages deployment
-        uses: actions/checkout@v2
-      - name: "Download DB zips"
-        uses: actions/download-artifact@v2
+      # - name: Checkout # Required for GH-pages deployment
+      #   uses: actions/checkout@v2
+      # - name: "Download DB zips"
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: parts_db_zip_files
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+        with:
+      artifact_name: parts_db_zip_files
+      # delete-artifact
+      - name: Clean
+        uses: geekyeggo/delete-artifact@v2
         with:
           name: parts_db_zip_files
-      - name: Deploy to GH Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.0
-        with:
-          branch: gh-pages
-          folder: data
-          single-commit: true

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+db_build/
 develop-eggs/
 dist/
 downloads/

--- a/jlcparts_db_convert.py
+++ b/jlcparts_db_convert.py
@@ -142,3 +142,28 @@ conn.close()
 # compress the result
 with ZipFile("parts.db.zip", "w", zipfile.ZIP_DEFLATED) as zf:
     zf.write(partsdb)
+
+# split the archive on byte level so we stay below githubs 100M limit
+
+# Set the size of each split file (in bytes)
+split_size = 80000000  # 80 MB
+
+# Open the zip file for byte-reading
+with open("parts.db.zip", "rb") as z:
+    # Read the file data in chunks
+    chunk = z.read(split_size)
+    chunk_num = 1
+
+    while chunk:
+        split_file_name = f"parts.db.zip.{chunk_num:03}"
+        with open(split_file_name, "wb") as split_file:
+            # Write the chunk to the new split file
+            split_file.write(chunk)
+
+        # Read the next chunk of data from the file
+        chunk = z.read(split_size)
+        chunk_num += 1
+
+# remove the large zip file und uncompressed db after splitting
+os.unlink("parts.db.zip")
+os.unlink()

--- a/jlcparts_db_convert.py
+++ b/jlcparts_db_convert.py
@@ -166,4 +166,4 @@ with open("parts.db.zip", "rb") as z:
 
 # remove the large zip file und uncompressed db after splitting
 os.unlink("parts.db.zip")
-os.unlink()
+os.unlink(partsdb)

--- a/jlcparts_db_convert.py
+++ b/jlcparts_db_convert.py
@@ -1,0 +1,144 @@
+#!/bin/env python3
+
+"""
+Use the amazing work of https://github.com/yaqwsx/jlcparts and
+convert their database into something we can conveniently use for
+this plugin.
+This replaces the old .csv based database creation that JLCPCB
+no longer supports.
+
+Before this script can run, the cache.sqlite3 file has to be
+present in db_build folder. Download and reassemble it like
+jlcparts does it in their build pipeline:
+https://github.com/yaqwsx/jlcparts/blob/1a07e1ff42fef2d35419cfb9ba47df090037cc7b/.github/workflows/update_components.yaml#L45-L50
+
+by @markusdd
+"""
+
+import json
+import os
+import sqlite3
+import zipfile
+from datetime import date
+from datetime import datetime
+from pathlib import Path
+from zipfile import ZipFile
+
+os.makedirs("db_build", exist_ok=True)
+os.chdir("db_build")
+
+partsdb = Path("parts.db")
+
+# we want to rebuild a new parts.db, so remove the old one
+if partsdb.exists():
+    partsdb.unlink()
+
+# connection to the jlcparts db
+conn_jp = sqlite3.connect("cache.sqlite3")
+
+# connection to the plugin db we want to write
+conn = sqlite3.connect(partsdb)
+
+# schema creation
+conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS parts ( 
+        'LCSC Part',
+        'First Category',
+        'Second Category',
+        'MFR.Part',
+        'Package',
+        'Solder Joint',
+        'Manufacturer',
+        'Library Type',
+        'Description',
+        'Datasheet',
+        'Price',
+        'Stock'
+    )
+    """
+)
+
+conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS mapping (
+        'footprint',
+        'value',
+        'LCSC'
+    )
+    """
+)
+
+conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS meta (
+        'filename',
+        'size',
+        'partcount',
+        'date',
+        'last_update'
+    )
+    """
+)
+
+conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS rotation (
+        'regex',
+        'correction'
+    )
+    """
+)
+
+# load the tables into memory
+res = conn_jp.execute("SELECT * FROM manufacturers")
+mans = {i: m for i, m in res.fetchall()}
+
+res = conn_jp.execute("SELECT * FROM categories")
+cats = {i: (c, sc) for i, c, sc in res.fetchall()}
+
+res = conn_jp.execute("SELECT * FROM components")
+comps = res.fetchall()
+
+conn_jp.close()
+
+# now extract the data from the jlcparts db and fill
+# it into the plugin database
+rows = []
+for c in comps:
+    price = json.loads(c[10])
+    price_str = ",".join(
+        [
+            f"{entry.get('qFrom')}-{entry.get('qTo') if entry.get('qTo') is not None else ''}:{entry.get('price')}"
+            for entry in price
+        ]
+    )
+    row = (
+        f"C{c[0]}",  # LCSC Part
+        cats[c[1]][0],  # First Category
+        cats[c[1]][1],  # Second Category
+        c[2],  # MFR.Part
+        c[3],  # Package
+        int(c[4]),  # Solder Joint
+        mans[c[5]],  # Manufacturer
+        "Basic" if c[6] else "Extended",  # Library Type
+        c[7],  # Description
+        c[8],  # Datasheet
+        price_str,  # Price
+        int(c[9]),  # Stock
+    )
+    rows.append(row)
+
+conn.executemany("INSERT INTO parts VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+conn.commit()
+db_size = os.stat(partsdb).st_size
+conn.execute(
+    "INSERT INTO meta VALUES(?, ?, ?, ?, ?)",
+    ["cache.sqlite3", db_size, len(comps), date.today(), datetime.now().isoformat()],
+)
+conn.commit()
+conn.close()
+
+# compress the result
+with ZipFile("parts.db.zip", "w", zipfile.ZIP_DEFLATED) as zf:
+    zf.write(partsdb)

--- a/jlcparts_db_convert.py
+++ b/jlcparts_db_convert.py
@@ -125,7 +125,7 @@ for c in comps:
         c[7],  # Description
         c[8],  # Datasheet
         price_str,  # Price
-        int(c[9]),  # Stock
+        str(c[9]),  # Stock
     )
     rows.append(row)
 

--- a/unzip_parts.py
+++ b/unzip_parts.py
@@ -1,0 +1,36 @@
+#!/bin/env python3
+
+
+def unzip_parts():
+    # unzip (needs to go into download function finally)
+    # Set the name of the original file
+    db_zip_file = Path("parts.db.zip")
+    split_dir = Path("db_download")
+
+    # Open the original file for writing
+    with open(db_zip_file, "wb") as db:
+        # Get a list of the split files in the split directory
+        split_files = [
+            f for f in os.listdir(split_dir) if f.startswith("parts.db.zip.")
+        ]
+
+        # Sort the split files by their index
+        split_files.sort(key=lambda f: int(f.split(".")[-1]))
+
+        # Iterate over the split files and append their contents to the original file
+        for split_file_name in split_files:
+            # Open the split file
+            with open(split_dir / split_file_name, "rb") as split_file:
+                # Read the file data
+                file_data = split_file.read()
+
+                # Append the file data to the original file
+                db.write(file_data)
+
+            # Delete the split file
+            os.unlink(split_dir / split_file_name)
+
+    with ZipFile("parts.db.zip", "r") as zf:
+        zf.extractall()
+
+    os.unlink(db_zip_file)

--- a/unzip_parts.py
+++ b/unzip_parts.py
@@ -1,5 +1,9 @@
 #!/bin/env python3
 
+import os
+from pathlib import Path
+from zipfile import ZipFile
+
 
 def unzip_parts():
     # unzip (needs to go into download function finally)


### PR DESCRIPTION
Work in progress to resolve #304

Strategy: fetch jlcparts database which is generated daily, convert it to this plugins format to bring down size and enhance usability for the purposes of this plugin.
A github pipeline should then run daily, always serving the latest db, tehn just the download function of this plugin needs adaptation.

- [x] conversion script
  - [x] solve issue that in stock search is somehow not working although numbers are in
  - [x split zip in pure python so that it can be reassembled, Github limits to 100MB file size
- [x] pipeline
- [x] ~~adapt download function~~ will be done in a second PR