### PR TITLE
Fix missing rotation corrections display in the main view

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -616,13 +616,13 @@ class JLCPCBTools(wx.Dialog):
             # First check if the part name mathes
             for regex, correction in corrections:
                 if re.search(regex, str(part[1])):
-                    part[8] = correction
+                    part[8] = str(correction)
                     break
             # If there was no match for the part name, check if the package matches
             if part[8] == "":
                 for regex, correction in corrections:
                     if re.search(regex, str(part[2])):
-                        part[8] = correction
+                        part[8] = str(correction)
                         break
 
             self.footprint_list.AppendItem(part)


### PR DESCRIPTION
This patch corrects an issue where the rotation data was not being displayed correctly in the UI due to type recognition problems with the wx framework. Previously, certain rotation correction values were not converted to strings before adding to a wx list, leading to them being ignored by the GUI framework, showing no data and not reporting any errors.

The fix involves explicit string conversion of the rotation data in the populate_footprint_list method. Specifically, when correction rules are applied based on part names or packages, the corrected rotation values (part[8]) are now converted to strings (str(correction)) before being set. This change ensures that the wx framework recognises and displays the data correctly.

Please refer to this picture:
![image](https://github.com/Bouni/kicad-jlcpcb-tools/assets/1831537/d5ae146a-a239-417a-aafd-71d13815aba6)
