### PR TITLE
Feature Request: Export Additional Layers #525

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -25,6 +25,7 @@ from pcbnew import (  # pylint: disable=import-error
     F_SilkS,
     Refresh,
     ToMM,
+    ToLAYER_ID
 )
 
 # Compatibility hack for V6 / V7 / V7.99
@@ -202,6 +203,18 @@ class Fabrication:
                 ]
                 + plot_plan_bottom
             )
+
+        # Add all JLC prefixed layers - layers must have "JLC_" in their name
+        jlc_layers_to_plot = []
+        enabled_layer_ids = list(self.board.GetEnabledLayers().Seq())
+        for enabled_layer_id in enabled_layer_ids:
+            layer_name_string = str(
+                self.board.GetLayerName(enabled_layer_id)).upper()
+            if "JLC_" in layer_name_string:
+                plotter_info = (layer_name_string,
+                                enabled_layer_id, layer_name_string)
+                jlc_layers_to_plot.append(plotter_info)
+        plot_plan += jlc_layers_to_plot
 
         for layer_info in plot_plan:
             if layer_info[1] <= B_Cu:

--- a/fabrication.py
+++ b/fabrication.py
@@ -25,7 +25,6 @@ from pcbnew import (  # pylint: disable=import-error
     F_SilkS,
     Refresh,
     ToMM,
-    ToLAYER_ID
 )
 
 # Compatibility hack for V6 / V7 / V7.99
@@ -152,7 +151,8 @@ class Fabrication:
         # In KiCAD 8.99 this must be set in the layer settings of KiCAD
         if hasattr(PCB_VIA, "SetPlotViaOnMaskLayer"):
             popt.SetPlotViaOnMaskLayer(
-                not self.parent.settings.get("gerber", {}).get("tented_vias", True)
+                not self.parent.settings.get(
+                    "gerber", {}).get("tented_vias", True)
             )
 
         popt.SetUseGerberX2format(True)
@@ -198,7 +198,8 @@ class Fabrication:
             plot_plan = (
                 plot_plan_top
                 + [
-                    (f"CuIn{layer}", getattr(import_module("pcbnew"), f"In{layer}_Cu"), f"Inner layer {layer}")
+                    (f"CuIn{layer}", getattr(import_module("pcbnew"),
+                     f"In{layer}_Cu"), f"Inner layer {layer}")
                     for layer in range(1, layer_count - 1)
                 ]
                 + plot_plan_bottom
@@ -258,7 +259,8 @@ class Fabrication:
                     filePath = os.path.join(folderName, filename)
                     zipfile.write(filePath, os.path.basename(filePath))
         self.logger.info(
-            "Finished generating ZIP file %s", os.path.join(self.outputdir, zipname)
+            "Finished generating ZIP file %s", os.path.join(
+                self.outputdir, zipname)
         )
 
     def generate_cpl(self):
@@ -274,9 +276,11 @@ class Fabrication:
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(
-                ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
+                ["Designator", "Val", "Package", "Mid X",
+                    "Mid Y", "Rotation", "Layer"]
             )
-            footprints = sorted(self.board.Footprints(), key=lambda x: x.GetReference())
+            footprints = sorted(self.board.Footprints(),
+                                key=lambda x: x.GetReference())
             for fp in footprints:
                 part = self.parent.store.get_part(fp.GetReference())
                 if not part:  # No matching part in the database, continue
@@ -303,7 +307,8 @@ class Fabrication:
                     ]
                 )
         self.logger.info(
-            "Finished generating CPL file %s", os.path.join(self.outputdir, cplname)
+            "Finished generating CPL file %s", os.path.join(
+                self.outputdir, cplname)
         )
 
     def generate_bom(self):
@@ -316,7 +321,8 @@ class Fabrication:
             os.path.join(self.outputdir, bomname), "w", newline="", encoding="utf-8"
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
-            writer.writerow(["Comment", "Designator", "Footprint", "LCSC", "Quantity"])
+            writer.writerow(
+                ["Comment", "Designator", "Footprint", "LCSC", "Quantity"])
             for part in self.parent.store.read_bom_parts():
                 components = part["refs"].split(",")
                 for component in components:
@@ -349,5 +355,6 @@ class Fabrication:
                     ]
                 )
         self.logger.info(
-            "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)
+            "Finished generating BOM file %s", os.path.join(
+                self.outputdir, bomname)
         )

--- a/fabrication.py
+++ b/fabrication.py
@@ -151,8 +151,7 @@ class Fabrication:
         # In KiCAD 8.99 this must be set in the layer settings of KiCAD
         if hasattr(PCB_VIA, "SetPlotViaOnMaskLayer"):
             popt.SetPlotViaOnMaskLayer(
-                not self.parent.settings.get(
-                    "gerber", {}).get("tented_vias", True)
+                not self.parent.settings.get("gerber", {}).get("tented_vias", True)
             )
 
         popt.SetUseGerberX2format(True)
@@ -198,8 +197,7 @@ class Fabrication:
             plot_plan = (
                 plot_plan_top
                 + [
-                    (f"CuIn{layer}", getattr(import_module("pcbnew"),
-                     f"In{layer}_Cu"), f"Inner layer {layer}")
+                    (f"CuIn{layer}", getattr(import_module("pcbnew"), f"In{layer}_Cu"), f"Inner layer {layer}")
                     for layer in range(1, layer_count - 1)
                 ]
                 + plot_plan_bottom
@@ -259,8 +257,7 @@ class Fabrication:
                     filePath = os.path.join(folderName, filename)
                     zipfile.write(filePath, os.path.basename(filePath))
         self.logger.info(
-            "Finished generating ZIP file %s", os.path.join(
-                self.outputdir, zipname)
+            "Finished generating ZIP file %s", os.path.join(self.outputdir, zipname)
         )
 
     def generate_cpl(self):
@@ -276,11 +273,9 @@ class Fabrication:
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(
-                ["Designator", "Val", "Package", "Mid X",
-                    "Mid Y", "Rotation", "Layer"]
+                ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
             )
-            footprints = sorted(self.board.Footprints(),
-                                key=lambda x: x.GetReference())
+            footprints = sorted(self.board.Footprints(), key=lambda x: x.GetReference())
             for fp in footprints:
                 part = self.parent.store.get_part(fp.GetReference())
                 if not part:  # No matching part in the database, continue
@@ -307,8 +302,7 @@ class Fabrication:
                     ]
                 )
         self.logger.info(
-            "Finished generating CPL file %s", os.path.join(
-                self.outputdir, cplname)
+            "Finished generating CPL file %s", os.path.join(self.outputdir, cplname)
         )
 
     def generate_bom(self):
@@ -321,8 +315,7 @@ class Fabrication:
             os.path.join(self.outputdir, bomname), "w", newline="", encoding="utf-8"
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
-            writer.writerow(
-                ["Comment", "Designator", "Footprint", "LCSC", "Quantity"])
+            writer.writerow(["Comment", "Designator", "Footprint", "LCSC", "Quantity"])
             for part in self.parent.store.read_bom_parts():
                 components = part["refs"].split(",")
                 for component in components:
@@ -355,6 +348,5 @@ class Fabrication:
                     ]
                 )
         self.logger.info(
-            "Finished generating BOM file %s", os.path.join(
-                self.outputdir, bomname)
+            "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)
         )


### PR DESCRIPTION
Added support for automatically exporting layers with _JLC__ prefix in the layer name. User must add a user defined layer with _JLC__ as the name prefix e.g. _JLC_SS_Stiffener_Top_0.2mm_

As of now there would be no way to disable this - if you have a layer with the _JLC__ prefix it will always be exported in your gerber. I believe this feature would only be used by people intentionally creating the JLC_ layer so there is probably no need to enable/disable it with a setting? 

Note: the _JLC__ prefix is not case sensitive because I know I would eventually write something like JlC_ or JLc_ by accident. 

Let me know what you think :) 