### PR TITLE
Remove Paste and V-Score layers from ZIP file

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -178,15 +178,12 @@ class Fabrication:
             ("CuTop", F_Cu, "Top layer"),
             ("SilkTop", F_SilkS, "Silk top"),
             ("MaskTop", F_Mask, "Mask top"),
-            ("PasteTop", F_Paste, "Paste top"),
         ]
         plot_plan_bottom = [
             ("CuBottom", B_Cu, "Bottom layer"),
             ("SilkBottom", B_SilkS, "Silk top"),
             ("MaskBottom", B_Mask, "Mask bottom"),
-            ("PasteBottom", B_Paste, "Paste bottom"),
             ("EdgeCuts", Edge_Cuts, "Edges"),
-            ("VScore", Cmts_User, "V score cut"),
         ]
 
         plot_plan = []

--- a/fabrication.py
+++ b/fabrication.py
@@ -17,13 +17,10 @@ from pcbnew import (  # pylint: disable=import-error
     ZONE_FILLER,
     B_Cu,
     B_Mask,
-    B_Paste,
     B_SilkS,
-    Cmts_User,
     Edge_Cuts,
     F_Cu,
     F_Mask,
-    F_Paste,
     F_SilkS,
     Refresh,
     ToMM,
@@ -310,7 +307,12 @@ class Fabrication:
                 components = part["refs"].split(",")
                 for component in components:
                     for fp in self.board.Footprints():
-                        if fp.GetReference() == component and hasattr(fp, "IsDNP") and callable(fp.IsDNP) and fp.IsDNP():
+                        if (
+                            fp.GetReference() == component
+                            and hasattr(fp, "IsDNP")
+                            and callable(fp.IsDNP)
+                            and fp.IsDNP()
+                        ):
                             components.remove(component)
                             part["refs"] = ",".join(components)
                             self.logger.info(
@@ -324,7 +326,13 @@ class Fabrication:
                     )
                     continue
                 writer.writerow(
-                    [part["value"], part["refs"], part["footprint"], part["lcsc"], len(components)]
+                    [
+                        part["value"],
+                        part["refs"],
+                        part["footprint"],
+                        part["lcsc"],
+                        len(components),
+                    ]
                 )
         self.logger.info(
             "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)


### PR DESCRIPTION
As described in #563, JLC does not like Paste Layers nor V-Score layers in the ZIP file.