### PR TITLE
Only run Update parts database on schedule

### DIFF
--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -1,8 +1,6 @@
 ---
 name: "Update parts database"
 on:
-  push:
-  pull_request:
   schedule:  # 2 hours after jlcparts updates their database
     - cron: "0 5 * * *"
 jobs:


### PR DESCRIPTION
Its completely useless to have the update parts database action running on each push / pull request.