### PR TITLE
Show component values in list (+ other minor conveniences)

### DIFF
--- a/datamodel.py
+++ b/datamodel.py
@@ -5,8 +5,6 @@ import re
 
 import wx.dataview as dv
 
-from .derive_params import params_for_part
-
 from .helpers import loadIconScaled
 
 

--- a/datamodel.py
+++ b/datamodel.py
@@ -5,6 +5,8 @@ import re
 
 import wx.dataview as dv
 
+from .derive_params import params_for_part
+
 from .helpers import loadIconScaled
 
 
@@ -25,6 +27,7 @@ class PartListDataModel(dv.PyDataViewModel):
             "POS_COL": 7,
             "ROT_COL": 8,
             "SIDE_COL": 9,
+            "PARAMS_COL": 10,
         }
 
         self.bom_pos_icons = [
@@ -74,6 +77,7 @@ class PartListDataModel(dv.PyDataViewModel):
             "wxDataViewIconText",
             "string",
             "wxDataViewIconText",
+            "string",
         )
         return columntypes[col]
 
@@ -193,7 +197,7 @@ class PartListDataModel(dv.PyDataViewModel):
                 alike.append(self.ObjectToItem(data))
         return alike
 
-    def set_lcsc(self, ref, lcsc, type, stock):
+    def set_lcsc(self, ref, lcsc, type, stock, params):
         """Set an lcsc number, type and stock for given reference."""
         if (index := self.find_index(ref)) is None:
             return
@@ -201,6 +205,7 @@ class PartListDataModel(dv.PyDataViewModel):
         item[self.columns["LCSC_COL"]] = lcsc
         item[self.columns["TYPE_COL"]] = type
         item[self.columns["STOCK_COL"]] = stock
+        item[self.columns["PARAMS_COL"]] = params
         self.ItemChanged(self.ObjectToItem(item))
 
     def remove_lcsc_number(self, item):
@@ -209,6 +214,7 @@ class PartListDataModel(dv.PyDataViewModel):
         obj[self.columns["LCSC_COL"]] = ""
         obj[self.columns["TYPE_COL"]] = ""
         obj[self.columns["STOCK_COL"]] = ""
+        item[self.columns["PARAMS_COL"]] = ""
         self.ItemChanged(self.ObjectToItem(obj))
 
     def toggle_bom(self, item):

--- a/derive_params.py
+++ b/derive_params.py
@@ -9,9 +9,8 @@
 # significant parameters of the parts from the LCSC data so they can be displayed
 # separately in the footprint list.
 
-from math import exp
 import re
-from unicodedata import category
+
 
 def params_for_part(part) -> str:
     description = part.get("description", "")
@@ -65,9 +64,8 @@ def params_for_part(part) -> str:
 
     # For other types, just show the part number
 
-    else:
-        if part_no:
-            result.append(part_no)
+    elif part_no:
+        result.append(part_no)
 
     if package != "":
         result.append(package)

--- a/derive_params.py
+++ b/derive_params.py
@@ -1,5 +1,5 @@
-# Derive parameters from the part description and package
-#
+"""Derive parameters from the part description and package."""
+
 # LCSC hides the critical parameters (like resistor values) in the middle of the
 # description field, which makes them invisible in the footprint list. This
 # makes it very tedious to double-check the part mappings, as the part details
@@ -9,10 +9,15 @@
 # significant parameters of the parts from the LCSC data so they can be displayed
 # separately in the footprint list.
 
+import logging
 import re
+
+logger = logging.getLogger()
+logging.basicConfig(encoding="utf-8", level=logging.DEBUG)
 
 
 def params_for_part(part) -> str:
+    """Derive parameters from the part description and package."""
     description = part.get("description", "")
     category = part.get("category", "")
     part_no = part.get("part_no", "")
@@ -72,6 +77,7 @@ def params_for_part(part) -> str:
 
     return " ".join(result)
 
+
 # Test cases from actual LCSC data
 #
 # Generate random samples from the parts DB with:
@@ -84,7 +90,9 @@ def params_for_part(part) -> str:
 #   ORDER BY RANDOM() LIMIT 10
 # )
 
+
 def test_params_for_part():
+    """Test cases from actual LCSC data."""
     test_cases = {
         "Resistors": [
             ("250mW Thin Film Resistor 200V ±0.1% ±25ppm/℃ 284kΩ", "284kΩ ±0.1%"),
@@ -155,7 +163,7 @@ def test_params_for_part():
             assert (
                 result == expected
             ), f"For {description}: expected {expected}, got {result}"
-    print("All tests passed.")
+    logger.info("All tests passed.")
 
 
 # Run the tests if this file was run as a script

--- a/derive_params.py
+++ b/derive_params.py
@@ -1,0 +1,165 @@
+# Derive parameters from the part description and package
+#
+# LCSC hides the critical parameters (like resistor values) in the middle of the
+# description field, which makes them invisible in the footprint list. This
+# makes it very tedious to double-check the part mappings, as the part details
+# dialog has to be opened for each one.
+#
+# This function uses heuristics to extract a human-readable summary of the most
+# significant parameters of the parts from the LCSC data so they can be displayed
+# separately in the footprint list.
+
+from math import exp
+import re
+from unicodedata import category
+
+def params_for_part(part) -> str:
+    description = part.get("description", "")
+    category = part.get("category", "")
+    part_no = part.get("part_no", "")
+    package = part.get("package", "")
+
+    result = []
+
+    # These are heuristic regexes to pull out parameters like resistance,
+    # capacitance, voltage, current, etc. from the description field. As LCSC
+    # makes random changes to the format of the descriptions, this function will
+    # need to follow along.
+    #
+    # The package size isn't always in the description, but will be added by the
+    # caller.
+
+    # For passives, focus on generic values like resistance, capacitance, voltage
+
+    if "Resistors" in category:
+        result.extend(re.findall(r"([.\d]+[mkM]?Ω)", description))
+        result.extend(re.findall(r"(±[.\d]+%)", description))
+    elif "Capacitors" in category:
+        result.extend(re.findall(r"([.\d]+[pnmuμ]?F)", description))
+        result.extend(re.findall(r"([.\d]+[mkM]?V)", description))
+    elif "Inductors" in category:
+        result.extend(re.findall(r"([.\d]+[nuμm]?H)", description))
+        result.extend(re.findall(r"([.\d]+m?A)", description))
+
+    # For diodes, we may be looking for specific part or generic I/V specs
+
+    elif "Diodes" in category:
+        if part_no:
+            result.append(part_no)
+        result.extend(re.findall(r"(?<!@)\b([.\d]+[mkM]?[AW])\b", description))
+        result.extend(
+            re.findall(r"(?<!@)\b([.\d]+[mk]?V(?:~[.\d]+[mk]?V)?)(?!@)", description)
+        )
+        result.extend(re.findall(r"Schottky|Fast|Dual", description))
+
+    # For LEDs, check the color
+
+    elif "Optoelectronics" in category:
+        result.extend(
+            re.findall(
+                r"(red|green|blue|amber|emerald|white|yellow)",
+                description,
+                re.IGNORECASE,
+            )
+        )
+
+    # For other types, just show the part number
+
+    else:
+        if part_no:
+            result.append(part_no)
+
+    if package != "":
+        result.append(package)
+
+    return " ".join(result)
+
+# Test cases from actual LCSC data
+#
+# Generate random samples from the parts DB with:
+#
+# SELECT "LCSC Part", "Description", "First Category", "Second Category"
+# FROM parts
+# WHERE ROWID IN (
+#   SELECT ROWID FROM parts
+#   where "First Category" match "Transistors"
+#   ORDER BY RANDOM() LIMIT 10
+# )
+
+def test_params_for_part():
+    test_cases = {
+        "Resistors": [
+            ("250mW Thin Film Resistor 200V ±0.1% ±25ppm/℃ 284kΩ", "284kΩ ±0.1%"),
+            ("Metal Film Resistors 357kΩ 400mW ±50ppm/℃ ±1%", "357kΩ ±1%"),
+            ("Wirewound Resistors 800Ω 13W ±30ppm/℃ ±5%", "800Ω ±5%"),
+            ("7W ±75ppm/℃ ±1% 200mΩ", "200mΩ ±1%"),
+            ("500mW Thick Film Resistors ±100ppm/℃ ±1% 365Ω", "365Ω ±1%"),
+            ("250mW ±0.1% ±100ppm/℃ 6.04kΩ", "6.04kΩ ±0.1%"),
+            ("±20% 250mW 1kΩ   Potentiometers, Variable Resistors", "1kΩ ±20%"),
+            ("Carbon Resister 3.3kΩ 2W -500ppm/℃~0ppm/℃ ±10%", "3.3kΩ ±10%"),
+            ("47.04kΩ ±50ppm/℃ ±1%", "47.04kΩ ±1%"),
+            ("2 ±5% 4.3kΩ 62.5mW ±200ppm/℃", "4.3kΩ ±5%"),
+        ],
+        "Capacitors": [
+            ("16V 68nF X7R ±20%", "68nF 16V"),
+            ("1kV 33pF null ±10%", "33pF 1kV"),
+            ("25V 100nF ±5%", "100nF 25V"),
+            ("150V 8.2pF", "8.2pF 150V"),
+            ("±10% 1.5nF R 2kV   Through Hole Ceramic Capacitors", "1.5nF 2kV"),
+            ("100V 120pF NP0 ±2%", "120pF 100V"),
+            ("10V 22uF X6S ±20%", "22uF 10V"),
+            ("100uF 15V 180mΩ ±10%", "100uF 15V"),
+        ],
+        "Inductors": [
+            ("3A 18.5nH ±5%", "18.5nH 3A"),
+            ("175mA 12uH ±5%", "12uH 175mA"),
+            ("600mA 1.4nH 150mΩ", "1.4nH 600mA"),
+            ("6.4A 6uH ±25% 15A", "6uH 6.4A 15A"),
+        ],
+        "Diodes": [
+            ("1W 82V", "1W 82V"),
+            ("500mW 8.2V", "500mW 8.2V"),
+            (
+                "16V 1 pair of common cathodes 1V@35mA 75mA   Schottky Diodes",
+                "75mA 16V Schottky",
+            ),
+            ("150V 875mV@1A 25ns 1A   s", "1A 150V"),
+            (
+                "100uA@100V 100V Dual Common Cathode 950mV@20A 20A TO-220AB",
+                "20A 100V Dual",
+            ),
+            ("45V 15A 580mV@15A   Schottky Diodes", "15A 45V Schottky"),
+            ("35V 100mA 300mV@10mA   Schottky Diodes", "100mA 35V Schottky"),
+            (
+                "1.7V@2A 100ns 2A 1kV  Fast Recovery / High Efficiency Diodes",
+                "2A 1kV Fast",
+            ),
+            ("40V Independent Type 450mV@3A 3A  Schottky Diodes", "3A 40V Schottky"),
+            ("Independent Type 5.8V~6.6V 300mW 6.2V", "300mW 5.8V~6.6V 6.2V"),
+            ("6.2V~6.6V 200mW 5.8V", "200mW 6.2V~6.6V 5.8V"),
+        ],
+        "Optoelectronics": [
+            ("Blue  LED Indication - Discrete", "Blue"),
+            ("Emerald,Blue  LED Indication - Discrete", "Emerald Blue"),
+            ("350mA 7000K White 125° 2.73V", "White"),
+        ],
+        "Other": [
+            ("doesn't matter", ""),
+        ],
+    }
+
+    for category, tests in test_cases.items():
+        for description, parsed_params in tests:
+            result = params_for_part(
+                {"description": description, "category": category, "package": "thepkg"}
+            )
+            expected = f"{parsed_params} thepkg" if parsed_params else "thepkg"
+            assert (
+                result == expected
+            ), f"For {description}: expected {expected}, got {result}"
+    print("All tests passed.")
+
+
+# Run the tests if this file was run as a script
+if __name__ == "__main__":
+    test_params_for_part()

--- a/library.py
+++ b/library.py
@@ -120,6 +120,7 @@ class Library:
             "Manufacturer",
             "Description",
             "Price",
+            "First Category"
         ]
         s = ",".join(f'"{c}"' for c in columns)
         query = f"SELECT {s} FROM parts WHERE "
@@ -364,7 +365,10 @@ class Library:
         with contextlib.closing(sqlite3.connect(self.partsdb_file)) as con:
             con.row_factory = dict_factory  # noqa: DC05
             cur = con.cursor()
-            query = """SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type FROM parts WHERE parts MATCH :number"""
+            query = """SELECT "LCSC Part" AS lcsc, "Stock" AS stock, "Library Type" AS type,
+                "MFR.Part" as part_no, "Description" as description, "Package" as package,
+                "First Category" as category
+                FROM parts WHERE parts MATCH :number"""
             cur.execute(query, {"number": number})
             return next((n for n in cur.fetchall() if n["lcsc"] == number), {})
 

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -360,8 +360,11 @@ class JLCPCBTools(wx.Dialog):
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
         table_sizer.SetMinSize(HighResWxSize(self.window, wx.Size(-1, 600)))
 
+        table_scroller = wx.ScrolledWindow(self, style=wx.HSCROLL | wx.VSCROLL)
+        table_scroller.SetScrollRate(20, 20)
+
         self.footprint_list = dv.DataViewCtrl(
-            self,
+            table_scroller,
             style=wx.BORDER_THEME | dv.DV_ROW_LINES | dv.DV_VERT_RULES | dv.DV_MULTIPLE,
         )
 
@@ -410,8 +413,13 @@ class JLCPCBTools(wx.Dialog):
         pos.SetSortable(False)
         rotation.SetSortable(True)
         side.SetSortable(True)
+        params.SetSortable(True)
 
-        table_sizer.Add(self.footprint_list, 20, wx.ALL | wx.EXPAND, 5)
+        scrolled_sizer = wx.BoxSizer(wx.VERTICAL)
+        scrolled_sizer.Add(self.footprint_list, 1, wx.EXPAND)
+        table_scroller.SetSizer(scrolled_sizer)
+
+        table_sizer.Add(table_scroller, 20, wx.ALL | wx.EXPAND, 5)
 
         self.footprint_list.Bind(
             dv.EVT_DATAVIEW_SELECTION_CHANGED, self.OnFootprintSelected

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -834,7 +834,7 @@ class JLCPCBTools(wx.Dialog):
             and not self.check_order_number()
         ):
             result = wx.MessageBox(
-                "JLC order number placehodler not present! Continue?",
+                "JLC order number placeholder not present! Continue?",
                 "JLC order number placeholder",
                 wx.OK | wx.CANCEL | wx.CENTER,
             )

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -810,7 +810,6 @@ class JLCPCBTools(wx.Dialog):
         selection = {}
         for item in self.footprint_list.GetSelections():
             ref = self.partlist_data_model.get_reference(item)
-            lcsc = self.partlist_data_model.get_lcsc(item)
             value = self.partlist_data_model.get_value(item)
             footprint = self.partlist_data_model.get_footprint(item)
             if ref.startswith("R"):

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -429,6 +429,8 @@ class JLCPCBTools(wx.Dialog):
             dv.EVT_DATAVIEW_SELECTION_CHANGED, self.OnFootprintSelected
         )
 
+        self.footprint_list.Bind(dv.EVT_DATAVIEW_ITEM_ACTIVATED, self.select_part)
+
         self.footprint_list.Bind(dv.EVT_DATAVIEW_ITEM_CONTEXT_MENU, self.OnRightDown)
 
         table_sizer.Add(self.right_toolbar, 1, wx.EXPAND, 5)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -812,10 +812,13 @@ class JLCPCBTools(wx.Dialog):
             ref = self.partlist_data_model.get_reference(item)
             lcsc = self.partlist_data_model.get_lcsc(item)
             value = self.partlist_data_model.get_value(item)
-            if lcsc != "":
-                selection[ref] = lcsc
-            else:
-                selection[ref] = value
+            footprint = self.partlist_data_model.get_footprint(item)
+            if ref.startswith("R"):
+                value += "Ω"
+            m = re.search(r"_(\d+)_\d+Metric", footprint)
+            if m:
+                value += f" {m.group(1)}"
+            selection[ref] = value
         PartSelectorDialog(self, selection).ShowModal()
 
     def check_order_number(self):

--- a/partdetails.py
+++ b/partdetails.py
@@ -23,7 +23,7 @@ class PartDetailsDialog(wx.Dialog):
             title="JLCPCB Part Details",
             pos=wx.DefaultPosition,
             size=HighResWxSize(parent.window, wx.Size(1000, 800)),
-            style=wx.DEFAULT_DIALOG_STYLE | wx.STAY_ON_TOP,
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.STAY_ON_TOP,
         )
 
         self.logger = logging.getLogger(__name__)

--- a/partselector.py
+++ b/partselector.py
@@ -6,6 +6,8 @@ import time
 import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
 
+from .derive_params import params_for_part  # pylint: disable=import-error
+
 from .events import AssignPartsEvent, UpdateSetting
 from .helpers import HighResWxSize, loadBitmapScaled
 from .partdetails import PartDetailsDialog
@@ -443,6 +445,13 @@ class PartSelectorDialog(wx.Dialog):
             flags=wx.dataview.DATAVIEW_COL_RESIZABLE,
         ).GetRenderer().EnableEllipsize(wx.ELLIPSIZE_NONE)
         self.part_list.AppendTextColumn(
+            "Params",
+            mode=wx.dataview.DATAVIEW_CELL_INERT,
+            width=int(parent.scale_factor * 150),
+            align=wx.ALIGN_CENTER,
+            flags=wx.dataview.DATAVIEW_COL_RESIZABLE,
+        ).GetRenderer().EnableEllipsize(wx.ELLIPSIZE_NONE)
+        self.part_list.AppendTextColumn(
             "Stock",
             mode=wx.dataview.DATAVIEW_CELL_INERT,
             width=int(parent.scale_factor * 50),
@@ -689,6 +698,8 @@ class PartSelectorDialog(wx.Dialog):
                 )
             else:
                 item[pricecol] = "Error in price data"
+            params = params_for_part({"description": item[7], "category": item[9], "package": item[2]})
+            item.insert(5, params)
             self.part_list.AppendItem(item)
 
     def select_part(self, *_):
@@ -699,7 +710,7 @@ class PartSelectorDialog(wx.Dialog):
             return
         selection = self.part_list.GetTextValue(row, 0)
         type = self.part_list.GetTextValue(row, 4)
-        stock = self.part_list.GetTextValue(row, 5)
+        stock = self.part_list.GetTextValue(row, 6)
         wx.PostEvent(
             self.parent,
             AssignPartsEvent(

--- a/partselector.py
+++ b/partselector.py
@@ -490,6 +490,9 @@ class PartSelectorDialog(wx.Dialog):
             wx.dataview.EVT_DATAVIEW_SELECTION_CHANGED, self.OnPartSelected
         )
 
+        self.part_list.Bind(wx.EVT_LEFT_DCLICK, self.select_part)
+
+
         table_sizer = wx.BoxSizer(wx.HORIZONTAL)
         table_sizer.SetMinSize(HighResWxSize(parent.window, wx.Size(-1, 400)))
         table_sizer.Add(self.part_list, 20, wx.ALL | wx.EXPAND, 5)

--- a/partselector.py
+++ b/partselector.py
@@ -7,7 +7,6 @@ import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
 
 from .derive_params import params_for_part  # pylint: disable=import-error
-
 from .events import AssignPartsEvent, UpdateSetting
 from .helpers import HighResWxSize, loadBitmapScaled
 from .partdetails import PartDetailsDialog

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"partselector": {"basic": true, "extended": true, "stock": false}, "gerber": {"tented_vias": true, "fill_zones": false, "plot_values": true, "plot_references": true, "lcsc_bom_cpl": true}, "general": {"lcsc_priority": true, "order_number": true}}
+{"partselector": {"basic": true, "extended": true, "stock": false}, "gerber": {"tented_vias": true, "fill_zones": false, "plot_values": true, "plot_references": true, "lcsc_bom_cpl": true}, "general": {"lcsc_priority": false, "order_number": true}}

--- a/standalone_impl.py
+++ b/standalone_impl.py
@@ -11,6 +11,25 @@ class LIB_ID_Stub:
         """Item name."""
         return self.item_name
 
+class Field_Stub:
+    """Implementation of pcbnew.Field."""
+
+    def __init__(self, name, text):
+        self.name = name
+        self.text = text
+
+    def GetName(self) -> str:
+        """Field name."""
+        return self.name
+
+    def GetText(self) -> str:
+        """Field text."""
+        return self.text
+
+    def SetVisible(self, visible):
+        """Set the field visibility."""
+        pass
+
 
 class Footprint_Stub:
     """Implementation of pcbnew.Footprint."""
@@ -39,6 +58,18 @@ class Footprint_Stub:
     def GetAttributes(self) -> int:
         """Attributes."""
         return 0
+
+    def GetFields(self) -> list:
+        """Fields."""
+        return []
+
+    def SetField(self, name, text):
+        """Set a field."""
+        pass
+
+    def GetFieldByName(self, name) -> Field_Stub:
+        """Get a field by name."""
+        return Field_Stub(name, "stub")
 
     def GetLayer(self) -> int:
         """Layer number."""

--- a/store.py
+++ b/store.py
@@ -218,7 +218,7 @@ class Store:
                             "Part %s is already in the database and has a lcsc value, the value supplied from the board will be ignored.",
                             board_part["reference"],
                         )
-                        board_part["lcsc"] = None
+                        board_part["lcsc"] = db_part["lcsc"]
                     else:
                         self.logger.debug(
                             "Part %s is already in the database and has a lcsc value, the value supplied from the board will overwrite that in the database.",


### PR DESCRIPTION
There are several commits in this PR, sorry. However, they are all independent, so you can apply whichever you approve of.

They're all small conveniences except the "**Show parameters derived from LCSC description**" commit, which addresses the following pain points:

1. LCSC often buries the most important data (like the resistance of a resistor) at the end of the description field. For example: "50mW Thick Film Resistors ±200ppm/℃ ±1% 234kΩ". The "234kΩ" is past the point where the part details dialog truncates the description. (And that dialog is not resizable, which is one of the minor fixes.)

2. When choosing a part, the values aren't visible in the list. If you search for "5kΩ" you'll also get "25kΩ", "1.5kΩ", etc. and you can't see which is which without opening the details dialog.

3. When double-checking the assignments, you can't just look down the footprint list to be sure the values are sane, because you can't see the values.

This commit tries to address this by implementing heuristics to pull the important data out of the LCSC description field and show it in the footprint and parts lists. For example:
<img width="803" alt="image" src="https://github.com/user-attachments/assets/1831e7f0-742e-4001-ab0b-8b2e94111bd6">
<img width="898" alt="image" src="https://github.com/user-attachments/assets/cbe09df5-172f-4e55-8134-bfc483486c05">
You can easily scan the list to make sure the values and footprints match.

In part selection:
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/f96f11d2-f846-4629-b6cf-313b2b333f35">
It's easy to tell the 5.1k from the 51k from the 1k.

This (in addition to implementing double-click in another commit) has vastly accelerated my workflow.

There's one other minor change to note: I altered the default setting of `lcsc_priority`. With the current setting, my experience as a new user was that I put in 15 minutes of work assigning parts, closed the dialog, and immediately lost all my work because I didn't know to click the "export" button. It seems safer to default the other way.