### PR TITLE
fix(version): make version checking more robust

### DIFF
--- a/core/version.py
+++ b/core/version.py
@@ -1,11 +1,14 @@
 """Contains helper function used all over the plugin."""
 
+import re
+
 from packaging.version import Version
 
 
 def _is_version_in_range(version: str, min_version: str, max_version: str) -> bool:
     """Check if version is in range. Must comply with https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers."""
-    ver = Version(version)
+    # Remove any trailing '.fc42', '+gXXXX', or similar after the first long segment
+    ver = Version(re.sub(r"([^-]+(?:-[^-]+)*)-.*", r"\1", version))
     return Version(min_version) <= ver < Version(max_version)
 
 

--- a/core/version.py
+++ b/core/version.py
@@ -23,6 +23,8 @@ def test_version():
     """Tests for the various is_versionX() functions."""
     v6 = "6.1"
     v7 = "7.0.1"
+    v72 = "7.0.2-2.fc42"
+    v7rc1 = "7.0.1-rc1-378-ge76fd128c3"
     v8 = "8.2.3"
     v9 = "9.0.1-rc1"
 
@@ -30,6 +32,8 @@ def test_version():
     assert not is_version6(v7)
 
     assert is_version7(v7)
+    assert is_version7(v72)
+    assert is_version7(v7rc1)
     assert not is_version7(v8)
 
     assert not is_version6(v8)


### PR DESCRIPTION
Versions like `9.0.2-2.fc42` or `7.0.0-rc1-378-ge76fd128c3` were causing an errors, so they have to be normalised before comparison.

/cc @slabua