### PR TITLE
Fix icon colours for dark theme

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -56,6 +56,8 @@ def loadBitmapScaled(filename, scale=1.0, static=False):
         bmp = wx.Bitmap(path)
         w, h = bmp.GetSize()
         img = bmp.ConvertToImage()
+        if wx.SystemSettings.GetAppearance().IsDark():
+            img.Replace(0, 0, 0, 255, 255, 255)
         bmp = wx.Bitmap(img.Scale(int(w * scale), int(h * scale)))
     else:
         bmp = wx.Bitmap()


### PR DESCRIPTION
Tested on MacOS 13.4 and current KiCAD 7.

Had to patch the scaling to 1.0 as well, BTW (Bouni#330).

Great plugin!
