### PR TITLE
fix(release): copy missing files into release archive

### DIFF
--- a/PCM/create_pcm_archive.sh
+++ b/PCM/create_pcm_archive.sh
@@ -19,6 +19,9 @@ cp *.py PCM/archive/plugins
 cp *.png PCM/archive/plugins
 cp settings.json PCM/archive/plugins
 cp -r icons PCM/archive/plugins
+cp -r lib PCM/archive/plugins
+mkdir PCM/archive/plugins/core
+cp core/*.py PCM/archive/plugins/core
 cp PCM/icon.png PCM/archive/resources
 cp PCM/metadata.template.json PCM/archive/metadata.json
 


### PR DESCRIPTION
The `version.py` file was missing as same as the own python packaging module from `lib` folder.