### PR TITLE
Refactor populate_footprints and get_part_details

### DIFF
--- a/library.py
+++ b/library.py
@@ -381,7 +381,7 @@ class Library:
             con.executemany(query, data)
             con.commit()
 
-    def get_part_details(self, lcsc: list) -> dict:
+    def get_part_details(self, lcsc: list) -> list:
         """Get the part details for a list of LCSC numbers using optimized FTS5 querying."""
         with contextlib.closing(sqlite3.connect(self.partsdb_file)) as con:
             con.row_factory = dict_factory
@@ -390,11 +390,10 @@ class Library:
             query = '''SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number LIMIT 1'''
             # Use parameter binding to prevent SQL injection and handle the query more efficiently
             for number in lcsc:
-                cur.execute(query, {"number": number})
-                results.extend([x for x in cur.fetchall() if x[0] == number]) # Filter exact match as FTS5 does return every match
-            if results:
-                return results[0]
-            return {}
+                self.logger.debug(number)
+                cur.execute(query, {"number": f'"{number}"'})
+                results.extend([x for x in cur.fetchall() if x["lcsc"] == number]) # Filter exact match as FTS5 does return every match
+            return results
 
     def update(self):
         """Update the sqlite parts database from the JLCPCB CSV."""

--- a/library.py
+++ b/library.py
@@ -391,7 +391,7 @@ class Library:
             # Use parameter binding to prevent SQL injection and handle the query more efficiently
             for number in lcsc:
                 cur.execute(query, {"number": number})
-                results.extend(cur.fetchall())
+                results.extend([x for x in cur.fetchall() if x[0] == number]) # Filter exact match as FTS5 does return every match
             if results:
                 return results[0]
             return {}

--- a/library.py
+++ b/library.py
@@ -387,11 +387,11 @@ class Library:
             con.row_factory = dict_factory
             cur = con.cursor()
             results = []
-            query = '''SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number LIMIT 1'''
+            query = """SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number"""
             # Use parameter binding to prevent SQL injection and handle the query more efficiently
             for number in lcsc:
-                cur.execute(query, {"number": f'"{number}"'})
-                results.extend(cur.fetchall())
+                cur.execute(query, {"number": number})
+                results.extend([n for n in cur.fetchall() if n["lcsc"] == number])
             return results
 
     def update(self):

--- a/library.py
+++ b/library.py
@@ -392,7 +392,7 @@ class Library:
             for number in lcsc:
                 self.logger.debug(number)
                 cur.execute(query, {"number": f'"{number}"'})
-                results.extend([x for x in cur.fetchall() if x["lcsc"] == number]) # Filter exact match as FTS5 does return every match
+                results.extend(cur.fetchall())
             return results
 
     def update(self):

--- a/library.py
+++ b/library.py
@@ -387,13 +387,10 @@ class Library:
             con.row_factory = dict_factory
             cur = con.cursor()
             results = []
-            query = '''SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH ?'''
-
+            query = '''SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number LIMIT 1'''
             # Use parameter binding to prevent SQL injection and handle the query more efficiently
             for number in lcsc:
-                # Each number needs to be wrapped in double quotes for exact match in FTS5
-                match_query = f'"LCSC Part:{number}"'
-                cur.execute(query, (match_query,))
+                cur.execute(query, {"number": number})
                 results.extend(cur.fetchall())
             if results:
                 return results[0]

--- a/library.py
+++ b/library.py
@@ -381,18 +381,14 @@ class Library:
             con.executemany(query, data)
             con.commit()
 
-    def get_part_details(self, lcsc: list) -> list:
-        """Get the part details for a list of LCSC numbers using optimized FTS5 querying."""
+    def get_part_details(self, number: str) -> dict:
+        """Get the part details for a LCSC number using optimized FTS5 querying."""
         with contextlib.closing(sqlite3.connect(self.partsdb_file)) as con:
             con.row_factory = dict_factory
             cur = con.cursor()
-            results = []
             query = """SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number"""
-            # Use parameter binding to prevent SQL injection and handle the query more efficiently
-            for number in lcsc:
-                cur.execute(query, {"number": number})
-                results.extend([n for n in cur.fetchall() if n["lcsc"] == number])
-            return results
+            cur.execute(query, {"number": number})
+            return next((n for n in cur.fetchall() if n["lcsc"] == number), {})
 
     def update(self):
         """Update the sqlite parts database from the JLCPCB CSV."""

--- a/library.py
+++ b/library.py
@@ -390,7 +390,6 @@ class Library:
             query = '''SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number LIMIT 1'''
             # Use parameter binding to prevent SQL injection and handle the query more efficiently
             for number in lcsc:
-                self.logger.debug(number)
                 cur.execute(query, {"number": f'"{number}"'})
                 results.extend(cur.fetchall())
             return results

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -612,9 +612,15 @@ class JLCPCBTools(wx.Dialog):
         corrections = self.library.get_all_correction_data()
         # find rotation correction values
         for part in parts:
-            if details:
-                part["type"] = details["type"]
-                part["stock"] = details["stock"]
+            detail = list(
+                filter(
+                    lambda x, lcsc=part["lcsc"]: x["lcsc"] == lcsc,
+                    details,
+                )
+            )
+            if detail:
+                part["type"] = detail[0]["type"]
+                part["stock"] = detail[0]["stock"]
             # First check if the part name mathes
             for regex, correction in corrections:
                 if re.search(regex, str(part["reference"])):


### PR DESCRIPTION
PR #503 made the plugin way faster but introduced a problem so that no more part details are returned.

The main issue is (as far as may SQLite knowledge goes) that the named parameter was used in a wrong way.

The for loop gernerates a query like this for example, which does not yield any results:

`'''SELECT "LCSC Part", "Stock", "Library Type" FROM parts WHERE parts MATCH "LCSC Part:C2286"'''` 

Fixing that we end up with:

`'''SELECT "LCSC Part", "Stock", "Library Type" FROM parts WHERE parts MATCH C2286'''`

But that return every LCSC number that includes the searched number.

So limit the reults to 1 like this:

`'''SELECT "LCSC Part", "Stock", "Library Type" FROM parts WHERE parts MATCH C2286 LIMIT 1'''`

Gives us just the first match, which should give us the search LCSC number only.

I'm not 100% sure about the `LIMIT 1` but it seems to work.

@chmorgan Do you know FTS5 good enough that you can verify if theres another way than double quotes do not yield a exact match? (double quotes do not work)