### PR TITLE
Force Scalefactor to 1.0 if on Mac OS

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -35,8 +35,15 @@ def getVersion():
         return f.read().strip()
 
 
+def GetOS():
+    """Get String with OS type"""
+    return wx.PlatformInformation.Get().GetOperatingSystemIdName()
+
+
 def GetScaleFactor(window):
-    """Workaround if wxWidgets Version does not support GetDPIScaleFactor"""
+    """Workaround if wxWidgets Version does not support GetDPIScaleFactor, for Mac OS always return 1.0"""
+    if "Apple Mac OS" in GetOS():
+        return 1.0
     if hasattr(window, "GetDPIScaleFactor"):
         return window.GetDPIScaleFactor()
     return 1.0


### PR DESCRIPTION
As reported in #330 and #353 on Mac OS a scale factor of 1.0 is needed in order to scale the icons correctly.