### PR TITLE
Extended rotation correction to also have X/Y offsets.

### DIFF
--- a/jlcparts_db_convert.py
+++ b/jlcparts_db_convert.py
@@ -244,15 +244,6 @@ class Jlcpcb(Generate):
             """
         )
 
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS rotation (
-                'regex',
-                'correction'
-            )
-            """
-        )
-
     def build(self):
         """Run all of the steps to generate the database files for upload."""
         self.remove_original()
@@ -313,15 +304,6 @@ class JlcpcbFTS5(Generate):
                 'partcount',
                 'date',
                 'last_update'
-            )
-            """
-        )
-
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS rotation (
-                'regex',
-                'correction'
             )
             """
         )

--- a/library.py
+++ b/library.py
@@ -41,6 +41,7 @@ class Library:
         self.datadir = os.path.join(PLUGIN_PATH, "jlcpcb")
         self.partsdb_file = os.path.join(self.datadir, "parts-fts5.db")
         self.rotationsdb_file = os.path.join(self.datadir, "rotations.db")
+        self.correctionsdb_file = os.path.join(self.datadir, "corrections.db")
         self.mappingsdb_file = os.path.join(self.datadir, "mappings.db")
         self.state = None
         self.category_map = {}
@@ -65,11 +66,11 @@ class Library:
         else:
             self.state = LibraryState.INITIALIZED
         if (
-            not os.path.isfile(self.rotationsdb_file)
-            or os.path.getsize(self.rotationsdb_file) == 0
+            not os.path.isfile(self.correctionsdb_file)
+            or os.path.getsize(self.correctionsdb_file) == 0
         ):
-            self.create_rotation_table()
-            self.migrate_rotations()
+            self.create_correction_table()
+            self.migrate_corrections()
         if (
             not os.path.isfile(self.mappingsdb_file)
             or os.path.getsize(self.mappingsdb_file) == 0
@@ -230,63 +231,63 @@ class Library:
             )
             cur.commit()
 
-    def create_rotation_table(self):
-        """Create the rotation table."""
-        self.logger.debug("Create SQLite table for rotations")
+    def create_correction_table(self):
+        """Create the correction table."""
+        self.logger.debug("Create SQLite table for corrections")
         with contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as con, con as cur:
-            cur.execute("CREATE TABLE IF NOT EXISTS rotation ('regex', 'correction')")
+            cur.execute("CREATE TABLE IF NOT EXISTS correction ('regex', 'rotation', 'offset_x', 'offset_y')")
             cur.commit()
 
     def get_correction_data(self, regex):
         """Get the correction data by its regex."""
         with contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as con, con as cur:
             return cur.execute(
-                f"SELECT * FROM rotation WHERE regex = '{regex}'"
+                f"SELECT * FROM correction WHERE regex = '{regex}'"
             ).fetchone()
 
     def delete_correction_data(self, regex):
         """Delete a correction from the database."""
         with contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as con, con as cur:
-            cur.execute(f"DELETE FROM rotation WHERE regex = '{regex}'")
+            cur.execute(f"DELETE FROM correction WHERE regex = '{regex}'")
             cur.commit()
 
-    def update_correction_data(self, regex, rotation):
+    def update_correction_data(self, regex, rotation, offset):
         """Update a correction in the database."""
         with contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as con, con as cur:
             cur.execute(
-                f"UPDATE rotation SET correction = '{rotation}' WHERE regex = '{regex}'"
+                f"UPDATE correction SET rotation = '{rotation}', offset_x = '{offset[0]}', offset_y = '{offset[1]}' WHERE regex = '{regex}'"
             )
             cur.commit()
 
-    def insert_correction_data(self, regex, rotation):
+    def insert_correction_data(self, regex, rotation, offset):
         """Insert a correction into the database."""
         with contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as con, con as cur:
             cur.execute(
-                "INSERT INTO rotation VALUES (?, ?)",
-                (regex, rotation),
+                "INSERT INTO correction VALUES (?, ?, ?, ?)",
+                (regex, rotation, offset[0], offset[1]),
             )
             cur.commit()
 
     def get_all_correction_data(self):
         """Get all corrections from the database."""
         with contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as con, con as cur:
             try:
                 result = cur.execute(
-                    "SELECT * FROM rotation ORDER BY regex ASC"
+                    "SELECT * FROM correction ORDER BY regex ASC"
                 ).fetchall()
-                return [(c[0], int(c[1])) for c in result]
+                return [(c[0], int(c[1]), (float(c[2]), float(c[3]))) for c in result]
             except sqlite3.OperationalError:
                 return []
 
@@ -568,7 +569,7 @@ class Library:
         self.create_meta_table()
         self.delete_parts_table()
         self.create_parts_table(headers)
-        self.create_rotation_table()
+        self.create_correction_table()
         self.create_mapping_table()
 
     @property
@@ -598,12 +599,43 @@ class Library:
         """Get the subcategories associated with the given category."""
         return self.category_map[category]
 
-    def migrate_rotations(self):
-        """Migrate existing rotations from parts db to rotations db."""
+    def migrate_corrections_from_rotation(self):
+        """Migrate existing rotations from rotation db to correction db."""
+        if not os.path.exists(self.rotationsdb_file):
+            return
+        with contextlib.closing(
+            sqlite3.connect(self.rotationsdb_file)
+        ) as rdb, contextlib.closing(
+            sqlite3.connect(self.correctionsdb_file)
+        ) as cdb, rdb as rcur, cdb as ccur:
+            try:
+                result = rcur.execute(
+                    "SELECT * FROM rotation ORDER BY regex ASC"
+                ).fetchall()
+                if not result:
+                    return
+                for r in result:
+                    ccur.execute(
+                        "INSERT INTO correction VALUES (?, ?, 0, 0)",
+                        (r[0], r[1]),
+                    )
+                    ccur.commit()
+                self.logger.debug(
+                    "Migrated %d rotations to corrections database.", len(result)
+                )
+                os.remove(self.rotationsdb_file)
+                self.logger.debug("Deleted rotations database.")
+            except sqlite3.OperationalError:
+                return
+            except OSError:
+                return
+
+    def migrate_corrections_from_parts(self):
+        """Migrate existing rotations from parts db to correction db."""
         with contextlib.closing(
             sqlite3.connect(self.partsdb_file)
         ) as pdb, contextlib.closing(
-            sqlite3.connect(self.rotationsdb_file)
+            sqlite3.connect(self.correctionsdb_file)
         ) as rdb, pdb as pcur, rdb as rcur:
             try:
                 result = pcur.execute(
@@ -613,18 +645,23 @@ class Library:
                     return
                 for r in result:
                     rcur.execute(
-                        "INSERT INTO rotation VALUES (?, ?)",
+                        "INSERT INTO correction VALUES (?, ?, 0, 0)",
                         (r[0], r[1]),
                     )
                     rcur.commit()
                 self.logger.debug(
-                    "Migrated %d rotations to sepetrate database.", len(result)
+                    "Migrated %d rotations to separate database.", len(result)
                 )
                 pcur.execute("DROP TABLE IF EXISTS rotation")
                 pcur.commit()
                 self.logger.debug("Droped rotations table from parts database.")
             except sqlite3.OperationalError:
                 return
+
+    def migrate_corrections(self):
+        """Migrate existing rotations from old rotation db and parts db to correction db."""
+        self.migrate_corrections_from_rotation()
+        self.migrate_corrections_from_parts()
 
     def migrate_mappings(self):
         """Migrate existing mappings from parts db to mappings db."""

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -40,7 +40,7 @@ from .library import Library, LibraryState
 from .partdetails import PartDetailsDialog
 from .partmapper import PartMapperManagerDialog
 from .partselector import PartSelectorDialog
-from .rotations import RotationManagerDialog
+from .corrections import CorrectionManagerDialog
 from .schematicexport import SchematicExport
 from .settings import SettingsDialog
 from .store import Store
@@ -50,7 +50,7 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 ID_GENERATE = 0
 ID_LAYERS = 1
-ID_ROTATIONS = 2
+ID_CORRECTIONS = 2
 ID_MAPPINGS = 3
 ID_DOWNLOAD = 4
 ID_SETTINGS = 5
@@ -178,11 +178,11 @@ class JLCPCBTools(wx.Dialog):
 
         self.upper_toolbar.AddStretchableSpace()
 
-        self.rotation_button = self.upper_toolbar.AddTool(
-            ID_ROTATIONS,
-            "Rotations",
+        self.correction_button = self.upper_toolbar.AddTool(
+            ID_CORRECTIONS,
+            "Corrections",
             loadBitmapScaled("mdi-format-rotate-90.png", self.scale_factor),
-            "Manage part rotations",
+            "Manage part corrections",
         )
 
         self.mapping_button = self.upper_toolbar.AddTool(
@@ -211,7 +211,7 @@ class JLCPCBTools(wx.Dialog):
         self.upper_toolbar.Realize()
 
         self.Bind(wx.EVT_TOOL, self.generate_fabrication_data, self.generate_button)
-        self.Bind(wx.EVT_TOOL, self.manage_rotations, self.rotation_button)
+        self.Bind(wx.EVT_TOOL, self.manage_corrections, self.correction_button)
         self.Bind(wx.EVT_TOOL, self.manage_mappings, self.mapping_button)
         self.Bind(wx.EVT_TOOL, self.update_library, self.download_button)
         self.Bind(wx.EVT_TOOL, self.manage_settings, self.settings_button)
@@ -387,7 +387,7 @@ class JLCPCBTools(wx.Dialog):
             10,
             width=150,
             mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_CENTER,
+            align=wx.ALIGN_CENTER
         )
         lcsc = self.footprint_list.AppendTextColumn(
             "LCSC", 3, width=100, mode=dv.DATAVIEW_CELL_INERT, align=wx.ALIGN_CENTER
@@ -404,8 +404,8 @@ class JLCPCBTools(wx.Dialog):
         pos = self.footprint_list.AppendIconTextColumn(
             "POS", 7, width=50, mode=dv.DATAVIEW_CELL_INERT
         )
-        rotation = self.footprint_list.AppendTextColumn(
-            "Rotation", 8, width=70, mode=dv.DATAVIEW_CELL_INERT, align=wx.ALIGN_CENTER
+        correction = self.footprint_list.AppendTextColumn(
+            "Correction", 8, width=70, mode=dv.DATAVIEW_CELL_INERT, align=wx.ALIGN_CENTER
         )
         side = self.footprint_list.AppendIconTextColumn(
             "Side", 9, width=50, mode=dv.DATAVIEW_CELL_INERT
@@ -419,7 +419,7 @@ class JLCPCBTools(wx.Dialog):
         stock.SetSortable(True)
         bom.SetSortable(True)
         pos.SetSortable(False)
-        rotation.SetSortable(True)
+        correction.SetSortable(True)
         side.SetSortable(True)
         params.SetSortable(True)
 
@@ -564,14 +564,14 @@ class JLCPCBTools(wx.Dialog):
     def get_correction(self, part: dict, corrections: list) -> str:
         """Try to find correction data for a given part."""
         # First check if the part name matches
-        for regex, correction in corrections:
+        for regex, rotation, offset in corrections:
             if re.search(regex, str(part["reference"])):
-                return str(correction)
+                return "{}°, {}/{}".format(str(rotation), str(offset[0]), str(offset[1]))
         # If there was no match for the part name, check if the package matches
-        for regex, correction in corrections:
+        for regex, rotation, offset in corrections:
             if re.search(regex, str(part["footprint"])):
-                return str(correction)
-        return "0"
+                return "{}°, {}/{}".format(str(rotation), str(offset[0]), str(offset[1]))
+        return "0°, 0.0/0.0"
 
     def populate_footprint_list(self, *_):
         """Populate list of footprints."""
@@ -779,9 +779,9 @@ class JLCPCBTools(wx.Dialog):
         """Update the library from the JLCPCB CSV file."""
         self.library.update()
 
-    def manage_rotations(self, *_):
-        """Manage rotation corrections."""
-        RotationManagerDialog(self, "").ShowModal()
+    def manage_corrections(self, *_):
+        """Manage corrections."""
+        CorrectionManagerDialog(self, "").ShowModal()
 
     def manage_mappings(self, *_):
         """Manage footprint mappings."""
@@ -898,15 +898,15 @@ class JLCPCBTools(wx.Dialog):
                     )
                     self.store.set_lcsc(reference, lcsc)
 
-    def add_rotation(self, e):
-        """Add part rotation for the current part."""
+    def add_correction(self, e):
+        """Add part correction for the current part."""
         for item in self.footprint_list.GetSelections():
             if e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_PACKAGE:
                 if footprint := self.partlist_data_model.get_footprint(item):
-                    RotationManagerDialog(self, "^" + re.escape(footprint)).ShowModal()
+                    CorrectionManagerDialog(self, "^" + re.escape(footprint)).ShowModal()
             elif e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_NAME:
                 if value := self.partlist_data_model.get_value(item):
-                    RotationManagerDialog(self, re.escape(value)).ShowModal()
+                    CorrectionManagerDialog(self, re.escape(value)).ShowModal()
 
     def save_all_mappings(self, *_):
         """Save all mappings."""
@@ -988,19 +988,19 @@ class JLCPCBTools(wx.Dialog):
         right_click_menu.Append(paste_lcsc)
         right_click_menu.Bind(wx.EVT_MENU, self.paste_part_lcsc, paste_lcsc)
 
-        rotation_by_package = wx.MenuItem(
+        correction_by_package = wx.MenuItem(
             right_click_menu,
             ID_CONTEXT_MENU_ADD_ROT_BY_PACKAGE,
-            "Add Rotation by package",
+            "Add Correction by package",
         )
-        right_click_menu.Append(rotation_by_package)
-        right_click_menu.Bind(wx.EVT_MENU, self.add_rotation, rotation_by_package)
+        right_click_menu.Append(correction_by_package)
+        right_click_menu.Bind(wx.EVT_MENU, self.add_correction, correction_by_package)
 
-        rotation_by_name = wx.MenuItem(
-            right_click_menu, ID_CONTEXT_MENU_ADD_ROT_BY_NAME, "Add Rotation by name"
+        correction_by_name = wx.MenuItem(
+            right_click_menu, ID_CONTEXT_MENU_ADD_ROT_BY_NAME, "Add Correction by name"
         )
-        right_click_menu.Append(rotation_by_name)
-        right_click_menu.Bind(wx.EVT_MENU, self.add_rotation, rotation_by_name)
+        right_click_menu.Append(correction_by_name)
+        right_click_menu.Bind(wx.EVT_MENU, self.add_correction, correction_by_name)
 
         find_mapping = wx.MenuItem(
             right_click_menu, ID_CONTEXT_MENU_FIND_MAPPING, "Find LCSC from Mappings"


### PR DESCRIPTION
Implements/Fixes #418

Renamed the rotations.db file to corrections.db to reflect the more general correction approach.
Implemented update logic to convert existing rotation databases to the new correction database (setting the offsets to 0 in this case).
The online corrections file already contains offsets, these are imported.

Some notes about things I am unsure about:

* While implementing this, I noticed that there is a `rotation` table created in the parts.db. This table seems to be never used thus I removed the table creation. (see change of jlcparts_db_convert.py)
* I’m not 100% sure if the code works with KiCAD before version 8, I especially unsure if the usage of wxPoint in fabrication.py is the correct way to do what I do there.
* The new code automatically imports the previous rotations.db. I tried to modify all code (e.g.  import/export) in a way that does not break existing workflows. Obviously exporting now includes two additional columns but importing still accepts files that do not contain offset information (setting those to 0/0).
* I tried to match the code style as best as I could but Python not my day-to-day language so please bear with me.
