### PR TITLE
Do not fail creating BOM if part is not found in database

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -261,6 +261,7 @@ class Fabrication:
             for fp in footprints:
                 part = self.parent.store.get_part(fp.GetReference())
                 if not part: # No matching part in the database, continue
+                    self.logger.debug("No matching database entry found for %s", fp.GetReference())
                     continue
                 if part[6] == 1: # Exclude from POS
                     continue

--- a/fabrication.py
+++ b/fabrication.py
@@ -261,7 +261,6 @@ class Fabrication:
             for fp in footprints:
                 part = self.parent.store.get_part(fp.GetReference())
                 if not part: # No matching part in the database, continue
-                    self.logger.debug("No matching database entry found for %s", fp.GetReference())
                     continue
                 if part[6] == 1: # Exclude from POS
                     continue

--- a/fabrication.py
+++ b/fabrication.py
@@ -260,6 +260,8 @@ class Fabrication:
             footprints = sorted(self.board.Footprints(), key = lambda x: x.GetReference())
             for fp in footprints:
                 part = self.parent.store.get_part(fp.GetReference())
+                if not part: # No matching part in the database, continue
+                    continue
                 if part[6] == 1: # Exclude from POS
                     continue
                 if not add_without_lcsc and not part[3]:


### PR DESCRIPTION
This is an attempt to fix #484 

I cannot reporduce this issue but I think that a part is not found in the database which results in a None returned and that leads to a failed BOM creation 