### PR TITLE
refactor(schematic,version): refactor version handling

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,6 @@
 """Contains helper function used all over the plugin."""
 
+from distutils.version import LooseVersion
 import os
 import re
 
@@ -12,19 +13,20 @@ EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 
 
-def is_version8(version: str) -> bool:
-    """Check if version is 8 or 8 Nightly build."""
-    return any(v in version for v in ("8.0", "8.99"))
+def _is_version_in_range(version: str, min_version: str, max_version: str) -> bool:
+    """Check if version is in range."""
+    ver = LooseVersion(version)
+    return LooseVersion(min_version) <= ver < LooseVersion(max_version)
 
 
 def is_version7(version: str) -> bool:
     """Check if version is 7."""
-    return any(v in version for v in ("7.0"))
+    return _is_version_in_range(version, "6.99", "8.0")
 
 
 def is_version6(version: str) -> bool:
     """Check if version is 6."""
-    return any(v in version for v in ("6.0"))
+    return _is_version_in_range(version, "5.99", "7.0")
 
 
 def getWxWidgetsVersion():
@@ -146,6 +148,7 @@ def set_lcsc_value(fp, lcsc: str):
         fp.SetField("LCSC", lcsc)
         field = fp.GetFieldByName("LCSC")
         field.SetVisible(False)
+
 
 def get_valid_footprints(board):
     """Get all footprints that have a valid reference (drop all REF**)."""

--- a/schematicexport.py
+++ b/schematicexport.py
@@ -7,7 +7,7 @@ import re
 
 from pcbnew import GetBuildVersion  # pylint: disable=import-error
 
-from .helpers import is_version6, is_version7, is_version8
+from .helpers import is_version6, is_version7
 
 
 class SchematicExport:
@@ -21,20 +21,20 @@ class SchematicExport:
 
     def load_schematic(self, paths):
         """Load schematic file."""
-        if is_version8(GetBuildVersion()):
-            self.logger.info("Kicad 8+...")
+        if is_version6(GetBuildVersion()):
+            self.logger.info("Kicad 6...")
             for path in paths:
-                self._update_schematic8(path)
+                self._update_schematic6(path)
         elif is_version7(GetBuildVersion()):
             self.logger.info("Kicad 7...")
             for path in paths:
                 self._update_schematic7(path)
-        elif is_version6(GetBuildVersion()):
-            self.logger.info("Kicad 6...")
+        else:
+            self.logger.info("Kicad 8+...")
             for path in paths:
                 self._update_schematic(path)
 
-    def _update_schematic(self, path):
+    def _update_schematic6(self, path):
         """Only works with KiCad V6 files."""
         self.logger.info("Reading %s...", path)
         # Regex to look through schematic property, if we hit the pin section without finding a LCSC property, add it
@@ -185,8 +185,8 @@ class SchematicExport:
                 f.write(line + "\n")
         self.logger.info("Added LCSC's to %s (maybe?)", path)
 
-    def _update_schematic8(self, path):
-        """Only works with KiCad V8 files."""
+    def _update_schematic(self, path):
+        """Only works with KiCad V8+ files."""
         self.logger.info("Reading %s...", path)
         # Regex to look through schematic property, if we hit the pin section without finding a LCSC property, add it
         # keep track of property ids and Reference property location to use with new LCSC property
@@ -250,7 +250,7 @@ class SchematicExport:
                     if file_name not in files_seen:
                         files_seen.add(file_name)
                         dir_name = os.path.dirname(path)
-                        self._update_schematic8(os.path.join(dir_name, file_name))
+                        self._update_schematic(os.path.join(dir_name, file_name))
             # if we hit the pin section without finding a LCSC property, add it
             m3 = pinRx.search(inLine)
             if m3 and partSection:


### PR DESCRIPTION
- Invert the version logic. Try to search for versions 6 and 7 explicitly. For versions 8+ use the default mechanism. This will allow us to be compatible with newly builds.