### PR TITLE
Fix: check_order_number function on empty files

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -804,9 +804,13 @@ class JLCPCBTools(wx.Dialog):
 
     def check_order_number(self):
         """Verify that the JLC order number placeholder is present."""
-        with open(self.pcbnew.GetBoard().GetFileName()) as f:
-            data = f.read()
-            return "JLCJLCJLCJLC" in data
+        try:
+            with open(self.pcbnew.GetBoard().GetFileName()) as f:
+                data = f.read()
+                return "JLCJLCJLCJLC" in data
+        except OSError:
+            pass
+        return True
 
     def generate_fabrication_data(self, *_):
         """Generate fabrication data."""


### PR DESCRIPTION
When empty board is used, `pcbnew.GetBoard().GetFileName()` returns `FileNotFound` exception which was not handled in `check_order_number` function. Catch `OSError` exception which should fix this behaviour.

Maybe longing an error would be useful?