### PR TITLE
rotations.py - Cleanup BoxSizer flags

### DIFF
--- a/rotations.py
+++ b/rotations.py
@@ -63,11 +63,11 @@ class RotationManagerDialog(wx.Dialog):
         )
 
         sizer_left = wx.BoxSizer(wx.VERTICAL)
-        sizer_left.Add(regex_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        sizer_left.Add(regex_label, 0, wx.ALL, 5)
         sizer_left.Add(
             self.regex,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 
@@ -86,11 +86,11 @@ class RotationManagerDialog(wx.Dialog):
         )
 
         sizer_right = wx.BoxSizer(wx.VERTICAL)
-        sizer_right.Add(correction_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        sizer_right.Add(correction_label, 0, wx.ALL, 5)
         sizer_right.Add(
             self.correction,
             0,
-            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.ALIGN_CENTER_VERTICAL,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
         )
 


### PR DESCRIPTION
Remove inactive wx.ALIGN_CENTER_VERTICAL flags on elem…ents inside of vertical BoxSizers

The flag produces an assertion error as only horizontal alignment is possible inside of vertical sizers.

Assertion output:

Traceback (most recent call last):
  File "/Users/cmorgan/Documents/KiCad/8.0/scripting/plugins/kicad-jlcpcb-tools/mainwindow.py", line 883, in manage_rotations
    RotationManagerDialog(self, "").ShowModal()
  File "/Users/cmorgan/Documents/KiCad/8.0/scripting/plugins/kicad-jlcpcb-tools/rotations.py", line 89, in __init__
    sizer_right.Add(correction_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
wx._core.wxAssertionError: C++ assertion "CheckSizerFlags(!((flags) & (wxALIGN_CENTRE_VERTICAL)))" failed at ./src/common/sizer.cpp(2273) in DoInsert(): wxALIGN_CENTRE_VERTICAL will be ignored in this sizer: only horizontal alignment flags can be used in vertical sizers