### PR TITLE
Plausibility check

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -393,3 +393,25 @@ class Fabrication:
         self.logger.info(
             "Finished generating BOM file %s", os.path.join(self.outputdir, bomname)
         )
+
+    def check_plausibility(self) -> str:
+        """Check the plausibility of the parts, there should be just one value per LCSC number."""
+        lcsc_numbers = {}
+        for item in self.parent.store.read_bom_parts():
+            if not item["lcsc"]:
+                continue
+            if item["lcsc"] not in lcsc_numbers:
+                lcsc_numbers[item["lcsc"]] = [
+                    {"refs": item["refs"], "values": item["value"]}
+                ]
+            else:
+                lcsc_numbers[item["lcsc"]].append(
+                    {"refs": item["refs"], "values": item["value"]}
+                )
+        filtered = {key: value for key, value in lcsc_numbers.items() if len(value) > 1}
+        result = ""
+        for lcsc, items in filtered.items():
+            result += f"{lcsc}:\n"
+            for item in items:
+                result += f"  - {item['refs']} -> {item['values']}\n"
+        return result

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -985,7 +985,7 @@ class JLCPCBTools(wx.Dialog):
                     "JLC order/serial number placeholder",
                     wx.OK | wx.CANCEL | wx.CENTER,
                 )
-                if result == wx.ID_CANCEL:
+                if result == wx.CANCEL:
                     return
             elif count > 1:
                 result = wx.MessageBox(
@@ -993,7 +993,7 @@ class JLCPCBTools(wx.Dialog):
                     "JLC order/serial number placeholder",
                     wx.OK | wx.CANCEL | wx.CENTER,
                 )
-                if result == wx.ID_CANCEL:
+                if result == wx.CANCEL:
                     return
         self.fabrication.fill_zones()
         layer_selection = self.layer_selection.GetSelection()
@@ -1073,7 +1073,7 @@ class JLCPCBTools(wx.Dialog):
             "KiCad V6 Schematics (*.kicad_sch)|*.kicad_sch",
             wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE,
         ) as openFileDialog:
-            if openFileDialog.ShowModal() == wx.ID_CANCEL:
+            if openFileDialog.ShowModal() == wx.CANCEL:
                 return
             paths = openFileDialog.GetPaths()
             SchematicExport(self).load_schematic(paths)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -965,6 +965,18 @@ class JLCPCBTools(wx.Dialog):
 
     def generate_fabrication_data(self, *_):
         """Generate fabrication data."""
+        warnings = self.fabrication.check_plausibility()
+        if warnings:
+            result = wx.MessageBox(
+                "There are items with identical LCSC number but different values in the list:\n"
+                + warnings
+                + "Continue?",
+                "Plausibility check",
+                wx.OK | wx.CANCEL | wx.CENTER,
+            )
+            if result == wx.CANCEL:
+                return
+
         if self.settings.get("general", {}).get("order_number"):
             count = self.count_order_number_placeholders()
             if count == 0:

--- a/store.py
+++ b/store.py
@@ -98,7 +98,7 @@ class Store:
             con.row_factory = dict_factory
             # Query all parts that are supposed to be in the BOM an have an lcsc number, group the references together
             subquery = "SELECT value, reference, footprint, lcsc FROM part_info WHERE exclude_from_bom = '0' AND lcsc != '' ORDER BY lcsc, reference"
-            query = f"SELECT value, GROUP_CONCAT(reference) AS refs, footprint, lcsc  FROM ({subquery}) GROUP BY lcsc"
+            query = f"SELECT value, GROUP_CONCAT(reference) AS refs, footprint, lcsc  FROM ({subquery}) GROUP BY value, lcsc"
             a = cur.execute(query).fetchall()
             # Query all parts that are supposed to be in the BOM but have no lcsc number
             query = "SELECT value, reference AS refs, footprint, lcsc FROM part_info WHERE exclude_from_bom = '0' AND lcsc = ''"


### PR DESCRIPTION
As requested in #560 this PR add a plausibility check.
It shows a warning message to the user if there are components with the same LCSC value but different values.

![grafik](https://github.com/user-attachments/assets/fbe237b1-128b-4809-ba86-698a4ae15cb1)


While creating this PR I stumbled upon an error in the SQL query https://github.com/Bouni/kicad-jlcpcb-tools/blob/0064a9217f8b1a5a0e012f71401458c9201afe98/store.py#L101

When we have a constelation like this

![grafik](https://github.com/user-attachments/assets/84777072-b417-49aa-ba8e-900dd4c28832)

We end up with a BOM that looks like this

![grafik](https://github.com/user-attachments/assets/c813bbf9-883b-4389-a7f1-f60d4777f958)

The Value LED_G is overwritten with LED_W

After the change we get this

![grafik](https://github.com/user-attachments/assets/573a0960-e588-4c3e-bffa-4e2911fd74de)

Which I thik is the correct output



And furthermore, I realized that we had a bunch of message boxes in the code that did a check after wards that looked like tis `result == wx.ID_CANCEL` in order to check if the user pressed cancel or ok.

This never worked because the result of the cancel button is `16`  and the value of wx.ID_CANCEL is `5101`.

The fix was to replace wx.ID_CANCEL with wx.CANCEL.

