### PR TITLE
Fixed: If unregistering logging_handler1 fails, logging_handler2 was not unregistered.

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -538,6 +538,9 @@ class JLCPCBTools(wx.Dialog):
         root = logging.getLogger()
         try:
             root.removeHandler(self.logging_handler1)
+        except AttributeError:
+            pass
+        try:
             root.removeHandler(self.logging_handler2)
         except AttributeError:
             pass


### PR DESCRIPTION
The title says it all: If the unregister of logging_handler1 raises an exception, the logging_handler2 is not unregistered.