### PR TITLE
Cmm direct - Direct calls and remove duplicate helper

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     NO_DRILL_SHAPE = PCB_PLOT_PARAMS.NO_DRILL_SHAPE
 
-from .helpers import get_exclude_from_pos, get_footprint_by_ref
+from .helpers import get_exclude_from_pos
 
 
 class Fabrication:
@@ -269,8 +269,9 @@ class Fabrication:
             writer.writerow(
                 ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
             )
+            board = GetBoard()
             for part in self.parent.store.read_pos_parts():
-                for fp in get_footprint_by_ref(self.board, part[0]):
+                for fp in board.FindFootprintByReference(part[0]):
                     if get_exclude_from_pos(fp):
                         continue
                     if not add_without_lcsc and not part[3]:

--- a/helpers.py
+++ b/helpers.py
@@ -157,15 +157,6 @@ def get_footprint_keys(fp):
     return (package, reference)
 
 
-def get_footprint_by_ref(board, ref):
-    """Get a footprint from the list of footprints by its Reference."""
-    fps = []
-    for fp in get_valid_footprints(board):
-        if str(fp.GetReference()) == ref:
-            fps.append(fp)
-    return fps
-
-
 def get_bit(value, bit):
     """Get the nth bit of a byte."""
     return value & (1 << bit)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -7,7 +7,7 @@ import re
 import sys
 import time
 
-from pcbnew import GetBoard, GetBuildVersion  # pylint: disable=import-error
+import pcbnew
 import wx  # pylint: disable=import-error
 from wx import adv  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
@@ -82,12 +82,12 @@ class JLCPCBTools(wx.Dialog):
             size=wx.Size(1300, 800),
             style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
         )
-        self.KicadBuildVersion = GetBuildVersion()
+        self.KicadBuildVersion = pcbnew.GetBuildVersion()
         self.window = wx.GetTopLevelParent(self)
         self.SetSize(HighResWxSize(self.window, wx.Size(1300, 800)))
         self.scale_factor = GetScaleFactor(self.window)
-        self.project_path = os.path.split(GetBoard().GetFileName())[0]
-        self.board_name = os.path.split(GetBoard().GetFileName())[1]
+        self.project_path = os.path.split(pcbnew.GetBoard().GetFileName())[0]
+        self.board_name = os.path.split(pcbnew.GetBoard().GetFileName())[1]
         self.schematic_name = f"{self.board_name.split('.')[0]}.kicad_sch"
         self.hide_bom_parts = False
         self.hide_pos_parts = False
@@ -575,7 +575,7 @@ class JLCPCBTools(wx.Dialog):
         numbers = []
         parts = []
         for part in self.store.read_all():
-            fp = get_footprint_by_ref(GetBoard(), part[0])[0]
+            fp = get_footprint_by_ref(pcbnew.GetBoard(), part[0])[0]
             if part[3] and part[3] not in numbers:
                 numbers.append(part[3])
             part.insert(4, "")
@@ -730,7 +730,7 @@ class JLCPCBTools(wx.Dialog):
             row = self.footprint_list.ItemToRow(item)
             selected_rows.append(row)
             ref = self.footprint_list.GetTextValue(row, 0)
-            fp = get_footprint_by_ref(GetBoard(), ref)[0]
+            fp = get_footprint_by_ref(pcbnew.GetBoard(), ref)[0]
             bom = toggle_exclude_from_bom(fp)
             pos = toggle_exclude_from_pos(fp)
             self.store.set_bom(ref, bom)
@@ -749,7 +749,7 @@ class JLCPCBTools(wx.Dialog):
             row = self.footprint_list.ItemToRow(item)
             selected_rows.append(row)
             ref = self.footprint_list.GetTextValue(row, 0)
-            fp = get_footprint_by_ref(GetBoard(), ref)[0]
+            fp = get_footprint_by_ref(pcbnew.GetBoard(), ref)[0]
             bom = toggle_exclude_from_bom(fp)
             self.store.set_bom(ref, bom)
             self.footprint_list.SetValue(
@@ -763,7 +763,7 @@ class JLCPCBTools(wx.Dialog):
             row = self.footprint_list.ItemToRow(item)
             selected_rows.append(row)
             ref = self.footprint_list.GetTextValue(row, 0)
-            fp = get_footprint_by_ref(GetBoard(), ref)[0]
+            fp = get_footprint_by_ref(pcbnew.GetBoard(), ref)[0]
             pos = toggle_exclude_from_pos(fp)
             self.store.set_pos(ref, pos)
             self.footprint_list.SetValue(

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -27,7 +27,6 @@ from .helpers import (
     GetListIcon,
     GetScaleFactor,
     HighResWxSize,
-    get_footprint_by_ref,
     getVersion,
     loadBitmapScaled,
     loadIconScaled,
@@ -575,7 +574,8 @@ class JLCPCBTools(wx.Dialog):
         numbers = []
         parts = []
         for part in self.store.read_all():
-            fp = get_footprint_by_ref(pcbnew.GetBoard(), part[0])[0]
+            board = pcbnew.GetBoard()
+            fp = board.FindFootprintByReference(part[0])
             if part[3] and part[3] not in numbers:
                 numbers.append(part[3])
             part.insert(4, "")
@@ -730,7 +730,8 @@ class JLCPCBTools(wx.Dialog):
             row = self.footprint_list.ItemToRow(item)
             selected_rows.append(row)
             ref = self.footprint_list.GetTextValue(row, 0)
-            fp = get_footprint_by_ref(pcbnew.GetBoard(), ref)[0]
+            board = pcbnew.GetBoard()
+            fp = board.FindFootprintByReference(ref)
             bom = toggle_exclude_from_bom(fp)
             pos = toggle_exclude_from_pos(fp)
             self.store.set_bom(ref, bom)
@@ -749,7 +750,8 @@ class JLCPCBTools(wx.Dialog):
             row = self.footprint_list.ItemToRow(item)
             selected_rows.append(row)
             ref = self.footprint_list.GetTextValue(row, 0)
-            fp = get_footprint_by_ref(pcbnew.GetBoard(), ref)[0]
+            board = pcbnew.GetBoard()
+            fp = board.FindFootprintByReference(ref)
             bom = toggle_exclude_from_bom(fp)
             self.store.set_bom(ref, bom)
             self.footprint_list.SetValue(
@@ -763,7 +765,8 @@ class JLCPCBTools(wx.Dialog):
             row = self.footprint_list.ItemToRow(item)
             selected_rows.append(row)
             ref = self.footprint_list.GetTextValue(row, 0)
-            fp = get_footprint_by_ref(pcbnew.GetBoard(), ref)[0]
+            board = pcbnew.GetBoard()
+            fp = board.FindFootprintByReference(ref)
             pos = toggle_exclude_from_pos(fp)
             self.store.set_pos(ref, pos)
             self.footprint_list.SetValue(


### PR DESCRIPTION
I'm not sure if the get_footprint_by_ref() is necessary for older versions of kicad but that could be a good reason to keep it.

The direct calls make it easier to determine which object is being referenced.