### PR TITLE
Fix/layers

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -1,6 +1,7 @@
 """Handles the generation of the Gerber files, the BOM and the POS file."""
 
 import csv
+from importlib import import_module
 import logging
 import os
 from pathlib import Path
@@ -196,7 +197,7 @@ class Fabrication:
             plot_plan = (
                 plot_plan_top
                 + [
-                    (f"CuIn{layer}", layer, f"Inner layer {layer}")
+                    (f"CuIn{layer}", getattr(import_module("pcbnew"), f"In{layer}_Cu"), f"Inner layer {layer}")
                     for layer in range(1, layer_count - 1)
                 ]
                 + plot_plan_bottom

--- a/fabrication.py
+++ b/fabrication.py
@@ -178,7 +178,7 @@ class Fabrication:
         ]
         plot_plan_bottom = [
             ("CuBottom", B_Cu, "Bottom layer"),
-            ("SilkBottom", B_SilkS, "Silk top"),
+            ("SilkBottom", B_SilkS, "Silk bottom"),
             ("MaskBottom", B_Mask, "Mask bottom"),
             ("EdgeCuts", Edge_Cuts, "Edges"),
         ]


### PR DESCRIPTION
- fix typo
  - `Silk top` -> `Silk bottom`
- replace generated layer numbers with pcbnew's enums
  - The layer IDs have been changed in KiCad 9, so get the enums directly from `pcbnew`. This change is backport compatible with the older KiCad versions.

Closes #573, closes #567 