### PR TITLE
Added wx attributes check to prevent startup crash

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -63,9 +63,10 @@ def loadBitmapScaled(filename, scale=1.0, static=False):
         bmp = wx.Bitmap(path)
         w, h = bmp.GetSize()
         img = bmp.ConvertToImage()
-        if wx.SystemSettings.GetAppearance().IsUsingDarkBackground():
-            img.Replace(0, 0, 0, 255, 255, 255)
-        bmp = wx.Bitmap(img.Scale(int(w * scale), int(h * scale)))
+        if hasattr(wx.SystemSettings, "GetAppearance") and hasattr(wx.SystemSettings.GetAppearance, "IsUsingDarkBackground"):
+            if wx.SystemSettings.GetAppearance().IsUsingDarkBackground():
+                img.Replace(0, 0, 0, 255, 255, 255)
+            bmp = wx.Bitmap(img.Scale(int(w * scale), int(h * scale)))
     else:
         bmp = wx.Bitmap()
     if getWxWidgetsVersion() > 315 and not static:

--- a/helpers.py
+++ b/helpers.py
@@ -63,7 +63,9 @@ def loadBitmapScaled(filename, scale=1.0, static=False):
         bmp = wx.Bitmap(path)
         w, h = bmp.GetSize()
         img = bmp.ConvertToImage()
-        if hasattr(wx.SystemSettings, "GetAppearance") and hasattr(wx.SystemSettings.GetAppearance, "IsUsingDarkBackground"):
+        if hasattr(wx.SystemSettings, "GetAppearance") and hasattr(
+            wx.SystemSettings.GetAppearance, "IsUsingDarkBackground"
+        ):
             if wx.SystemSettings.GetAppearance().IsUsingDarkBackground():
                 img.Replace(0, 0, 0, 255, 255, 255)
             bmp = wx.Bitmap(img.Scale(int(w * scale), int(h * scale)))


### PR DESCRIPTION
Fixes #362, where a crash happens on startup for certain versions of wx that do not have `GetAppearance` and `IsUsingDarkBackground` attributes. This issue is only present in stable version  `2023.08.02`.

This fix checks for the existence of the attributes before checking their contents.