### PR TITLE
Board local corrections

### DIFF
--- a/corrections.py
+++ b/corrections.py
@@ -441,7 +441,7 @@ class CorrectionManagerDialog(wx.Dialog):
                 wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
             )
         result = dialog.ShowModal()
-        
+
         if result == wx.ID_NO:
             self.global_corrections.SetValue(self.parent.library.uses_global_correction_database())
             return

--- a/corrections.py
+++ b/corrections.py
@@ -293,12 +293,31 @@ class CorrectionManagerDialog(wx.Dialog):
         )
         self.export_button.SetBitmapMargins((2, 0))
 
+        self.global_corrections = wx.CheckBox(
+            self,
+            id=wx.ID_ANY,
+            label="Use global corrections",
+            pos=wx.DefaultPosition,
+            size=wx.DefaultSize,
+            style=0,
+            name="corrections_global_corrections",
+        )
+
+        self.global_corrections.SetToolTip(
+            wx.ToolTip("Whether the global corrections database is used or a project local one")
+        )
+        self.global_corrections.Bind(wx.EVT_CHECKBOX, self.on_global_corrections_changed)
+        self.global_corrections.SetValue(self.parent.library.uses_global_correction_database())
+
         tool_sizer = wx.BoxSizer(wx.VERTICAL)
         tool_sizer.Add(self.save_button, 0, wx.ALL, 5)
         tool_sizer.Add(self.delete_button, 0, wx.ALL, 5)
         tool_sizer.Add(self.update_button, 0, wx.ALL, 5)
         tool_sizer.Add(self.import_button, 0, wx.ALL, 5)
         tool_sizer.Add(self.export_button, 0, wx.ALL, 5)
+        tool_sizer.AddStretchSpacer()
+        tool_sizer.Add(self.global_corrections, 0, wx.ALL, 5)
+
         table_sizer.Add(tool_sizer, 3, wx.EXPAND, 5)
 
         # ---------------------------------------------------------------------
@@ -403,6 +422,34 @@ class CorrectionManagerDialog(wx.Dialog):
             self.enable_toolbar_buttons(True)
         else:
             self.enable_toolbar_buttons(False)
+
+    def on_global_corrections_changed(self, use_global):
+        """Switch between global or local correction database file."""
+        if self.parent.library.uses_global_correction_database():
+            dialog = wx.MessageDialog(
+                self,
+                "Do you want to switch to the local corrections database?",
+                "Switching corrections database",
+                wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION
+            )
+            dialog.ExtendedMessage = "Switching to a board local database copies the current global database."
+        else:
+            dialog = wx.MessageDialog(
+                self,
+                "Do you want to switch to the global corrections database?",
+                "Switching corrections database",
+                wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
+            )
+        result = dialog.ShowModal()
+        
+        if result == wx.ID_NO:
+            self.global_corrections.SetValue(self.parent.library.uses_global_correction_database())
+            return
+
+        self.parent.library.switch_to_global_correction_database(not self.parent.library.uses_global_correction_database())
+        self.populate_corrections_list()
+        wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        self.global_corrections.SetValue(self.parent.library.uses_global_correction_database())
 
     def download_correction_data(self, *_):
         """Fetch the latest rotation correction table from Matthew Lai's JLCKicadTool repo."""

--- a/library.py
+++ b/library.py
@@ -96,7 +96,10 @@ class Library:
             self.migrate_mappings()
 
     def uses_global_correction_database(self):
-        """Checks if there is a board specific corrections database or not. Returns True if the global database is used."""
+        """Check if there is a board specific corrections database or not.
+
+        Returns True if the global database is used.
+        """
 
         try:
             with contextlib.closing(
@@ -111,7 +114,7 @@ class Library:
                 return result[0] != 1
         except sqlite3.OperationalError:
             return True
-            
+
         return True
 
     def switch_to_global_correction_database(self, use_global):

--- a/library.py
+++ b/library.py
@@ -50,7 +50,9 @@ class Library:
         self.datadir = os.path.join(PLUGIN_PATH, "jlcpcb")
         self.partsdb_file = os.path.join(self.datadir, "parts-fts5.db")
         self.rotationsdb_file = os.path.join(self.datadir, "rotations.db")
-        self.correctionsdb_file = os.path.join(self.datadir, "corrections.db")
+        self.localcorrectionsdb_file = os.path.join(self.parent.project_path, "jlcpcb", "project.db")
+        self.globalcorrectionsdb_file = os.path.join(self.datadir, "corrections.db")
+        self.correctionsdb_file = self.globalcorrectionsdb_file if self.uses_global_correction_database() else self.localcorrectionsdb_file
         self.mappingsdb_file = os.path.join(self.datadir, "mappings.db")
         self.state = None
         self.category_map = {}
@@ -92,6 +94,51 @@ class Library:
         ):
             self.create_mapping_table()
             self.migrate_mappings()
+
+    def uses_global_correction_database(self):
+        """Checks if there is a board specific corrections database or not. Returns True if the global database is used."""
+
+        try:
+            with contextlib.closing(
+                sqlite3.connect(self.localcorrectionsdb_file)
+            ) as ldb, ldb as lcur:
+                result = lcur.execute(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='correction')"
+                ).fetchone()
+                if not result:
+                    return True
+
+                return result[0] != 1
+        except sqlite3.OperationalError:
+            return True
+            
+        return True
+
+    def switch_to_global_correction_database(self, use_global):
+        """Switches to global or board local database."""
+
+        currently_using_global = self.correctionsdb_file == self.globalcorrectionsdb_file
+        if currently_using_global == use_global:
+            return
+
+        if use_global:
+            try:
+                with contextlib.closing(
+                    sqlite3.connect(self.localcorrectionsdb_file)
+                ) as con, con as cur:
+                    cur.execute("DROP TABLE IF EXISTS correction")
+                    cur.commit()
+                self.correctionsdb_file = self.globalcorrectionsdb_file
+            except OSError:
+                self.logger.warning(
+                    "Failed to remove board local corrections file."
+                )
+        else:
+            global_corrections = self.get_all_correction_data()
+            self.correctionsdb_file = self.localcorrectionsdb_file
+            self.create_correction_table()
+            for regex, rotation, offset in global_corrections:
+                self.insert_correction_data(regex, rotation, offset)
 
     def set_order_by(self, n):
         """Set which value we want to order by when getting data from the database."""


### PR DESCRIPTION
Based on my other pull request (#583), I added an option to use project local corrections: By default the global corrections database is used but you can choose to use project local corrections. When doing so, the then current global corrections are copied into the project.db database and that data is used.

Returning to the global corrections database simply drops the correction table from the project.db (with an appropriate warning since all local corrections are lost).

The logic whether the local or global correction data is used is based on the existence of the correction table in project.db. If it exists, even empty, local correction data is used, if it does not exist, global correction data is used.

If you want to transfer the local corrections into the global corrections database, you can use export/import to do so.

Alternative considered: In my first attempt, I used a dedicated corrections.db file next to the project.db. I didn’t see any advantages in doing so.