### PR TITLE
Load rotations from database as ints

### DIFF
--- a/library.py
+++ b/library.py
@@ -248,7 +248,7 @@ class Library:
                 result = cur.execute(
                     "SELECT * FROM rotation ORDER BY regex ASC"
                 ).fetchall()
-                return [list(c) for c in result]
+                return [(c[0], int(c[1])) for c in result]
             except sqlite3.OperationalError:
                 return []
 


### PR DESCRIPTION
I was getting error messages when generating files because `Fabrication.rotate()` was trying to use rotations as numbers but they were really coming out of the database as strings. This parses the values coming from the database as integers.