### PR TITLE
Fix image URL for GetPartDetails

### DIFF
--- a/partdetails.py
+++ b/partdetails.py
@@ -215,8 +215,10 @@ class PartDetailsDialog(wx.Dialog):
                     str(attribute.get("attribute_value_name")),
                 ]
             )
-        picture = data.get("data", {}).get("componentImageUrl")
+        picture = data.get("data", {}).get("minImage")
         if picture:
+            # get the full resolution image instead of the thumbnail
+            picture = picture.replace("96x96","900x900") 
             self.image.SetBitmap(
                 self.get_scaled_bitmap(
                     picture,


### PR DESCRIPTION
As reported in #309 the Part Details button no longer works and even crashes the plugin.
This was caused by an API change of JLCPCB / LCSC which is fixed now.