### PR TITLE
Calculate footprint centroid based on its pads.

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     NO_DRILL_SHAPE = PCB_PLOT_PARAMS.NO_DRILL_SHAPE
 
-from .helpers import get_exclude_from_pos, get_footprint_by_ref, get_smd
+from .helpers import get_exclude_from_pos, get_footprint_by_ref
 
 
 class Fabrication:
@@ -113,9 +113,10 @@ class Fabrication:
 
     def get_position(self, footprint):
         """Calculate position based on center of bounding box."""
-        if get_smd(footprint):
-            return footprint.GetPosition()
-        bbox = footprint.GetBoundingBox(False, False)
+        pads = footprint.Pads()
+        bbox = pads[0].GetBoundingBox()
+        for pad in pads:
+            bbox.Merge(pad.GetBoundingBox())
         return bbox.GetCenter()
 
     def generate_geber(self, layer_count=None):
@@ -230,7 +231,7 @@ class Fabrication:
         offset = self.board.GetDesignSettings().GetAuxOrigin()
         mergeNPTH = False
         drlwriter.SetOptions(mirror, minimalHeader, offset, mergeNPTH)
-        drlwriter.SetFormat(True)  # True = metric drill files
+        drlwriter.SetFormat(False)
         genDrl = True
         genMap = True
         drlwriter.CreateDrillandMapFilesSet(self.gerberdir, genDrl, genMap)


### PR DESCRIPTION
Solves issue https://github.com/Bouni/kicad-jlcpcb-tools/issues/379 that silkscreen was affecting centroid position calculation.

Nice and center now regardless of the uneven silk:
<img width="404" alt="image" src="https://github.com/Bouni/kicad-jlcpcb-tools/assets/841061/8a0025ac-f053-46e4-811c-db1802377e00">
