### PR TITLE
Changed CPL generation to move components with offset correction relative to component orientation.

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -3,8 +3,8 @@
 import csv
 from importlib import import_module
 import logging
-import os
 import math
+import os
 from pathlib import Path
 import re
 from zipfile import ZIP_DEFLATED, ZipFile


### PR DESCRIPTION
Components that have a offset configured in the corrections dialog were always moved based on the PCB coordinate system (left-right/top-bottom). This is correct for components that are placed in the 0° orientation but is incorrect when they are placed in different orientations.

For example, if you placed a USB connector at the left and right edge of the PCB, one at 90°, the other at -90°, and configured a 0.15 x-offset, both connectors were corrected toward the right edge, moving the left connector inward and the right connector outwards. With this patch, one is corrected upwards, the other downwards (since both are rotated by 90°, their X-axis is up/down).