### PR TITLE
Detect top/bottom layer correctly for flipped footprints

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -96,23 +96,24 @@ class Fabrication:
 
     def rotate(self, footprint, rotation, correction):
         """Calculate the actual correction"""
+        correction_int = int(correction)
         if get_is_top(footprint):
-            rotation = (rotation + int(correction)) % 360
+            rotation = (rotation + correction_int) % 360
             self.logger.info(
                 "Fixed rotation of %s (%s / %s) on Top Layer by %d degrees",
                 footprint.GetReference(),
                 footprint.GetValue(),
                 footprint.GetFPID().GetLibItemName(),
-                correction,
+                correction_int,
             )
         else:
-            rotation = (rotation - int(correction)) % 360
+            rotation = (rotation - correction_int) % 360
             self.logger.info(
                 "Fixed rotation of %s (%s / %s) on Bottom Layer by %d degrees",
                 footprint.GetReference(),
                 footprint.GetValue(),
                 footprint.GetFPID().GetLibItemName(),
-                correction,
+                correction_int,
             )
         return rotation
 

--- a/fabrication.py
+++ b/fabrication.py
@@ -36,7 +36,12 @@ try:
 except ImportError:
     NO_DRILL_SHAPE = PCB_PLOT_PARAMS.NO_DRILL_SHAPE
 
-from .helpers import get_exclude_from_pos, get_footprint_by_ref, get_smd
+from .helpers import (
+    get_exclude_from_pos,
+    get_footprint_by_ref,
+    get_is_top,
+    get_smd,
+)
 
 
 class Fabrication:
@@ -75,7 +80,7 @@ class Fabrication:
             # we need to divide by 10 to get 180 out of 1800 for example.
             # This might be a bug in 5.99 / 6.0 RC
             rotation = original / 10
-        if footprint.GetLayer() != 0:
+        if not get_is_top(footprint):
             # bottom angles need to be mirrored on Y-axis
             rotation = (180 - rotation) % 360
         # First check if the value aka part name matches
@@ -91,7 +96,7 @@ class Fabrication:
 
     def rotate(self, footprint, rotation, correction):
         """Calculate the actual correction"""
-        if footprint.GetLayer() == 0:
+        if get_is_top(footprint):
             rotation = (rotation + int(correction)) % 360
             self.logger.info(
                 "Fixed rotation of %s (%s / %s) on Top Layer by %d degrees",
@@ -283,7 +288,7 @@ class Fabrication:
                             ToMM(position.x),
                             ToMM(position.y) * -1,
                             self.fix_rotation(fp),
-                            "top" if fp.GetLayer() == 0 else "bottom",
+                            "top" if get_is_top(fp) else "bottom",
                         ]
                     )
         self.logger.info("Finished generating CPL file")

--- a/helpers.py
+++ b/helpers.py
@@ -226,6 +226,14 @@ def get_not_in_schematic(footprint):
     return bool(get_bit(val, NOT_IN_SCHEMATIC))
 
 
+def get_is_top(footprint):
+    """Get if the footprint is on the top or bottom."""
+    is_top = footprint.GetLayer() == 0
+    if footprint.IsFlipped():
+        is_top = not is_top
+    return is_top
+
+
 def set_tht(footprint):
     """Set the THT property of a footprint."""
     if not footprint:

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -27,6 +27,7 @@ from .helpers import (
     GetScaleFactor,
     HighResWxSize,
     get_footprint_by_ref,
+    get_is_top,
     getVersion,
     loadBitmapScaled,
     loadIconScaled,
@@ -589,7 +590,7 @@ class JLCPCBTools(wx.Dialog):
             part[6] = icons.get(part[6], icons.get(0))
             part[7] = icons.get(part[7], icons.get(0))
             part.insert(8, "")
-            side = "Top" if fp.GetLayer() == 0 else "Bot"
+            side = "Top" if get_is_top(fp) else "Bot"
             part.insert(9, side)
             part.insert(10, "")
             parts.append(part)


### PR DESCRIPTION
Check footprint.IsFlipped() when detecting top vs bottom layer placement to correctly handle flipped footprints.

Also fix an unhandled exception when logging about rotation corrections.