### PR TITLE
Fixes #528 Feature/component count

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -322,9 +322,8 @@ class Fabrication:
                             )
                 if not add_without_lcsc and not part["lcsc"]:
                     continue
-                component_count = len(components)   # Get the updated size of the component list 
                 writer.writerow(
-                    [part["value"], part["refs"], part["footprint"], part["lcsc"], component_count]
+                    [part["value"], part["refs"], part["footprint"], part["lcsc"], len(components)]
                 )
         self.logger.info(
             "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)

--- a/fabrication.py
+++ b/fabrication.py
@@ -308,7 +308,7 @@ class Fabrication:
             os.path.join(self.outputdir, bomname), "w", newline="", encoding="utf-8"
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
-            writer.writerow(["Comment", "Designator", "Footprint", "LCSC"])
+            writer.writerow(["Comment", "Designator", "Footprint", "LCSC", "Quantity"])
             for part in self.parent.store.read_bom_parts():
                 components = part["refs"].split(",")
                 for component in components:
@@ -322,8 +322,9 @@ class Fabrication:
                             )
                 if not add_without_lcsc and not part["lcsc"]:
                     continue
+                component_count = len(components)   # Get the updated size of the component list 
                 writer.writerow(
-                    [part["value"], part["refs"], part["footprint"], part["lcsc"]]
+                    [part["value"], part["refs"], part["footprint"], part["lcsc"], component_count]
                 )
         self.logger.info(
             "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)


### PR DESCRIPTION
Added quantity column to the BOM CSV output for each component. This lets us choose Quantity as one of the row headers in LCSCs BOM tool. The LCSC BOM tool now can allocate the correct quantity of parts for each part number