### PR TITLE
Create and use a separate table (parts_by_lcsc) to index FTS5 parts table by rowid to speed up.

### DIFF
--- a/library.py
+++ b/library.py
@@ -553,7 +553,7 @@ class Library:
             self.logger.debug("Indexing parts table...")
             wx.PostEvent(self.parent, UpdateGaugeEvent(value=0))
             with contextlib.closing(sqlite3.connect(self.partsdb_file)) as con:
-                con.execute('DROP TABLE parts_by_lcsc;')
+                con.execute('DROP TABLE IF EXISTS parts_by_lcsc;')
                 con.execute('CREATE TABLE IF NOT EXISTS parts_by_lcsc (partsId INTEGER, lcsc TEXT);')
                 con.execute('DROP INDEX IF EXISTS LCSCpartIdx;')
                 cur = con.execute('SELECT rowid, `LCSC Part` FROM parts')


### PR DESCRIPTION
The purpose of this PR is to increase the speed of any operation that involves list rebuilding, which is basically *any* operation, such as part selection, sorting, hiding/showing BOM parts, or even invoking the plugin window.

The database increase due to this is +3.3%, which I think is a reasonable trade-off until a better way is found to integrate it with FTS5 directly while maintaining the speed.

The problem is illustrated in this YouTube video (the principal part of the commit is initially commented out and then uncommented to show the difference in performance impact). 

[Youtube video with demonstrating the problem](https://www.youtube.com/watch?v=hYp7NG1VdmA)

The commit includes the following changes:

1. **Creation of a New Table (`parts_by_lcsc`)**: A new table is created in the database to hold mappings between part identifiers (`partsId`) and the `LCSC Part` numbers. This table is designed to optimise lookup times by indexing parts based on their `LCSC Part` number rather than through direct queries on the `parts` table, which seems to be slow.

2. **Modification in `get_part_details` Function**:
   - The method has been updated to first attempt fetching `partsId` values from the new `parts_by_lcsc` table using the provided `LCSC Part` numbers.
   - If the new method finds all required `partsId`, it then fetches the parts details directly using these IDs, which is much faster as it leverages the row IDs for direct access instead of scanning through text fields.
   - In case of any issues (e.g., the new table not having all the entries), it falls back to the original method of fetching data directly using the `LCSC Part` numbers from the `parts` table.

3. **Database Indexing in the `download` Method**:
   - A significant process added in the `download` method is the population of the `parts_by_lcsc` table and the removal of an old index if it exists.
   - It iterates through every row in the `parts` table, inserts or updates the mapping in the `parts_by_lcsc` table, and updates a progress indicator, which communicates the operation's progress to the user interface.
   - After filling up the new table, it creates an index on the `lcsc` column of the `parts_by_lcsc` table to speed up the lookups.
   - This indexing is expected to significantly reduce the query time by utilising a quicker, more efficient index.

4. **User Interface Updates**: The code updates a gauge control that reflects the progress of the database indexing operation. On a modern M1 MacBook Pro it finishes under 5 seconds and is significantly faster than the downloading.
