### PR TITLE
Removed unused 'rotation' table from the parts database.

### DIFF
--- a/jlcparts_db_convert.py
+++ b/jlcparts_db_convert.py
@@ -244,15 +244,6 @@ class Jlcpcb(Generate):
             """
         )
 
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS rotation (
-                'regex',
-                'correction'
-            )
-            """
-        )
-
     def build(self):
         """Run all of the steps to generate the database files for upload."""
         self.remove_original()
@@ -313,15 +304,6 @@ class JlcpcbFTS5(Generate):
                 'partcount',
                 'date',
                 'last_update'
-            )
-            """
-        )
-
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS rotation (
-                'regex',
-                'correction'
             )
             """
         )


### PR DESCRIPTION
The 'rotation' table in the parts database is created but I cannot find any usage of it.
So I removed it.