### PR TITLE
Fix LCSC numbers appearing on silkscreen

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -133,14 +133,19 @@ def get_lcsc_value(fp):
 
 def set_lcsc_value(fp, lcsc: str):
     """Set an lcsc number to the first matching propertie of the footprint, use LCSC as property name if not found."""
-    lcsc_field = "LCSC"
+    lcsc_field = None
     for field in fp.GetFields():
         if re.match(r"lcsc|jlc", field.GetName(), re.IGNORECASE) and re.match(
             r"^C\d+$", field.GetText()
         ):
-            lcsc_field = field.GetName()
-    fp.SetField(lcsc_field, lcsc)
+            lcsc_field = field
 
+    if lcsc_field:
+        fp.SetField(lcsc_field.GetName(), lcsc)
+    else:
+        fp.SetField("LCSC", lcsc)
+        field = fp.GetFieldByName("LCSC")
+        field.SetVisible(False)
 
 def get_valid_footprints(board):
     """Get all footprints that have a valid reference (drop all REF**)."""


### PR DESCRIPTION
Fixes #546

The Python scripting API is a bit awkward.  It would be nice if `pcbnew.FOOTPRINT.SetField` returned the resulting field so we could call `SetVisible(False)` on it.

I looked for ways to bypass the call to `GetFieldByName()`.  The [source code for SetField](https://docs.kicad.org/doxygen-python-8.0/pcbnew_8py_source.html#l19337) has some ideas.  But it wasn't working quite right and I would have to modify the function signature to take `pcbnew` as an argument for use in standalone mode.  I think we would also have to modify our standalone impl to add a couple of extra stub methods.  

Thanks @Carbon225 for the example code showing the problem and a prototype solution.