### PR TITLE
Flag guard population of preferred parts

### DIFF
--- a/db_build/jlcparts_db_convert.py
+++ b/db_build/jlcparts_db_convert.py
@@ -149,6 +149,7 @@ class Generate:
         output_db: Path,
         chunk_num: Path = Path("chunk_num_fts5.txt"),
         obsolete_parts_threshold_days: int = 0,
+        populate_preferred_extended: bool = False,
         skip_cleanup: bool = False,
     ):
         self.output_db = output_db
@@ -157,6 +158,7 @@ class Generate:
         self.chunk_num = chunk_num
         self.skip_cleanup = skip_cleanup
         self.obsolete_parts_threshold_days = obsolete_parts_threshold_days
+        self.populate_preferred_extended = populate_preferred_extended
 
     def remove_original(self):
         """Remove the original output database."""
@@ -316,12 +318,11 @@ class Generate:
             """
         )
 
-    @staticmethod
-    def library_type(row: sqlite3.Row) -> str:
+    def library_type(self, row: sqlite3.Row) -> str:
         """Return library type string."""
         if row["basic"]:
             return "Basic"
-        if row["preferred"]:
+        if row["preferred"] and self.populate_preferred_extended:
             return "Preferred"
         return "Extended"
 
@@ -655,11 +656,19 @@ def test_price_duplicate_price_filter():
         in the source parts database for at least this many days.
     """,
 )
+@click.option(
+    "--populate-preferred-extended",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Populate 'Preferred' parts as 'Preferred' library type instead of 'Extended'",
+)
 def main(
     skip_cleanup: bool,
     fetch_parts_db: bool,
     skip_generate: bool,
     obsolete_parts_threshold_days: int,
+    populate_preferred_extended: bool,
 ):
     """Perform the database steps."""
 
@@ -778,6 +787,7 @@ def main(
             output_db=partsdb,
             skip_cleanup=skip_cleanup,
             obsolete_parts_threshold_days=obsolete_parts_threshold_days,
+            populate_preferred_extended=populate_preferred_extended,
         )
         generator.build()
 


### PR DESCRIPTION
I realized that there might be an ordering problem with PR#681, where the parts converter will start
marking parts as 'Preferred' before clients know how to deal with it, meaning that these components
will disappear from searches unless the 'Basic' and 'Extended' boxes are both unchecked.

This flag guards the generation of the 'Preferred' library type -- I think what I'll do is create a new database
name that selects the preferred parts, and update the client to use the new database name while maintaining the
parts-ft5.db file as the backwards compatibility option.  I'll do that in a followup PR but wanted to fix this
before it breaks things.

After running without the flag:
sqlite> select `Library Type`, count(*) from parts group by 1;
Basic|351
Extended|7035887

With the flag:
sqlite> select `Library Type`, count(*) from parts group by 1;
Basic|351
Extended|7034887
Preferred|1000

(Also there's a separate bug In the upstream about  identifying preferred parts that I've sent a PR for)



