### PR TITLE
Possible fix for Plugin Crash

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import sys
+import time
 
 import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
@@ -70,8 +71,8 @@ class JLCPCBTools(wx.Dialog):
     """Main Windows class for this plugin."""
 
     def __init__(self, parent):
-        if sys.platform != "darwin":
-            self.app = wx.App()
+        while not wx.GetApp():
+            time.sleep(1)
         wx.Dialog.__init__(
             self,
             parent,


### PR DESCRIPTION
It was pointed out by a KiCAD developer that the `self.app = wx.App()` might be the problem. See [issue 15520](https://gitlab.com/kicad/code/kicad/-/issues/15520) for details.
Removing it solved the issue for me but most likely will bring back #291

So I looked at KiBuzzards source an shamelessly stole [two lines](https://github.com/gregdavill/KiBuzzard/blob/main/KiBuzzard/__init__.py#L33-L34) from there 😅