### PR TITLE
partselector.py - Remove vertical alignment flags that are only valid…

### DIFF
--- a/partselector.py
+++ b/partselector.py
@@ -236,86 +236,80 @@ class PartSelectorDialog(wx.Dialog):
         )
 
         search_sizer_one = wx.BoxSizer(wx.VERTICAL)
-        search_sizer_one.Add(keyword_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_one.Add(keyword_label, 0, wx.ALL, 5)
         search_sizer_one.Add(
             self.keyword,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
-        search_sizer_one.Add(
-            manufacturer_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
-        )
+        search_sizer_one.Add(manufacturer_label, 0, wx.ALL, 5)
         search_sizer_one.Add(
             self.manufacturer,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
-        search_sizer_one.Add(package_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_one.Add(package_label, 0, wx.ALL, 5)
         search_sizer_one.Add(
             self.package,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 
         search_sizer_two = wx.BoxSizer(wx.VERTICAL)
-        search_sizer_two.Add(category_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_two.Add(category_label, 0, wx.ALL, 5)
         search_sizer_two.Add(
             self.category,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
-        search_sizer_two.Add(part_no_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_two.Add(part_no_label, 0, wx.ALL, 5)
         search_sizer_two.Add(
             self.part_no,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
-        search_sizer_two.Add(
-            solder_joints_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
-        )
+        search_sizer_two.Add(solder_joints_label, 0, wx.ALL, 5)
         search_sizer_two.Add(
             self.solder_joints,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 
         search_sizer_three = wx.BoxSizer(wx.VERTICAL)
-        search_sizer_three.Add(
-            subcategory_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
-        )
+        search_sizer_three.Add(subcategory_label, 0, wx.ALL, 5)
         search_sizer_three.Add(
             self.subcategory,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 
         search_sizer_four = wx.BoxSizer(wx.VERTICAL)
-        search_sizer_four.Add(basic_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_four.Add(basic_label, 0, wx.ALL, 5)
         search_sizer_four.Add(
             self.basic_checkbox,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
-        search_sizer_four.Add(extended_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_four.Add(extended_label, 0, wx.ALL, 5)
         search_sizer_four.Add(
             self.extended_checkbox,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
-        search_sizer_four.Add(stock_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        search_sizer_four.Add(stock_label, 0, wx.ALL, 5)
         search_sizer_four.Add(
             self.assert_stock_checkbox,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 
@@ -323,14 +317,14 @@ class PartSelectorDialog(wx.Dialog):
         search_sizer_five.Add(
             help_button,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
         search_sizer_five.AddSpacer(80)
         search_sizer_five.Add(
             self.search_button,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 


### PR DESCRIPTION
… in horizontal sizers

Fixes wxWidgets flags checking warnings like:

Traceback (most recent call last):
  File "/Users/cmorgan/Documents/KiCad/7.0/scripting/plugins/kicad-jlcpcb-tools/mainwindow.py", line 909, in select_part
    PartSelectorDialog(self, selection).ShowModal()
  File "/Users/cmorgan/Documents/KiCad/7.0/scripting/plugins/kicad-jlcpcb-tools/partselector.py", line 289, in __init__
    search_sizer_three.Add(
wx._core.wxAssertionError: C++ assertion "CheckSizerFlags(!((flags) & (wxALIGN_CENTRE_VERTICAL)))" failed at ./src/common/sizer.cpp(2262) in DoInsert(): wxALIGN_CENTRE_VERTICAL will be ignored in this sizer: only horizontal alignment flags can be used in vertical sizers

DO NOT PANIC !!

If you're an end user running a program not developed by you, please ignore this message, it is harmless, and please try reporting the problem to the program developers.

You may also set WXSUPPRESS_SIZER_FLAGS_CHECK environment variable to suppress all such checks when running this program.

If you're the developer, simply remove this flag from your code to avoid getting this message. You can also call wxSizerFlags::DisableConsistencyChecks() to globally disable all such checks, but this is strongly not recommended.