### PR TITLE
Use dict_factory in store for better readability

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -322,7 +322,6 @@ class Fabrication:
                             )
                 if not add_without_lcsc and not part["lcsc"]:
                     continue
-                self.logger.debug(part)
                 writer.writerow(
                     [
                         part["value"],

--- a/fabrication.py
+++ b/fabrication.py
@@ -310,19 +310,27 @@ class Fabrication:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(["Comment", "Designator", "Footprint", "LCSC"])
             for part in self.parent.store.read_bom_parts():
-                components = part[1].split(",")
+                components = part["refs"].split(",")
                 for component in components:
                     for fp in self.board.Footprints():
                         if fp.GetReference() == component and fp.IsDNP():
                             components.remove(component)
-                            part[1] = ",".join(components)
+                            part["refs"] = ",".join(components)
                             self.logger.info(
                                 "Component %s has 'Do not placed' enabled: removing from BOM",
                                 component,
                             )
-                if not add_without_lcsc and not part[3]:
+                if not add_without_lcsc and not part["lcsc"]:
                     continue
-                writer.writerow(part)
+                self.logger.debug(part)
+                writer.writerow(
+                    [
+                        part["value"],
+                        part["refs"],
+                        part["footprint"],
+                        part["lcsc"]
+                    ]
+                )
         self.logger.info(
             "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)
         )

--- a/fabrication.py
+++ b/fabrication.py
@@ -273,9 +273,9 @@ class Fabrication:
                 part = self.parent.store.get_part(fp.GetReference())
                 if not part:  # No matching part in the database, continue
                     continue
-                if part[6] == 1:  # Exclude from POS
+                if part["exclude_from_pos"] == 1:
                     continue
-                if not add_without_lcsc and not part[3]:
+                if not add_without_lcsc and not part["lcsc"]:
                     continue
                 try:  # Kicad <= 8.0
                     position = self.get_position(fp) - aux_orgin
@@ -285,9 +285,9 @@ class Fabrication:
                     position = VECTOR2I(x1 - x2, y1 - y2)
                 writer.writerow(
                     [
-                        part[0],
-                        part[1],
-                        part[2],
+                        part["reference"],
+                        part["value"],
+                        part["footprint"],
                         ToMM(position.x),
                         ToMM(position.y) * -1,
                         self.fix_rotation(fp),

--- a/helpers.py
+++ b/helpers.py
@@ -128,6 +128,14 @@ def natural_sort_collation(a, b):
     return -1 if natorder.index(a) == 0 else 1
 
 
+def dict_factory(cursor, row) -> dict:
+    """Row factory that returns a dict."""
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+
 def get_lcsc_value(fp):
     """Get the first lcsc number (C123456 for example) from the properties of the footprint."""
     # KiCad 7.99

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -780,7 +780,7 @@ class JLCPCBTools(wx.Dialog):
             bom = toggle_exclude_from_bom(fp)
             pos = toggle_exclude_from_pos(fp)
             self.store.set_bom(ref, int(bom))
-            self.store.set_pos(ref, pos)
+            self.store.set_pos(ref, int(pos))
             self.footprint_list.SetValue(
                 GetListIcon(bom, self.scale_factor), row, Column.BOM
             )
@@ -813,7 +813,7 @@ class JLCPCBTools(wx.Dialog):
             board = self.pcbnew.GetBoard()
             fp = board.FindFootprintByReference(ref)
             pos = toggle_exclude_from_pos(fp)
-            self.store.set_pos(ref, pos)
+            self.store.set_pos(ref, int(pos))
             self.footprint_list.SetValue(
                 GetListIcon(pos, self.scale_factor), row, Column.POS
             )

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -554,7 +554,7 @@ class JLCPCBTools(wx.Dialog):
         """Assign a selected LCSC number to parts."""
         for reference in e.references:
             self.store.set_lcsc(reference, e.lcsc)
-            self.store.set_stock(reference, e.stock)
+            self.store.set_stock(reference, int(e.stock))
         self.populate_footprint_list()
 
     def display_message(self, e):

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -779,7 +779,7 @@ class JLCPCBTools(wx.Dialog):
             fp = board.FindFootprintByReference(ref)
             bom = toggle_exclude_from_bom(fp)
             pos = toggle_exclude_from_pos(fp)
-            self.store.set_bom(ref, bom)
+            self.store.set_bom(ref, int(bom))
             self.store.set_pos(ref, pos)
             self.footprint_list.SetValue(
                 GetListIcon(bom, self.scale_factor), row, Column.BOM
@@ -798,7 +798,7 @@ class JLCPCBTools(wx.Dialog):
             board = self.pcbnew.GetBoard()
             fp = board.FindFootprintByReference(ref)
             bom = toggle_exclude_from_bom(fp)
-            self.store.set_bom(ref, bom)
+            self.store.set_bom(ref, int(bom))
             self.footprint_list.SetValue(
                 GetListIcon(bom, self.scale_factor), row, Column.BOM
             )

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -842,7 +842,7 @@ class JLCPCBTools(wx.Dialog):
         for r in range(self.footprint_list.GetItemCount()):
             value = self.footprint_list.GetValue(r, 1)
             fp = self.footprint_list.GetValue(r, 2)
-            if part[1] == value and part[2] == fp:
+            if part["value"] == value and part["footprint"] == fp:
                 self.footprint_list.SelectRow(r)
 
     def get_part_details(self, *_):

--- a/store.py
+++ b/store.py
@@ -178,13 +178,6 @@ class Store:
                     "Part %s does not exist in the database and will be created from the board.",
                     board_part["reference"],
                 )
-<<<<<<< HEAD
-                self.create_part(part)
-            elif (
-                part[0:3] == list(dbpart[0:3])
-                and part[4:] == [bool(x) for x in dbpart[5:]]
-            ):  # if the board part matches the dbpart except for the LCSC and the stock value,
-=======
                 self.create_part(board_part)
             # if the board part matches the db_part except for the LCSC and the stock value
             elif [
@@ -200,7 +193,6 @@ class Store:
                 bool(db_part["exclude_from_bom"]),
                 bool(db_part["exclude_from_pos"]),
             ]:
->>>>>>> 2621281 (Improve get_part to use dict_factory for better readability)
                 # if part in the database, has no lcsc value the board part has a lcsc value, update including lcsc
                 if db_part and not db_part["lcsc"] and board_part["lcsc"]:
                     self.logger.debug(

--- a/store.py
+++ b/store.py
@@ -129,7 +129,7 @@ class Store:
         """Change the BOM attribute for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
-                f"UPDATE part_info SET exclude_from_bom = '{int(state)}' WHERE reference = '{ref}'"
+                "UPDATE part_info SET exclude_from_bom = :state WHERE reference = :reference", {"reference": ref, "state": state}
             )
             cur.commit()
 

--- a/store.py
+++ b/store.py
@@ -119,7 +119,6 @@ class Store:
     def set_stock(self, ref: str, stock: int):
         """Set the stock value for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
-            self.logger.debug(ref)
             cur.execute(
                 "UPDATE part_info SET stock = :stock WHERE reference = :reference", {"reference": ref, "stock": stock}
             )

--- a/store.py
+++ b/store.py
@@ -41,7 +41,7 @@ class Store:
             Path(self.datadir).mkdir(parents=True, exist_ok=True)
         self.create_db()
 
-    def set_order_by(self, n):
+    def set_order_by(self, n: int):
         """Set which value we want to order by when getting data from the database."""
         if n > 7:
             return
@@ -118,7 +118,7 @@ class Store:
             cur.execute("INSERT INTO part_info VALUES (:reference, :value, :footprint, :lcsc, '', :exclude_from_bom, :exclude_from_pos)", part)
             cur.commit()
 
-    def update_part(self, part):
+    def update_part(self, part: dict):
         """Update a part in the database, overwrite lcsc if supplied."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
@@ -135,13 +135,13 @@ class Store:
                 "SELECT * FROM part_info WHERE reference=?", (ref,)
             ).fetchone()
 
-    def delete_part(self, ref):
+    def delete_part(self, ref: str):
         """Delete a part from the database by its reference."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute("DELETE FROM part_info WHERE reference=?", (ref,))
             cur.commit()
 
-    def set_stock(self, ref, stock):
+    def set_stock(self, ref: str, stock: int):
         """Set the stock value for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
@@ -149,7 +149,7 @@ class Store:
             )
             cur.commit()
 
-    def set_bom(self, ref, state):
+    def set_bom(self, ref: str, state: int):
         """Change the BOM attribute for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
@@ -157,7 +157,7 @@ class Store:
             )
             cur.commit()
 
-    def set_pos(self, ref, state):
+    def set_pos(self, ref: str, state: int):
         """Change the BOM attribute for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
@@ -165,7 +165,7 @@ class Store:
             )
             cur.commit()
 
-    def set_lcsc(self, ref, value):
+    def set_lcsc(self, ref: str, value: str):
         """Change the BOM attribute for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(

--- a/store.py
+++ b/store.py
@@ -112,10 +112,10 @@ class Store:
                 query = "SELECT reference, value, footprint, lcsc FROM part_info WHERE exclude_from_pos = '0' ORDER BY reference COLLATE naturalsort ASC"
                 return [list(part) for part in cur.execute(query).fetchall()]
 
-    def create_part(self, part):
+    def create_part(self, part: dict):
         """Create a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
-            cur.execute("INSERT INTO part_info VALUES (?,?,?,?,'',?,?)", part)
+            cur.execute("INSERT INTO part_info VALUES (:reference, :value, :footprint, :lcsc, '', :exclude_from_bom, :exclude_from_pos)", part)
             cur.commit()
 
     def update_part(self, part):

--- a/store.py
+++ b/store.py
@@ -123,15 +123,8 @@ class Store:
         """Update a part in the database, overwrite lcsc if supplied."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
-                "UPDATE part_info set value = ?, footprint = ?, lcsc = ?, exclude_from_bom = ?, exclude_from_pos = ? WHERE reference = ?",
-                (
-                    part["value"],
-                    part["footprint"],
-                    part["lcsc"],
-                    part["exclude_from_bom"],
-                    part["exclude_from_pos"],
-                    part["reference"],
-                ),
+                "UPDATE part_info set value = :value, footprint = :footprint, lcsc = :lcsc, exclude_from_bom = :exclude_from_bom, exclude_from_pos = :exclude_from_pos WHERE reference = :reference",
+                part,
             )
             cur.commit()
 

--- a/store.py
+++ b/store.py
@@ -115,11 +115,6 @@ class Store:
                 "SELECT * FROM part_info WHERE reference=?", (ref,)
             ).fetchone()
 
-    def delete_part(self, ref: str):
-        """Delete a part from the database by its reference."""
-        with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
-            cur.execute("DELETE FROM part_info WHERE reference=?", (ref,))
-            cur.commit()
 
     def set_stock(self, ref: str, stock: int):
         """Set the stock value for a part in the database."""

--- a/store.py
+++ b/store.py
@@ -112,7 +112,7 @@ class Store:
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             con.row_factory = dict_factory
             return cur.execute(
-                "SELECT * FROM part_info WHERE reference=?", (ref,)
+                "SELECT * FROM part_info WHERE reference = :reference", {"reference": ref}
             ).fetchone()
 
 

--- a/store.py
+++ b/store.py
@@ -212,14 +212,12 @@ class Store:
                 board_part["reference"],
                 board_part["value"],
                 board_part["footprint"],
+                board_part["exclude_from_bom"],
+                board_part["exclude_from_pos"],
             ] == [
                 db_part["reference"],
                 db_part["value"],
                 db_part["footprint"],
-            ] and [
-                board_part["exclude_from_bom"],
-                board_part["exclude_from_pos"],
-            ] == [
                 bool(db_part["exclude_from_bom"]),
                 bool(db_part["exclude_from_pos"]),
             ]:

--- a/store.py
+++ b/store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sqlite3
 
 from .helpers import (
+    dict_factory,
     get_exclude_from_bom,
     get_exclude_from_pos,
     get_lcsc_value,
@@ -85,13 +86,11 @@ class Store:
         """Read all parts from the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con:
             con.create_collation("naturalsort", natural_sort_collation)
+            con.row_factory = dict_factory
             with con as cur:
-                return [
-                    list(part)
-                    for part in cur.execute(
-                        f"SELECT * FROM part_info ORDER BY {self.order_by} COLLATE naturalsort {self.order_dir}"
-                    ).fetchall()
-                ]
+                return cur.execute(
+                    f"SELECT * FROM part_info ORDER BY {self.order_by} COLLATE naturalsort {self.order_dir}"
+                ).fetchall()
 
     def read_bom_parts(self):
         """Read all parts that should be included in the BOM."""

--- a/store.py
+++ b/store.py
@@ -122,17 +122,17 @@ class Store:
     def update_part(self, part):
         """Update a part in the database, overwrite lcsc if supplied."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
-            if len(part) == 6:
-                cur.execute(
-                    "UPDATE part_info set value = ?, footprint = ?, lcsc = ?, exclude_from_bom = ?, exclude_from_pos = ? WHERE reference = ?",
-                    part[1:] + part[0:1],
-                )
-            else:
-                cur.execute(
-                    "UPDATE part_info set value = ?, footprint = ?, exclude_from_bom = ?, exclude_from_pos = ? WHERE reference = ?",
-                    part[1:] + part[0:1],
-                )
-
+            cur.execute(
+                "UPDATE part_info set value = ?, footprint = ?, lcsc = ?, exclude_from_bom = ?, exclude_from_pos = ? WHERE reference = ?",
+                (
+                    part["value"],
+                    part["footprint"],
+                    part["lcsc"],
+                    part["exclude_from_bom"],
+                    part["exclude_from_pos"],
+                    part["reference"],
+                ),
+            )
             cur.commit()
 
     def get_part(self, ref: str) -> dict:

--- a/store.py
+++ b/store.py
@@ -91,26 +91,6 @@ class Store:
                 f"SELECT * FROM part_info ORDER BY {self.order_by} COLLATE naturalsort {self.order_dir}"
             ).fetchall()
 
-    def read_bom_parts(self):
-        """Read all parts that should be included in the BOM."""
-        with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
-            # Query all parts that are supposed to be in the BOM an have an lcsc number, group the references together
-            subquery = "SELECT value, reference, footprint, lcsc FROM part_info WHERE exclude_from_bom = '0' AND lcsc != '' ORDER BY lcsc, reference"
-            query = f"SELECT value, GROUP_CONCAT(reference) AS refs, footprint, lcsc  FROM ({subquery}) GROUP BY lcsc"
-            a = [list(part) for part in cur.execute(query).fetchall()]
-            # Query all parts that are supposed to be in the BOM but have no lcsc number
-            query = "SELECT value, reference, footprint, lcsc FROM part_info WHERE exclude_from_bom = '0' AND lcsc = ''"
-            b = [list(part) for part in cur.execute(query).fetchall()]
-            return a + b
-
-    def read_pos_parts(self):
-        """Read all parts that should be included in the POS."""
-        with contextlib.closing(sqlite3.connect(self.dbfile)) as con:
-            con.create_collation("naturalsort", natural_sort_collation)
-            with con as cur:
-                # Query all parts that are supposed to be in the POS
-                query = "SELECT reference, value, footprint, lcsc FROM part_info WHERE exclude_from_pos = '0' ORDER BY reference COLLATE naturalsort ASC"
-                return [list(part) for part in cur.execute(query).fetchall()]
 
     def create_part(self, part: dict):
         """Create a part in the database."""

--- a/store.py
+++ b/store.py
@@ -119,8 +119,9 @@ class Store:
     def set_stock(self, ref: str, stock: int):
         """Set the stock value for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
+            self.logger.debug(ref)
             cur.execute(
-                f"UPDATE part_info SET stock = '{int(stock)}' WHERE reference = '{ref}'"
+                "UPDATE part_info SET stock = :stock WHERE reference = :reference", {"reference": ref, "stock": stock}
             )
             cur.commit()
 

--- a/store.py
+++ b/store.py
@@ -137,7 +137,7 @@ class Store:
         """Change the BOM attribute for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
-                f"UPDATE part_info SET exclude_from_pos = '{int(state)}' WHERE reference = '{ref}'"
+                "UPDATE part_info SET exclude_from_pos = :state WHERE reference = :reference", {"reference": ref, "state": state}
             )
             cur.commit()
 
@@ -243,8 +243,8 @@ class Store:
                 )
                 for row in csvreader:
                     self.set_lcsc(row["reference"], row["lcsc"])
-                    self.set_bom(row["reference"], row["bom"])
-                    self.set_pos(row["reference"], row["pos"])
+                    self.set_bom(row["reference"], int(row["bom"]))
+                    self.set_pos(row["reference"], int(row["pos"]))
                     self.logger.debug(
                         "Update %s from legacy 'part_assignments.csv'", row["reference"]
                     )

--- a/store.py
+++ b/store.py
@@ -141,11 +141,11 @@ class Store:
             )
             cur.commit()
 
-    def set_lcsc(self, ref: str, value: str):
+    def set_lcsc(self, ref: str, lcsc: str):
         """Change the BOM attribute for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
-                f"UPDATE part_info SET lcsc = '{value}' WHERE reference = '{ref}'"
+                "UPDATE part_info SET lcsc = :lcsc WHERE reference = :reference", {"reference": ref, "lcsc": lcsc}
             )
             cur.commit()
 

--- a/store.py
+++ b/store.py
@@ -82,15 +82,14 @@ class Store:
             )
             cur.commit()
 
-    def read_all(self):
+    def read_all(self) -> dict:
         """Read all parts from the database."""
-        with contextlib.closing(sqlite3.connect(self.dbfile)) as con:
+        with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             con.create_collation("naturalsort", natural_sort_collation)
             con.row_factory = dict_factory
-            with con as cur:
-                return cur.execute(
-                    f"SELECT * FROM part_info ORDER BY {self.order_by} COLLATE naturalsort {self.order_dir}"
-                ).fetchall()
+            return cur.execute(
+                f"SELECT * FROM part_info ORDER BY {self.order_by} COLLATE naturalsort {self.order_dir}"
+            ).fetchall()
 
     def read_bom_parts(self):
         """Read all parts that should be included in the BOM."""


### PR DESCRIPTION
I always struggled with al those index numbers scatterd all around the code base and for a long time wanted to improve that.

So I started with the store and introduced a [row_factory](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.row_factory) that returns a dict instead of a list which improves readability throughout the code base a lot.

For example

`if self.hide_bom_parts and part[6]:`

becomes

`if self.hide_bom_parts and part["exclude_from_bom"]:`