### PR TITLE
fabrication.py Export PasteLayers per JLCPCB recommendations

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -18,10 +18,12 @@ from pcbnew import (  # pylint: disable=import-error
     ZONE_FILLER,
     B_Cu,
     B_Mask,
+    B_Paste,
     B_SilkS,
     Edge_Cuts,
     F_Cu,
     F_Mask,
+    F_Paste,
     F_SilkS,
     FromMM,
     Refresh,
@@ -216,12 +218,14 @@ class Fabrication:
             ("CuTop", F_Cu, "Top layer"),
             ("SilkTop", F_SilkS, "Silk top"),
             ("MaskTop", F_Mask, "Mask top"),
+            ("PasteTop", F_Paste, "Paste top"),
         ]
         plot_plan_bottom = [
             ("CuBottom", B_Cu, "Bottom layer"),
             ("SilkBottom", B_SilkS, "Silk bottom"),
             ("MaskBottom", B_Mask, "Mask bottom"),
             ("EdgeCuts", Edge_Cuts, "Edges"),
+            ("PasteBottom", B_Paste, "Paste bottom"),
         ]
 
         plot_plan = []


### PR DESCRIPTION
Export Paste layers

1) The JLCPCB KiCad Export guide says they should be exported: https://jlcpcb.com/help/article/how-to-generate-gerber-and-drill-files-in-kicad-8
2) I recently had a review where they mentioned the missing paste files

Fixes #662 and #632