### PR TITLE
Cmm jlcparts fetch - move jlcparts database fetching into the jlcparts_db_convert.py script

### DIFF
--- a/.github/workflows/update_parts_database.yml
+++ b/.github/workflows/update_parts_database.yml
@@ -47,23 +47,11 @@ jobs:
           echo "============================================================================================================================="
 
           cd db_build
-          mkdir -p db_working
-          cd db_working
 
-          wget -q https://yaqwsx.github.io/jlcparts/data/cache.zip
+          # fetch the cached database
+          python3 jlcparts_db_convert.py --fetch-parts-db --skip-generate
 
-          VOLUMES=$(7z l cache.zip | grep "Volume Index = " | grep -Eoh "[0-9]+")
-
-          for seq in $(seq 1 $VOLUMES); do
-            CACHE=$(printf '%02d' $seq)
-            wget -q https://yaqwsx.github.io/jlcparts/data/cache.z$CACHE || true
-          done
-
-          7z x cache.zip
-          rm -rf cache.z*
-
-          ls -lah
-          cd ..
+          ls -lah db_working/
 
           # Print the current disk usage, might help with future "no disk space left" issues
           echo "============================================================================================================================="

--- a/db_build/jlcparts_db_convert.py
+++ b/db_build/jlcparts_db_convert.py
@@ -695,6 +695,8 @@ def main(skip_cleanup: bool, skip_generate: bool):
     """Perform the database steps."""
 
     output_directory = "db_working"
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
     os.chdir(output_directory)
 
     if not skip_generate:

--- a/db_build/jlcparts_db_convert.py
+++ b/db_build/jlcparts_db_convert.py
@@ -684,37 +684,49 @@ def test_price_duplicate_price_filter():
     default=False,
     help="Disable cleanup, intermediate database files will not be deleted",
 )
-def main(skip_cleanup: bool):
-    """Generate the databases."""
+@click.option(
+    "--skip-generate",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Skip the DB generation phase",
+)
+def main(skip_cleanup: bool, skip_generate: bool):
+    """Perform the database steps."""
 
     output_directory = "db_working"
     os.chdir(output_directory)
 
-    # sqlite database
-    start = datetime.now()
-    output_name = "parts.db"
-    partsdb = Path(output_name)
+    if not skip_generate:
+        # sqlite database
+        start = datetime.now()
+        output_name = "parts.db"
+        partsdb = Path(output_name)
 
-    print(f"Generating {output_name} in {output_directory} directory")
-    generator = Jlcpcb(partsdb, skip_cleanup)
-    generator.build()
+        print(f"Generating {output_name} in {output_directory} directory")
+        generator = Jlcpcb(partsdb, skip_cleanup)
+        generator.build()
 
-    end = datetime.now()
-    deltatime = end - start
-    print(f"Elapsed time: {humanize.precisedelta(deltatime, minimum_unit='seconds')}")
+        end = datetime.now()
+        deltatime = end - start
+        print(
+            f"Elapsed time: {humanize.precisedelta(deltatime, minimum_unit='seconds')}"
+        )
 
-    # sqlite fts5 database
-    start = datetime.now()
-    output_name = "parts-fts5.db"
-    partsdb = Path(output_name)
+        # sqlite fts5 database
+        start = datetime.now()
+        output_name = "parts-fts5.db"
+        partsdb = Path(output_name)
 
-    print(f"Generating {output_name} in {output_directory} directory")
-    generator = JlcpcbFTS5(partsdb, skip_cleanup)
-    generator.build()
+        print(f"Generating {output_name} in {output_directory} directory")
+        generator = JlcpcbFTS5(partsdb, skip_cleanup)
+        generator.build()
 
-    end = datetime.now()
-    deltatime = end - start
-    print(f"Elapsed time: {humanize.precisedelta(deltatime, minimum_unit='seconds')}")
+        end = datetime.now()
+        deltatime = end - start
+        print(
+            f"Elapsed time: {humanize.precisedelta(deltatime, minimum_unit='seconds')}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This makes it easier to test jlcparts_db_convert.py as otherwise you end up having to find the GitHub workflow and run those steps manually in a shell. Now the GitHub workflow uses the jlcparts_db_convert.py script.