### PR TITLE
Toggle BOM/POS without re-populate entire list

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,0 +1,14 @@
+from enum import IntEnum
+
+
+class Column(IntEnum):
+    REFERENCE = 0
+    VALUE = 1
+    FOOTPRINT = 2
+    LCSC = 3
+    TYPE = 4
+    STOCK = 5
+    BOM = 6
+    POS = 7
+    ROTATION = 8
+    SIDE = 9

--- a/helpers.py
+++ b/helpers.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import wx
+import wx.dataview
 
 PLUGIN_PATH = os.path.split(os.path.abspath(__file__))[0]
 
@@ -68,6 +69,25 @@ def loadIconScaled(filename, scale=1.0):
     if getWxWidgetsVersion() > 315:
         return bmp
     return wx.Icon(bmp)
+
+
+def GetListIcon(value, scale_factor):
+    if value == 0:
+        return wx.dataview.DataViewIconText(
+            "",
+            loadIconScaled(
+                "mdi-check-color.png",
+                scale_factor,
+            ),
+        )
+    else:
+        return wx.dataview.DataViewIconText(
+            "",
+            loadIconScaled(
+                "mdi-close-color.png",
+                scale_factor,
+            ),
+        )
 
 
 def natural_sort_collation(a, b):

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -26,9 +26,11 @@ from .helpers import (
     getVersion,
     loadBitmapScaled,
     loadIconScaled,
+    GetListIcon,
     toggle_exclude_from_bom,
     toggle_exclude_from_pos,
 )
+from .const import Column
 from .library import Library, LibraryState
 from .partdetails import PartDetailsDialog
 from .partmapper import PartMapperManagerDialog
@@ -719,9 +721,12 @@ class JLCPCBTools(wx.Dialog):
             pos = toggle_exclude_from_pos(fp)
             self.store.set_bom(ref, bom)
             self.store.set_pos(ref, pos)
-        self.populate_footprint_list()
-        for row in selected_rows:
-            self.footprint_list.SelectRow(row)
+            self.footprint_list.SetValue(
+                GetListIcon(bom, self.scale_factor), row, Column.BOM
+            )
+            self.footprint_list.SetValue(
+                GetListIcon(pos, self.scale_factor), row, Column.POS
+            )
 
     def toggle_bom(self, e):
         """Toggle the exclude from BOM attribute of a footprint."""
@@ -733,9 +738,9 @@ class JLCPCBTools(wx.Dialog):
             fp = get_footprint_by_ref(GetBoard(), ref)[0]
             bom = toggle_exclude_from_bom(fp)
             self.store.set_bom(ref, bom)
-        self.populate_footprint_list()
-        for row in selected_rows:
-            self.footprint_list.SelectRow(row)
+            self.footprint_list.SetValue(
+                GetListIcon(bom, self.scale_factor), row, Column.BOM
+            )
 
     def toggle_pos(self, e):
         selected_rows = []
@@ -747,9 +752,9 @@ class JLCPCBTools(wx.Dialog):
             fp = get_footprint_by_ref(GetBoard(), ref)[0]
             pos = toggle_exclude_from_pos(fp)
             self.store.set_pos(ref, pos)
-        self.populate_footprint_list()
-        for row in selected_rows:
-            self.footprint_list.SelectRow(row)
+            self.footprint_list.SetValue(
+                GetListIcon(pos, self.scale_factor), row, Column.POS
+            )
 
     def remove_part(self, e):
         """Remove an assigned a LCSC Part number to a footprint."""


### PR DESCRIPTION
This allows much faster toggling of BOM / POS values without re-populating the entire list.
Should also help with list jump to position 0