### PR TITLE
add new standalone mode for startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,74 @@ This plugin makes use of a lot of icons from the excellent [Material Design Icon
 
 Make sure you make use of pre-commit hooks in order to format everything nicely with `black`
 In the near future I'll add `ruff` / `pylint` and possibly other pre-commit-hooks that enforce nice and clean code style.
+
+## Standalone mode
+
+Allows the plugin UI to be started without KiCAD, enabling debugging with an IDE like pycharm / vscode.
+
+Standalone mode is under development.
+
+### Limitations
+
+- All board / footprint / value data are hardcoded stubs, see standalone_impl.py
+
+### How to use
+
+To use the plugin in standlone mode you'll need to identify three pieces of information specific to your Kicad version, plugin path, and OS.
+
+#### Python
+
+The <i><b>{KiCad python}</b></i> should be used, this can be found at different locations depending on your system:
+
+| OS | Kicad python |
+|---|---|
+|Mac| /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3|
+|Linux| TBD|
+|Windows | TBD|
+
+#### Working directory
+
+The <i><b>{working directory}</b></i> should be your plugins directory, ie:
+
+|OS | Working dir|
+|Mac| ~/Documents/KiCad/8.0/scripting/plugins/|
+|Linux|TBD|
+|Windows|TBD|
+
+#### Plugin folder name
+
+The <i><b>{kicad-jlcpcb-tools folder name}</b></i> should be the name of the kicad-jlcpcb-tools folder.
+
+- For Kicad managed plugins this may be like
+
+> com_github_bouni_kicad-jlcpcb-tools
+
+- If you are developing kicad-jlcpcb-tools this is the folder you cloned the kicad-jlcpcb-tools as.
+
+#### Command line
+
+- Change to the working directory as noted above
+- Run the python interpreter with the <i><b>{kicad-jlcpcb-tools folder name}</b></i> folder as a module.
+
+For example:
+
+```sh
+cd {working directory}
+{kicad_python} -m {kicad-jlcpcb-tools folder name}
+```
+
+For example on Mac:
+
+```sh
+/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3 -m kicad-jlcpcb-tools
+```
+
+#### IDE
+
+- Configure the command line to be '{kicad_python} -m {kicad-jlcpcb-tools folder name}'
+- Set the working directory to {working directory}
+
+If using PyCharm or Jetbrains IDEs, set the interpreter to Kicad's python, <i><b>{Kicad python}</b></i> and under 'run configuration' select Python.
+
+Click on 'script path' and change instead to 'module name',
+entering the name of the kicad-jlcpcb-tools folder, <i><b>{kicad-jlcpcb-tools folder name}</b></i>.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The <i><b>{KiCad python}</b></i> should be used, this can be found at different 
 |---|---|
 |Mac| /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3|
 |Linux| TBD|
-|Windows | TBD|
+|Windows | C:\Program Files\KiCad\8.0\bin\python.exe|
 
 #### Working directory
 
@@ -182,7 +182,7 @@ The <i><b>{working directory}</b></i> should be your plugins directory, ie:
 |OS | Working dir|
 |Mac| ~/Documents/KiCad/8.0/scripting/plugins/|
 |Linux|TBD|
-|Windows|TBD|
+|Windows| %USERPROFILE%\Documents\KiCad\8.0\scripting\plugins\|
 
 #### Plugin folder name
 
@@ -210,6 +210,12 @@ For example on Mac:
 
 ```sh
 /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3 -m kicad-jlcpcb-tools
+```
+
+For example on Windows:
+
+```cmd
+& 'C:\Program Files\KiCad\8.0\bin\python.exe' -m kicad-jlcpcb-tools
 ```
 
 #### IDE

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 """Init file for pligin."""
 from .plugin import JLCPCBPlugin
 
-JLCPCBPlugin().register()
+if __name__ != "__main__":
+    JLCPCBPlugin().register()

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,19 @@
+"""Entry point for running the plugin in standalone mode."""
+
+import wx
+
+from . import standalone_impl
+from .mainwindow import JLCPCBTools
+
+if __name__ == "__main__":
+    print("starting jlcpcbtools standalone mode...") # noqa: T201
+
+    # See README.md for how to use this
+
+    app = wx.App(None)
+
+    dialog = JLCPCBTools(None, kicad_provider=standalone_impl.KicadStub())
+    dialog.Center()
+    dialog.Show()
+
+    app.MainLoop()

--- a/fabrication.py
+++ b/fabrication.py
@@ -23,7 +23,6 @@ from pcbnew import (  # pylint: disable=import-error
     F_Mask,
     F_Paste,
     F_SilkS,
-    GetBoard,
     Refresh,
     ToMM,
 )
@@ -42,10 +41,10 @@ from .helpers import get_exclude_from_pos
 class Fabrication:
     """Contains all functionality to generate the JLCPCB production files."""
 
-    def __init__(self, parent):
+    def __init__(self, parent, board):
         self.parent = parent
         self.logger = logging.getLogger(__name__)
-        self.board = GetBoard()
+        self.board = board
         self.corrections = []
         self.path, self.filename = os.path.split(self.board.GetFileName())
         self.create_folders()
@@ -259,9 +258,8 @@ class Fabrication:
             writer.writerow(
                 ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
             )
-            board = GetBoard()
             for part in self.parent.store.read_pos_parts():
-                fp = board.FindFootprintByReference(part[0])
+                fp = self.board.FindFootprintByReference(part[0])
                 if get_exclude_from_pos(fp):
                     continue
                 if not add_without_lcsc and not part[3]:

--- a/standalone_impl.py
+++ b/standalone_impl.py
@@ -1,0 +1,99 @@
+"""Stubs for standalone usage of the plugin."""
+
+class LIB_ID_Stub:
+    """Implementation of pcbnew.LIB_ID."""
+
+    def __init__(self, item_name):
+        self.item_name = item_name
+
+    def GetLibItemName(self) -> str:
+        """Item name."""
+        return self.item_name
+
+
+class Footprint_Stub:
+    """Implementation of pcbnew.Footprint."""
+
+    def __init__(self, reference, value, fpid):
+        self.reference = reference
+        self.value = value
+        self.fpid = fpid
+
+    def GetReference(self) -> str:
+        """Retrieve the reference designator string."""
+        return self.reference
+
+    def GetValue(self) -> str:
+        """Value string."""
+        return self.value
+
+    def GetFPID(self) -> LIB_ID_Stub:
+        """Footprint LIB_ID."""
+        return self.fpid
+
+    def GetProperties(self) -> dict:
+        """Properties."""
+        return {}
+
+    def GetAttributes(self) -> int:
+        """Attributes."""
+        return 0
+
+    def GetLayer(self) -> int:
+        """Layer number."""
+        # TODO: maybe this is defined in a python module we can import and reuse here?
+        return 3  # F_Cu, see https://docs.kicad.org/doxygen/layer__ids_8h.html#ae0ad6e574332a997f501d1b091c3f53f
+
+    def SetSelected(self):
+        """Select this item."""
+
+
+class BoardStub:
+    """Implementation of pcbnew.Board."""
+
+    def __init__(self):
+        self.footprints = []
+        self.footprints.append(Footprint_Stub("R1", "100", LIB_ID_Stub("resistors")))
+
+    def GetFileName(self):
+        """Board filename."""
+        return "fake_test_board.kicad_pcb"
+
+    def GetFootprints(self):
+        """Footprint list."""
+        return self.footprints
+
+    def FindFootprintByReference(self, reference):
+        """Get a list of footprints that match a reference."""
+        return Footprint_Stub(reference, "stub", 100)
+
+class PcbnewStub:
+    """Stub implementation of pcbnew."""
+
+    def __init__(self):
+        self.board = BoardStub()
+
+    def GetBoard(self):
+        """Get the board."""
+        return self.board
+
+    def GetBuildVersion(self):
+        """Get the kicad build version."""
+        return "8.0.1"
+
+    def GetCurrentSelection(self):
+        """Get the currently selected board items."""
+        return []
+
+    def Refresh(self):
+        """Redraw the screen."""
+
+class KicadStub:
+    """Stub implementation of Kicad."""
+
+    def __init__(self):
+        self.pcbnew = PcbnewStub()
+
+    def get_pcbnew(self):
+        """Get the pcbnew stub."""
+        return self.pcbnew

--- a/store.py
+++ b/store.py
@@ -7,8 +7,6 @@ import os
 from pathlib import Path
 import sqlite3
 
-from pcbnew import GetBoard  # pylint: disable=import-error
-
 from .helpers import (
     get_exclude_from_bom,
     get_exclude_from_pos,
@@ -21,10 +19,11 @@ from .helpers import (
 class Store:
     """A storage class to get data from a sqlite database and write it back."""
 
-    def __init__(self, parent, project_path):
+    def __init__(self, parent, project_path, board):
         self.logger = logging.getLogger(__name__)
         self.parent = parent
         self.project_path = project_path
+        self.board = board
         self.datadir = os.path.join(self.project_path, "jlcpcb")
         self.dbfile = os.path.join(self.datadir, "project.db")
         self.order_by = "reference"
@@ -184,8 +183,7 @@ class Store:
 
     def update_from_board(self):
         """Read all footprints from the board and insert them into the database if they do not exist."""
-        board = GetBoard()
-        for fp in get_valid_footprints(board):
+        for fp in get_valid_footprints(self.board):
             part = [
                 fp.GetReference(),
                 fp.GetValue(),
@@ -241,7 +239,7 @@ class Store:
 
     def clean_database(self):
         """Delete all parts from the database that are no longer present on the board."""
-        refs = [f"'{fp.GetReference()}'" for fp in get_valid_footprints(GetBoard())]
+        refs = [f"'{fp.GetReference()}'" for fp in get_valid_footprints(self.board)]
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
                 f"DELETE FROM part_info WHERE reference NOT IN ({','.join(refs)})"


### PR DESCRIPTION
Bringing this one back since it was helpful in debugging plugin changes that were resulting in crashes.



- motivation: I wanted to be able to debug the UI with PyCharm/vscode
- this is not the most stable thing in the world but gets the job done
- allows the UI to start without Kicad being started, which allows real debugging from an IDE
- see __main__.py for instructions on how to launch this
- wrap all calls to GetBoard() with a class that can return a fake stub