### PR TITLE
Refactor DB generation to reduce duplication

### DIFF
--- a/db_build/jlcparts_db_convert.py
+++ b/db_build/jlcparts_db_convert.py
@@ -241,9 +241,9 @@ class Generate:
 
                 # The column names have spaces, so map them to placeholders without spaces
                 data = rows[0]
-                columns = ", ".join([f'"{k}"' for k in data.keys()])
+                columns = ", ".join([f'"{k}"' for k in data])
                 placeholders = ", ".join(
-                    [f":{k.replace(' ', '_').replace('.', '_')}" for k in data.keys()]
+                    [f":{k.replace(' ', '_').replace('.', '_')}" for k in data]
                 )
                 newrows = [
                     {k.replace(" ", "_").replace(".", "_"): v for k, v in row.items()}
@@ -533,6 +533,7 @@ class JlcpcbFTS5(Generate):
         )
 
     def price_entry_to_str(self, price: Price) -> str:
+        """Convert Price object to string for storage in the database."""
         price_entries = Price.reduce_precision(price.price_entries)
         self.stats["price_entries_total"] += len(price_entries)
         price_str: str = ""
@@ -566,6 +567,7 @@ class JlcpcbFTS5(Generate):
         return price_str
 
     def translate_row(self, c: sqlite3.Row) -> dict[str, Any]:
+        """Translate a row from the jlcparts db into the plugin db format."""
         price_str = self.price_entry_to_str(Price(json.loads(c["price"])))
         # default to 'description', override it with the 'description' property from
         # 'extra' if it exists
@@ -609,6 +611,7 @@ class JlcpcbFTS5(Generate):
         return row
 
     def display_stats(self):
+        """Print out some stats."""
         price_entries_total = self.stats["price_entries_total"]
         price_entries_deleted_total = self.stats["price_entries_deleted_total"]
         price_entries_duplicates_deleted_total = self.stats[
@@ -632,6 +635,7 @@ class JlcpcbFTS5(Generate):
         print("Done optimizing fts5 parts table")
 
     def post_build(self):
+        """Post build steps."""
         self.populate_categories()
         self.optimize()
 


### PR DESCRIPTION
I was working with this file to add Extended Preferred parts and do some speedups, and noticed
that there was quite a bit of duplication between the 'old' and 'new'(?) style databases.

It looks like a lot of changes, but I guess the github PR diff doesn't do move detection so it's
harder to tell that most of this is just shuffling some things around. The substantial changes are:

Changing the sqlite3 rowfactory to sqlite3.row - this makes it return (and accept) a dict with the column names as keys, rather than just having to remember what order you did your 'select' request. It's more verbose but hopefully less mistake prone and more self-documenting.
Moving the iteration of the source database into the base class, and having each subclass implement a row translation method that maps the incoming row from source into the destination row. I don't know enough about the history of this tool to know why there's a parts.db and parts-fts5 database. They seem to have the same columns, so it would simplify this further if it was possible to do the same row translation for each one (e.g. the FTS5 version does some more massaging of prices and descriptions, but maybe that's desirable for the older parts.db as well? LMK and I'm happy to make that change)
Moving the build steps into the base class with an optional per-class override to do post-build steps (e.g. the FTS5 version does the component table and optimization steps)
Using the click progress bar to track the import process rather than printing a bunch of messages every 100k lines.
As far as I can tell this creates more-or-less identical output on my machine. I did some diffs and noticed that the original had some extra spaces in descriptions but that was the only change I could see.

Output spam before: https://pastebin.com/ZZA3eJ9D
Output spam after: https://pastebin.com/qw9ux3nw

(Sorry for the extra work - I was getting annoyed at the merge/rebase and just decided to squash the merge on a new branch)