### PR TITLE
Probable fix for #535 - use union instead of | operator for python 3.9 compatibility

### DIFF
--- a/lcsc_api.py
+++ b/lcsc_api.py
@@ -1,6 +1,7 @@
 """Unofficial LCSC API."""
 
 import io
+from typing import Union
 from pathlib import Path
 
 import requests  # pylint: disable=import-error
@@ -31,7 +32,7 @@ class LCSC_API:
             }
         return {"success": True, "data": data}
 
-    def download_bitmap(self, url: str) -> io.BytesIO | None:
+    def download_bitmap(self, url: str) -> Union[io.BytesIO, None]:
         """Download a picture of the part from the API."""
         content = requests.get(url, headers=self.headers, timeout=10).content
         return io.BytesIO(content)

--- a/lcsc_api.py
+++ b/lcsc_api.py
@@ -1,8 +1,8 @@
 """Unofficial LCSC API."""
 
 import io
-from typing import Union
 from pathlib import Path
+from typing import Union
 
 import requests  # pylint: disable=import-error
 

--- a/store.py
+++ b/store.py
@@ -5,8 +5,8 @@ import csv
 import logging
 import os
 from pathlib import Path
-from typing import Union
 import sqlite3
+from typing import Union
 
 from .helpers import (
     dict_factory,

--- a/store.py
+++ b/store.py
@@ -5,6 +5,7 @@ import csv
 import logging
 import os
 from pathlib import Path
+from typing import Union
 import sqlite3
 
 from .helpers import (
@@ -131,7 +132,7 @@ class Store:
                 {"reference": ref},
             ).fetchone()
 
-    def set_stock(self, ref: str, stock: int | None):
+    def set_stock(self, ref: str, stock: Union[int, None]):
         """Set the stock value for a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(


### PR DESCRIPTION
Could using unions instead of the | operator be a compromise to keep the compatibility with python 3.9 on macOS?
https://docs.python.org/3.10/library/typing.html#typing.Union