### PR TITLE
Fix sorting: update cached part stock quantity if a mismatch with db is found

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -612,7 +612,9 @@ class JLCPCBTools(wx.Dialog):
             )
             if detail:
                 part[4] = detail[0][2]
-                part[5] = detail[0][1]
+                if part[5] != str(detail[0][1]):
+                    part[5] = str(detail[0][1])
+                    self.store.set_stock(part[0], detail[0][1])
             # First check if the part name mathes
             for regex, correction in corrections:
                 if re.search(regex, str(part[1])):


### PR DESCRIPTION
This patch corrects a sorting issue in the application where the GUI displayed the correct stock quantities but used outdated cached values for sorting operations.

The fix targets the populate_footprint_list method and involves a condition that checks if the cached stock value (part[5]) in the GUI matches the most recent stock quantity from the database (detail[0][1]). If a mismatch is detected, the cached value is updated to the current database value, and also `set_stock` is called, which updates the current board database with the new stock values.