### PR TITLE
Update pre-commit-config and linter action

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,11 +22,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Check code with ruff
+        uses: chartboost/ruff-action@v1
         with:
-          python-version: "3.11"
-      - name: Install ruff
-        run: pip install ruff
-      - name: Run ruff
-        run: ruff check $(git ls-files '*.py')
+          version: 0.5.6
+          args: check 
+          src: "."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 ---
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.5.6
     hooks:
       - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: [--py310-plus]
-        stages: [manual]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.35.0
+    rev: v0.41.0
     hooks:
       - id: markdownlint
         args:


### PR DESCRIPTION
### Linter action

- use ruff action instead of installing manually
- set ruff version to be consistent with pre-commit-config

### pre-commit-config

- update versions
- let ruff fix fixable issues
- add ruff format
- let pyupgrade do its magic