### PR TITLE
Fit some formatting nitpicks in the db_convert

### DIFF
--- a/db_build/jlcparts_db_convert.py
+++ b/db_build/jlcparts_db_convert.py
@@ -15,7 +15,6 @@ import sqlite3
 import subprocess
 import sys
 import time
-from typing import Optional
 import urllib.request
 import zipfile
 from zipfile import ZipFile
@@ -27,9 +26,7 @@ import humanize
 class PriceEntry:
     """Price for a quantity range."""
 
-    def __init__(
-        self, min_quantity: int, max_quantity: Optional[int], price_dollars: str
-    ):
+    def __init__(self, min_quantity: int, max_quantity: int | None, price_dollars: str):
         self.min_quantity = min_quantity
         self.max_quantity = max_quantity
         self.price_dollars_str = price_dollars
@@ -53,7 +50,7 @@ class PriceEntry:
         return f"{self.min_quantity}-{self.max_quantity if self.max_quantity is not None else ''}:{self.price_dollars_str}"
 
     min_quantity: int
-    max_quantity: Optional[int]
+    max_quantity: int | None
     price_dollars_str: str  # to avoid rounding due to float conversion
     price_dollars: float
 
@@ -117,7 +114,7 @@ class Price:
         if len(entries) > 1:
             first = 0
             second = 1
-            f: Optional[PriceEntry] = None
+            f: PriceEntry | None = None
             while True:
                 if f is None:
                     f = copy.deepcopy(entries[first])
@@ -185,9 +182,21 @@ class Generate:
 
         self.part_count = 0
         print("Reading components")
-        res = self.conn_jp.execute(
-            "SELECT lcsc, category_id, mfr, package, joints, manufacturer_id, basic, description, datasheet, stock, price, extra FROM components"
-        )
+        res = self.conn_jp.execute("""
+            SELECT
+                lcsc,
+                category_id,
+                mfr,
+                package,
+                joints,
+                manufacturer_id,
+                basic,
+                description,
+                datasheet,
+                stock,
+                price,
+                extra
+            FROM components""")
         while True:
             comps = res.fetchmany(size=100000)
 
@@ -329,7 +338,7 @@ class Jlcpcb(Generate):
     def __init__(self, output_db: Path, skip_cleanup: bool = False):
         chunk_num = Path("chunk_num.txt")
         self.skip_cleanup = skip_cleanup
-        super().__init__(output_db, chunk_num)
+        super().__init__(output_db=output_db, chunk_num=chunk_num)
 
     def create_tables(self):
         """Create the tables in the output database."""
@@ -404,7 +413,7 @@ class JlcpcbFTS5(Generate):
     def __init__(self, output_db: Path, skip_cleanup: bool = False):
         chunk_num = Path("chunk_num_fts5.txt")
         self.skip_cleanup = skip_cleanup
-        super().__init__(output_db, chunk_num)
+        super().__init__(output_db=output_db, chunk_num=chunk_num)
 
     def create_tables(self):
         """Create tables."""
@@ -486,9 +495,21 @@ class JlcpcbFTS5(Generate):
 
         self.part_count = 0
         print("Reading components")
-        res = self.conn_jp.execute(
-            "SELECT lcsc, category_id, mfr, package, joints, manufacturer_id, basic, description, datasheet, stock, price, extra FROM components"
-        )
+        res = self.conn_jp.execute("""
+            SELECT
+                lcsc,
+                category_id,
+                mfr,
+                package,
+                joints,
+                manufacturer_id,
+                basic,
+                description,
+                datasheet,
+                stock,
+                price,
+                extra
+            FROM components""")
         while True:
             comps = res.fetchmany(size=100000)
 
@@ -868,7 +889,7 @@ def main(skip_cleanup: bool, fetch_parts_db: bool, skip_generate: bool):
         partsdb = Path(output_name)
 
         print(f"Generating {output_name} in {output_directory} directory")
-        generator = Jlcpcb(partsdb, skip_cleanup)
+        generator = Jlcpcb(output_db=partsdb, skip_cleanup=skip_cleanup)
         generator.build()
 
         end = datetime.now()
@@ -883,7 +904,7 @@ def main(skip_cleanup: bool, fetch_parts_db: bool, skip_generate: bool):
         partsdb = Path(output_name)
 
         print(f"Generating {output_name} in {output_directory} directory")
-        generator = JlcpcbFTS5(partsdb, skip_cleanup)
+        generator = JlcpcbFTS5(output_db=partsdb, skip_cleanup=skip_cleanup)
         generator.build()
 
         end = datetime.now()


### PR DESCRIPTION

This fixes a few formatting nitpicks - specifically, I've run the 'Ruff: Fix auto-fixable issues' which got rid of
the use of Optional and switches to the "| None" style.  I've also made the select statements use more vertical
space to more easily see the select order, and made the arguments to the DB generators explicit rather than
order-dependent.
