### PR TITLE
WIP: Show the price for the number of selected parts

### DIFF
--- a/partselector.py
+++ b/partselector.py
@@ -643,7 +643,7 @@ class PartSelectorDialog(wx.Dialog):
         self.search(None)
 
     def get_price(self, quantity, prices):
-        """Find the prce for the number of selected parts accordning to the price ranges."""
+        """Find the price for the number of selected parts accordning to the price ranges."""
         price_ranges = prices.split(",")
         min_quantity = int(price_ranges[0].split("-")[0])
         if quantity <= min_quantity:

--- a/partselector.py
+++ b/partselector.py
@@ -656,7 +656,6 @@ class PartSelectorDialog(wx.Dialog):
                 return float(price)
             lower = int(lower)
             upper = int(upper)
-            self.logger.debug(upper)
             if lower <= quantity < upper:
                 return float(price)
 

--- a/partselector.py
+++ b/partselector.py
@@ -679,20 +679,8 @@ class PartSelectorDialog(wx.Dialog):
             self.result_count.SetLabel(f"{count} Results in {search_duration_text}")
         for p in parts:
             item = [str(c) for c in p]
-            # Munge price to be more readable
             pricecol = 8 # Must match order in library.py search function
             item[pricecol] = f"{len(self.parts)} parts: {self.get_price(len(self.parts), item[pricecol])} each"
-            # try:
-            #     for t in item[pricecol].split(","):
-            #         qty, p = t.split(":")
-            #         p = float(p)
-            #         if p < 1.0:
-            #             price.append(f"{qty}: {p * 100:.2f}c")
-            #         else:
-            #             price.append(f"{qty}: ${p:.2f}")
-            #     item[pricecol] = ", ".join(price)
-            # except ValueError:
-            #     self.logger.warning("unable to parse price %s", item[pricecol])
             self.part_list.AppendItem(item)
 
     def select_part(self, *_):

--- a/partselector.py
+++ b/partselector.py
@@ -642,23 +642,23 @@ class PartSelectorDialog(wx.Dialog):
         # search now that categories might have changed
         self.search(None)
 
-    def get_price(self, quantity, prices):
+    def get_price(self, quantity, prices) -> float:
         """Find the price for the number of selected parts accordning to the price ranges."""
         price_ranges = prices.split(",")
         min_quantity = int(price_ranges[0].split("-")[0])
         if quantity <= min_quantity:
             range, price = price_ranges[0].split(":")
-            return price
+            return float(price)
         for p in price_ranges:
             range, price = p.split(":")
             lower,upper = range.split("-")
             if not upper: # upper bound of price ranges
-                return price
+                return float(price)
             lower = int(lower)
             upper = int(upper)
             self.logger.debug(upper)
             if lower <= quantity < upper:
-                return price
+                return float(price)
 
     def populate_part_list(self, parts, search_duration):
         """Populate the list with the result of the search."""
@@ -680,7 +680,8 @@ class PartSelectorDialog(wx.Dialog):
         for p in parts:
             item = [str(c) for c in p]
             pricecol = 8 # Must match order in library.py search function
-            item[pricecol] = f"{len(self.parts)} parts: {self.get_price(len(self.parts), item[pricecol])} each"
+            price = round(self.get_price(len(self.parts), item[pricecol]) , 3)
+            item[pricecol] = f"{len(self.parts)} parts: ${price} each"
             self.part_list.AppendItem(item)
 
     def select_part(self, *_):

--- a/partselector.py
+++ b/partselector.py
@@ -642,6 +642,24 @@ class PartSelectorDialog(wx.Dialog):
         # search now that categories might have changed
         self.search(None)
 
+    def get_price(self, quantity, prices):
+        """Find the prce for the number of selected parts accordning to the price ranges."""
+        price_ranges = prices.split(",")
+        min_quantity = int(price_ranges[0].split("-")[0])
+        if quantity <= min_quantity:
+            range, price = price_ranges[0].split(":")
+            return price
+        for p in price_ranges:
+            range, price = p.split(":")
+            lower,upper = range.split("-")
+            if not upper: # upper bound of price ranges
+                return price
+            lower = int(lower)
+            upper = int(upper)
+            self.logger.debug(upper)
+            if lower <= quantity < upper:
+                return price
+
     def populate_part_list(self, parts, search_duration):
         """Populate the list with the result of the search."""
         search_duration_text = (
@@ -662,19 +680,19 @@ class PartSelectorDialog(wx.Dialog):
         for p in parts:
             item = [str(c) for c in p]
             # Munge price to be more readable
-            pricecol = 8  # Must match order in library.py search function
-            price = []
-            try:
-                for t in item[pricecol].split(","):
-                    qty, p = t.split(":")
-                    p = float(p)
-                    if p < 1.0:
-                        price.append(f"{qty}: {p * 100:.2f}c")
-                    else:
-                        price.append(f"{qty}: ${p:.2f}")
-                item[pricecol] = ", ".join(price)
-            except ValueError:
-                self.logger.warning("unable to parse price %s", item[pricecol])
+            pricecol = 8 # Must match order in library.py search function
+            item[pricecol] = f"{len(self.parts)} parts: {self.get_price(len(self.parts), item[pricecol])} each"
+            # try:
+            #     for t in item[pricecol].split(","):
+            #         qty, p = t.split(":")
+            #         p = float(p)
+            #         if p < 1.0:
+            #             price.append(f"{qty}: {p * 100:.2f}c")
+            #         else:
+            #             price.append(f"{qty}: ${p:.2f}")
+            #     item[pricecol] = ", ".join(price)
+            # except ValueError:
+            #     self.logger.warning("unable to parse price %s", item[pricecol])
             self.part_list.AppendItem(item)
 
     def select_part(self, *_):

--- a/partselector.py
+++ b/partselector.py
@@ -680,7 +680,8 @@ class PartSelectorDialog(wx.Dialog):
             item = [str(c) for c in p]
             pricecol = 8 # Must match order in library.py search function
             price = round(self.get_price(len(self.parts), item[pricecol]) , 3)
-            item[pricecol] = f"{len(self.parts)} parts: ${price} each"
+            sum = round(price * len(self.parts), 3)
+            item[pricecol] = f"{len(self.parts)} parts: ${price} each / ${sum} total"
             self.part_list.AppendItem(item)
 
     def select_part(self, *_):


### PR DESCRIPTION
This is an attempt to make the messy price column more useful.

We now go through the price ranges and check for the number of selected parts (doable via the alike button fr example) in whch price range we are. Then return that as the price:

![grafik](https://github.com/Bouni/kicad-jlcpcb-tools/assets/948965/1e0bd56e-f670-40a1-9edd-f7225957eca2)
