### PR TITLE
Fix broken update parts database action

### DIFF
--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_and_update:
     name: "Update component database and frontend"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: github-pages
     steps:
       - name: Install dependencies
@@ -90,7 +90,7 @@ jobs:
           path: db_build/db_working
   deploy:
     name: "Deploy"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build_and_update
     permissions:
       actions: write


### PR DESCRIPTION
This is a fix for #612 

We already use `ubuntu-latest` in all the other GH actions, so I chaged `update_parts_database.yml` to use it as well.