### PR TITLE
Remove support for the old parts DB (maybe fixes #629?)

### DIFF
--- a/db_build/jlcparts_db_convert.py
+++ b/db_build/jlcparts_db_convert.py
@@ -144,11 +144,17 @@ class Price:
 class Generate:
     """Base class for database generation."""
 
-    def __init__(self, output_db: Path, chunk_num: Path):
+    def __init__(
+        self,
+        output_db: Path,
+        chunk_num: Path = Path("chunk_num_fts5.txt"),
+        skip_cleanup: bool = False,
+    ):
         self.output_db = output_db
         self.jlcparts_db_name = "cache.sqlite3"
         self.compressed_output_db = f"{self.output_db}.zip"
         self.chunk_num = chunk_num
+        self.skip_cleanup = skip_cleanup
 
     def remove_original(self):
         """Remove the original output database."""
@@ -163,98 +169,6 @@ class Generate:
 
         # connection to the plugin db we want to write
         self.conn = sqlite3.connect(self.output_db)
-
-    def load_tables(self):
-        """Load the input data into the output database."""
-
-        # load the tables into memory
-        print("Reading manufacturers")
-        res = self.conn_jp.execute("SELECT * FROM manufacturers")
-        mans = dict(res.fetchall())
-
-        print("Reading categories")
-        res = self.conn_jp.execute("SELECT * FROM categories")
-        cats = {i: (c, sc) for i, c, sc in res.fetchall()}
-
-        res = self.conn_jp.execute("select count(*) from components")
-        results = res.fetchone()
-        print(f"{humanize.intcomma(results[0])} parts to import")
-
-        self.part_count = 0
-        print("Reading components")
-        res = self.conn_jp.execute("""
-            SELECT
-                lcsc,
-                category_id,
-                mfr,
-                package,
-                joints,
-                manufacturer_id,
-                basic,
-                description,
-                datasheet,
-                stock,
-                price,
-                extra
-            FROM components""")
-        while True:
-            comps = res.fetchmany(size=100000)
-
-            print(f"Read {humanize.intcomma(len(comps))} parts")
-
-            # if we have no more parts exit out of the loop
-            if len(comps) == 0:
-                break
-
-            self.part_count += len(comps)
-
-            # now extract the data from the jlcparts db and fill
-            # it into the plugin database
-            print("Building parts rows to insert")
-            rows = []
-            for c in comps:
-                price = json.loads(c[10])
-                price_str = ",".join(
-                    [
-                        f"{entry.get('qFrom')}-{entry.get('qTo') if entry.get('qTo') is not None else ''}:{entry.get('price')}"
-                        for entry in price
-                    ]
-                )
-
-                # default to 'description', override it with the 'description' property from
-                # 'extra' if it exists
-                description = c[7]
-                if c[11]:
-                    try:
-                        extra = json.loads(c[11])
-                        if "description" in extra:
-                            description = extra["description"]
-                    except Exception:
-                        pass
-
-                row = (
-                    f"C{c[0]}",  # LCSC Part
-                    cats[c[1]][0],  # First Category
-                    cats[c[1]][1],  # Second Category
-                    c[2],  # MFR.Part
-                    c[3],  # Package
-                    int(c[4]),  # Solder Joint
-                    mans[c[5]],  # Manufacturer
-                    "Basic" if c[6] else "Extended",  # Library Type
-                    description,  # Description
-                    c[8],  # Datasheet
-                    price_str,  # Price
-                    str(c[9]),  # Stock
-                )
-                rows.append(row)
-
-            print("Inserting into parts table")
-            self.conn.executemany(
-                "INSERT INTO parts VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows
-            )
-            self.conn.commit()
-
-        print("Done importing parts")
 
     def meta_data(self):
         """Populate the metadata table."""
@@ -330,90 +244,6 @@ class Generate:
 
         print(f"Deleting {self.output_db}")
         os.unlink(self.output_db)
-
-
-class Jlcpcb(Generate):
-    """Sqlite parts database generator."""
-
-    def __init__(self, output_db: Path, skip_cleanup: bool = False):
-        chunk_num = Path("chunk_num.txt")
-        self.skip_cleanup = skip_cleanup
-        super().__init__(output_db=output_db, chunk_num=chunk_num)
-
-    def create_tables(self):
-        """Create the tables in the output database."""
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS parts (
-                'LCSC Part',
-                'First Category',
-                'Second Category',
-                'MFR.Part',
-                'Package',
-                'Solder Joint',
-                'Manufacturer',
-                'Library Type',
-                'Description',
-                'Datasheet',
-                'Price',
-                'Stock'
-            )
-            """
-        )
-
-        self.conn.execute(
-            """
-            CREATE UNIQUE INDEX parts_lcsc_part_index
-                ON parts ('LCSC Part')
-            """
-        )
-
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS mapping (
-                'footprint',
-                'value',
-                'LCSC'
-            )
-            """
-        )
-
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS meta (
-                'filename',
-                'size',
-                'partcount',
-                'date',
-                'last_update'
-            )
-            """
-        )
-
-    def build(self):
-        """Run all of the steps to generate the database files for upload."""
-        self.remove_original()
-        self.connect_sqlite()
-        self.create_tables()
-        self.load_tables()
-        self.meta_data()
-        self.close_sqlite()
-        self.compress()
-        self.split()
-        self.display_stats()
-        if self.skip_cleanup:
-            print("Skipping cleanup")
-        else:
-            self.cleanup()
-
-
-class JlcpcbFTS5(Generate):
-    """FTS5 specific database generation."""
-
-    def __init__(self, output_db: Path, skip_cleanup: bool = False):
-        chunk_num = Path("chunk_num_fts5.txt")
-        self.skip_cleanup = skip_cleanup
-        super().__init__(output_db=output_db, chunk_num=chunk_num)
 
     def create_tables(self):
         """Create tables."""
@@ -885,26 +715,11 @@ def main(skip_cleanup: bool, fetch_parts_db: bool, skip_generate: bool):
     if not skip_generate:
         # sqlite database
         start = datetime.now()
-        output_name = "parts.db"
-        partsdb = Path(output_name)
-
-        print(f"Generating {output_name} in {output_directory} directory")
-        generator = Jlcpcb(output_db=partsdb, skip_cleanup=skip_cleanup)
-        generator.build()
-
-        end = datetime.now()
-        deltatime = end - start
-        print(
-            f"Elapsed time: {humanize.precisedelta(deltatime, minimum_unit='seconds')}"
-        )
-
-        # sqlite fts5 database
-        start = datetime.now()
         output_name = "parts-fts5.db"
         partsdb = Path(output_name)
 
         print(f"Generating {output_name} in {output_directory} directory")
-        generator = JlcpcbFTS5(output_db=partsdb, skip_cleanup=skip_cleanup)
+        generator = Generate(output_db=partsdb, skip_cleanup=skip_cleanup)
         generator.build()
 
         end = datetime.now()


### PR DESCRIPTION

Based on the conversation in PR  https://github.com/Bouni/kicad-jlcpcb-tools/pull/674, it sounds like it's time to remove support for the old parts.db - it's been several years since the switch to FTS5.  I think that the old parts.db won't be deleted anyway, it'll just stop updating it.

This PR removes support for the old database which allows the code to be simpler, and obsoletes PR https://github.com/Bouni/kicad-jlcpcb-tools/pull/674 since there's a lot less refactoring to be done.   It just squashes the base class + JlcpcbFTS5 classes together into one, and removes the Jlcpcb class.

I'll follow up with PRs to add the sqlite3.row interface and maybe the progress bar change. 
