### PR TITLE
Fixes for part assignment, order by Stock by default DESC

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -130,8 +130,9 @@ def set_lcsc_value(fp, lcsc: str):
         fp.SetField(lcsc_field.GetName(), lcsc)
     else:
         fp.SetField("LCSC", lcsc)
-        field = fp.GetFieldByName("LCSC")
-        field.SetVisible(False)
+        if hasattr(fp, "GetFieldByName"):
+            field = fp.GetFieldByName("LCSC")
+            field.SetVisible(False)
 
 
 def get_valid_footprints(board):

--- a/library.py
+++ b/library.py
@@ -45,8 +45,8 @@ class Library:
     def __init__(self, parent):
         self.logger = logging.getLogger(__name__)
         self.parent = parent
-        self.order_by = "LCSC Part"
-        self.order_dir = "ASC"
+        self.order_by = "Stock"
+        self.order_dir = "DESC"
         self.datadir = os.path.join(PLUGIN_PATH, "jlcpcb")
         self.partsdb_file = os.path.join(self.datadir, "parts-fts5.db")
         self.rotationsdb_file = os.path.join(self.datadir, "rotations.db")

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -628,7 +628,7 @@ class JLCPCBTools(wx.Dialog):
                 reference, e.lcsc, e.type, e.stock, params
             )
 
-    def display_message(self, e):
+    def display_message(self, e: wx.PyEvent) -> None:
         """Dispaly a message with the data from the event."""
         styles = {
             "info": wx.ICON_INFORMATION,
@@ -906,10 +906,11 @@ class JLCPCBTools(wx.Dialog):
                 if value.endswith("R") or value.endswith("r") or value.endswith("o"):
                     value = value[:-1]
                 value += "Ω"
-            m = re.search(r"_(\d+)_\d+Metric", footprint)
+            m = re.search(r"(R|L|C|LED|D)_(\d{4})", footprint)
             if m:
-                value += f" {m.group(1)}"
+                value += f" {m.group(2)}"
             selection[ref] = value
+        print(selection)
         PartSelectorDialog(self, selection).ShowModal()
 
     def count_order_number_placeholders(self):

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -910,7 +910,6 @@ class JLCPCBTools(wx.Dialog):
             if m:
                 value += f" {m.group(2)}"
             selection[ref] = value
-        print(selection)
         PartSelectorDialog(self, selection).ShowModal()
 
     def count_order_number_placeholders(self):

--- a/partselector.py
+++ b/partselector.py
@@ -16,7 +16,7 @@ from .partdetails import PartDetailsDialog
 class PartSelectorDialog(wx.Dialog):
     """The part selector window."""
 
-    def __init__(self, parent, parts):
+    def __init__(self, parent, parts: dict[str, str]):
         wx.Dialog.__init__(
             self,
             parent,

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"partselector": {"basic": false, "extended": false, "preferred": true, "stock": false}, "gerber": {"tented_vias": true, "fill_zones": false, "plot_values": true, "plot_references": true, "lcsc_bom_cpl": true}, "general": {"lcsc_priority": false, "order_number": true}}
+{"partselector": {"basic": true, "extended": true, "preferred": true, "stock": false}, "gerber": {"tented_vias": true, "fill_zones": false, "plot_values": true, "plot_references": true, "lcsc_bom_cpl": true}, "general": {"lcsc_priority": false, "order_number": true}}


### PR DESCRIPTION
When assigning parts, I had to click twice, turns out there was an exception when looking for the LCSC attribute, which seems is not set instantly.