### PR TITLE
Fix inconsistency between column ordering in the GUI and the database reference.

### DIFF
--- a/library.py
+++ b/library.py
@@ -89,10 +89,10 @@ class Library:
             "Package",
             "Solder Joint",
             "Library Type",
+            "Stock",
             "Manufacturer",
             "Description",
             "Price",
-            "Stock",
         ]
         if self.order_by == order_by[n] and self.order_dir == "ASC":
             self.order_dir = "DESC"


### PR DESCRIPTION
This patch addresses an issue where the column ordering in the GUI did not match the order used in database queries. This led to improper sorting functionality within the application in the part selection dialogue. The inconsistency was observed when a header was clicked to sort by a specific field, where the list would be sorted using a wrong field.

The position of the "Stock" field in the ordering array was adjusted to precede the `Manufacturer`, `Description`, and `Price` fields in the way it is in the GUI.