### PR TITLE
Fix broken update process

### DIFF
--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -10,25 +10,24 @@ jobs:
     runs-on: ubuntu-22.04
     environment: github-pages
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3 python3-pip wget zip unzip p7zip-full sqlite3
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            python3 python3-pip wget zip unzip p7zip-full sqlite3
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Show versions
         run: |
           sqlite3 --version
           python3 --version
           python3 -c "import sqlite3; import pprint; db = sqlite3.connect(':memory:'); cursor = db.execute('PRAGMA COMPILE_OPTIONS'); pprint.pprint(cursor.fetchall())"
-
       - name: Install python dependencies
         run: |
           pip install humanize


### PR DESCRIPTION
This fixes the broken update process due to [running out of disk space](https://github.com/Bouni/kicad-jlcpcb-tools/actions/runs/9902662267):

- install the requirements first
- then [maximize disk space](https://github.com/easimon/maximize-build-space?tab=readme-ov-file#usage) (remove optionally installed, and unused things - e.g. mono, merge tmp space)
- checkout as normal

In my fork this [passed as far as I have credentials](https://github.com/ukd1/kicad-jlcpcb-tools/actions/runs/9911850526/job/27385394133)...but I can't completely test. 

Note:
- there are [more things that can be dropped](https://github.com/easimon/maximize-build-space?tab=readme-ov-file#inputs), but this seems like enough
- this is somewhat temporary, if the disk usage goes over again