### PR TITLE
Revert "Fix icon colours for dark theme"

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -63,8 +63,6 @@ def loadBitmapScaled(filename, scale=1.0, static=False):
         bmp = wx.Bitmap(path)
         w, h = bmp.GetSize()
         img = bmp.ConvertToImage()
-        if wx.SystemSettings.GetAppearance().IsDark():
-            img.Replace(0, 0, 0, 255, 255, 255)
         bmp = wx.Bitmap(img.Scale(int(w * scale), int(h * scale)))
     else:
         bmp = wx.Bitmap()


### PR DESCRIPTION
Reverts Bouni/kicad-jlcpcb-tools#353

Unfortunately it seems that my windows settings are set to Dark mode but the wx frames of the plugin are still light.
That means the icons become white and are nearly invisible ☹️