### PR TITLE
Fix missing rotations display and sorting by Stock in the main list

### DIFF
--- a/library.py
+++ b/library.py
@@ -89,10 +89,10 @@ class Library:
             "Package",
             "Solder Joint",
             "Library Type",
+            "Stock",
             "Manufacturer",
             "Description",
             "Price",
-            "Stock",
         ]
         if self.order_by == order_by[n] and self.order_dir == "ASC":
             self.order_dir = "DESC"

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -616,13 +616,13 @@ class JLCPCBTools(wx.Dialog):
             # First check if the part name mathes
             for regex, correction in corrections:
                 if re.search(regex, str(part[1])):
-                    part[8] = correction
+                    part[8] = str(correction)
                     break
             # If there was no match for the part name, check if the package matches
             if part[8] == "":
                 for regex, correction in corrections:
                     if re.search(regex, str(part[2])):
-                        part[8] = correction
+                        part[8] = str(correction)
                         break
 
             self.footprint_list.AppendItem(part)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -612,7 +612,9 @@ class JLCPCBTools(wx.Dialog):
             )
             if detail:
                 part[4] = detail[0][2]
-                part[5] = detail[0][1]
+                if part[5] != str(detail[0][1]):
+                    part[5] = str(detail[0][1])
+                    self.store.set_stock(part[0], detail[0][1])
             # First check if the part name mathes
             for regex, correction in corrections:
                 if re.search(regex, str(part[1])):


### PR DESCRIPTION
Rotation column is empty regardless of the regex. This seems to be a display bug. This pull request brings it back.