### PR TITLE
Frightrisk fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This plugin makes use of a lot of icons from the excellent [Material Design Icon
 ## Development
 
 1. Fork repo
-2. Fit clone forked repo
+2. Git clone forked repo
 3. Install pre-commit `pip install pre-commit`
 4. Setup pre-commit `pre-commit run`
 5. Create feature branch `git switch -c my-awesome-feature`

--- a/library.py
+++ b/library.py
@@ -406,7 +406,7 @@ class Library:
                 "Parts db is split into %s parts. Proceeding to download...", r.text
             )
             cnt = int(r.text)
-            self.logger.debug("Removing any spurios old zip part files...")
+            self.logger.debug("Removing any spurious old zip part files...")
             for p in glob(str(Path(self.datadir) / (chunk_file_stub + "*"))):
                 self.logger.debug("Removing %s.", p)
                 os.unlink(p)


### PR DESCRIPTION
Fixed instructions in the readme that said to "Fit clone" a repo to "Git clone" and fixed the spelling of "spurious" in the library.py file.