### PR TITLE
Parts selector refactor: Bundle column<->db mapping in a struct

### DIFF
--- a/datamodel.py
+++ b/datamodel.py
@@ -6,6 +6,7 @@ import re
 import wx.dataview as dv
 
 from .helpers import loadIconScaled
+from .partselector_columns import COLUMN_INDEX, MODEL_COLUMN_TYPES
 
 
 class PartListDataModel(dv.PyDataViewModel):
@@ -245,18 +246,7 @@ class PartSelectorDataModel(dv.PyDataViewModel):
     def __init__(self):
         super().__init__()
         self.data = []
-        self.columns = {
-            "LCSC_COL": 0,
-            "MFR_NUMBER_COL": 1,
-            "PACKAGE_COL": 2,
-            "PIN_COL": 3,
-            "TYPE_COL": 4,
-            "PARAMS_COL": 5,
-            "STOCK_COL": 6,
-            "MFR_COL": 7,
-            "DESCR_COL": 8,
-            "PRICE_COL": 9,
-        }
+        self.columns = dict(COLUMN_INDEX)
 
         self.logger = logging.getLogger(__name__)
 
@@ -274,18 +264,7 @@ class PartSelectorDataModel(dv.PyDataViewModel):
 
     def GetColumnType(self, col):
         """Get type of each column."""
-        columntypes = (
-            "string",
-            "string",
-            "string",
-            "string",
-            "string",
-            "string",
-            "string",
-            "string",
-            "string",
-        )
-        return columntypes[col]
+        return MODEL_COLUMN_TYPES[col]
 
     def GetChildren(self, parent, children):
         """Get child items of a parent."""
@@ -350,12 +329,12 @@ class PartSelectorDataModel(dv.PyDataViewModel):
 
     def get_lcsc(self, item):
         """Get the reference of an item."""
-        return self.ItemToObject(item)[self.columns["LCSC_COL"]]
+        return self.ItemToObject(item)[self.columns["lcsc"]]
 
     def get_type(self, item):
         """Get the reference of an item."""
-        return self.ItemToObject(item)[self.columns["TYPE_COL"]]
+        return self.ItemToObject(item)[self.columns["type"]]
 
     def get_stock(self, item):
         """Get the reference of an item."""
-        return self.ItemToObject(item)[self.columns["STOCK_COL"]]
+        return self.ItemToObject(item)[self.columns["stock"]]

--- a/library.py
+++ b/library.py
@@ -20,6 +20,7 @@ from .events import (
     MessageEvent,
 )
 from .helpers import PLUGIN_PATH, dict_factory, natural_sort_collation
+from .partselector_columns import DB_FIELDS, SORTABLE_COLUMN_INDEX_TO_DB
 from .unzip_parts import unzip_parts
 
 
@@ -157,21 +158,13 @@ class Library:
 
     def set_order_by(self, n):
         """Set which value we want to order by when getting data from the database."""
-        order_by = [
-            "LCSC Part",
-            "MFR.Part",
-            "Package",
-            "Solder Joint",
-            "Library Type",
-            "Stock",
-            "Manufacturer",
-            "Description",
-            "Price",
-        ]
-        if self.order_by == order_by[n] and self.order_dir == "ASC":
+        column = SORTABLE_COLUMN_INDEX_TO_DB.get(n)
+        if column is None:
+            return
+        if self.order_by == column and self.order_dir == "ASC":
             self.order_dir = "DESC"
         else:
-            self.order_by = order_by[n]
+            self.order_by = column
             self.order_dir = "ASC"
 
     def search(self, parameters):
@@ -185,21 +178,8 @@ class Library:
         ):
             return []
 
-        # Note: this must mach the widget order in PartSelectorDialog init and
-        # populate_part_list in parselector.py
-        columns = [
-            "LCSC Part",
-            "MFR.Part",
-            "Package",
-            "Solder Joint",
-            "Library Type",
-            "Stock",
-            "Manufacturer",
-            "Description",
-            "Price",
-            "First Category",
-        ]
-        s = ",".join(f'"{c}"' for c in columns)
+        # Note: must match the shared part selector column definitions.
+        s = ",".join(f'"{c}"' for c in DB_FIELDS)
         query = f"SELECT {s} FROM parts WHERE "
 
         match_chunks = []

--- a/partselector.py
+++ b/partselector.py
@@ -11,6 +11,7 @@ from .derive_params import params_for_part  # pylint: disable=import-error
 from .events import AssignPartsEvent, UpdateSetting
 from .helpers import HighResWxSize, loadBitmapScaled
 from .partdetails import PartDetailsDialog
+from .partselector_columns import DB_FIELDS, PARTSELECTOR_COLUMNS
 
 
 class PartSelectorDialog(wx.Dialog):
@@ -438,88 +439,20 @@ class PartSelectorDialog(wx.Dialog):
             table_scroller,
             style=wx.BORDER_THEME | dv.DV_ROW_LINES | dv.DV_VERT_RULES | dv.DV_SINGLE,
         )
-
-        lcsc = self.part_list.AppendTextColumn(
-            "LCSC",
-            0,
-            width=int(parent.scale_factor * 60),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_CENTER,
-        )
-        mfr_number = self.part_list.AppendTextColumn(
-            "MFR Number",
-            1,
-            width=int(parent.scale_factor * 140),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_LEFT,
-        )
-        package = self.part_list.AppendTextColumn(
-            "Package",
-            2,
-            width=int(parent.scale_factor * 100),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_LEFT,
-        )
-        pins = self.part_list.AppendTextColumn(
-            "Pins",
-            3,
-            width=int(parent.scale_factor * 40),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_CENTER,
-        )
-        parttype = self.part_list.AppendTextColumn(
-            "Type",
-            4,
-            width=int(parent.scale_factor * 50),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_LEFT,
-        )
-        params = self.part_list.AppendTextColumn(
-            "Params",
-            5,
-            width=int(parent.scale_factor * 150),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_CENTER,
-        )
-        stock = self.part_list.AppendTextColumn(
-            "Stock",
-            6,
-            width=int(parent.scale_factor * 50),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_CENTER,
-        )
-        mfr = self.part_list.AppendTextColumn(
-            "Manufacturer",
-            7,
-            width=int(parent.scale_factor * 100),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_LEFT,
-        )
-        description = self.part_list.AppendTextColumn(
-            "Description",
-            8,
-            width=int(parent.scale_factor * 300),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_LEFT,
-        )
-        price = self.part_list.AppendTextColumn(
-            "Price",
-            9,
-            width=int(parent.scale_factor * 100),
-            mode=dv.DATAVIEW_CELL_INERT,
-            align=wx.ALIGN_LEFT,
-        )
-
-        lcsc.SetSortable(True)
-        mfr_number.SetSortable(True)
-        package.SetSortable(True)
-        pins.SetSortable(True)
-        parttype.SetSortable(True)
-        params.SetSortable(True)
-        stock.SetSortable(True)
-        mfr.SetSortable(True)
-        description.SetSortable(True)
-        price.SetSortable(True)
+        align_map = {
+            "left": wx.ALIGN_LEFT,
+            "center": wx.ALIGN_CENTER,
+        }
+        for idx, column in enumerate(PARTSELECTOR_COLUMNS):
+            view_col = self.part_list.AppendTextColumn(
+                column.label,
+                idx,
+                width=int(parent.scale_factor * column.width),
+                mode=dv.DATAVIEW_CELL_INERT,
+                align=align_map[column.align],
+            )
+            if column.sortable:
+                view_col.SetSortable(True)
 
         self.part_list.Bind(dv.EVT_DATAVIEW_SELECTION_CHANGED, self.OnPartSelected)
         self.part_list.Bind(dv.EVT_DATAVIEW_ITEM_ACTIVATED, self.select_part)
@@ -729,20 +662,30 @@ class PartSelectorDialog(wx.Dialog):
         else:
             self.result_count.SetLabel(f"{count} Results in {search_duration_text}")
         for p in parts:
-            item = [str(c) for c in p]
-            pricecol = 8  # Must match order in library.py search function
-            price = round(self.get_price(len(self.parts), item[pricecol]), 3)
+            db_row = {field: str(value) for field, value in zip(DB_FIELDS, p)}
+            price = round(self.get_price(len(self.parts), db_row.get("Price", "")), 3)
             if price > 0:
                 sum = round(price * len(self.parts), 3)
-                item[pricecol] = (
+                db_row["Price"] = (
                     f"{len(self.parts)} parts: ${price} each / ${sum} total"
                 )
             else:
-                item[pricecol] = "Error in price data"
+                db_row["Price"] = "Error in price data"
             params = params_for_part(
-                {"description": item[7], "category": item[9], "package": item[2]}
+                {
+                    "description": db_row.get("Description", ""),
+                    "category": db_row.get("First Category", ""),
+                    "package": db_row.get("Package", ""),
+                }
             )
-            item.insert(5, params)
+            item = []
+            for column in PARTSELECTOR_COLUMNS:
+                if column.key == "params":
+                    item.append(params)
+                elif column.db_field:
+                    item.append(db_row.get(column.db_field, ""))
+                else:
+                    item.append("")
             self.part_list_model.AddEntry(item)
 
     def select_part(self, *_):

--- a/partselector_columns.py
+++ b/partselector_columns.py
@@ -1,0 +1,52 @@
+"""Shared column definitions for the part selector UI and queries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PartSelectorColumn:
+    """Column metadata for the part selector list."""
+
+    key: str
+    label: str
+    db_field: str | None
+    width: int
+    align: str
+    sortable: bool = True
+    model_type: str = "string"
+
+
+PARTSELECTOR_COLUMNS: list[PartSelectorColumn] = [
+    PartSelectorColumn("lcsc", "LCSC", "LCSC Part", 60, "center"),
+    PartSelectorColumn("mfr_number", "MFR Number", "MFR.Part", 140, "left"),
+    PartSelectorColumn("package", "Package", "Package", 100, "left"),
+    PartSelectorColumn("pins", "Pins", "Solder Joint", 40, "center"),
+    PartSelectorColumn("type", "Type", "Library Type", 50, "left"),
+    PartSelectorColumn("params", "Params", None, 150, "center", sortable=False),
+    PartSelectorColumn("stock", "Stock", "Stock", 50, "center"),
+    PartSelectorColumn("mfr", "Manufacturer", "Manufacturer", 100, "left"),
+    PartSelectorColumn("description", "Description", "Description", 300, "left"),
+    PartSelectorColumn("price", "Price", "Price", 100, "left"),
+]
+
+EXTRA_DB_FIELDS: list[str] = ["First Category"]
+
+DB_FIELDS: list[str] = [
+    c.db_field for c in PARTSELECTOR_COLUMNS if c.db_field is not None
+] + EXTRA_DB_FIELDS
+
+COLUMN_INDEX: dict[str, int] = {
+    column.key: idx for idx, column in enumerate(PARTSELECTOR_COLUMNS)
+}
+
+SORTABLE_COLUMN_INDEX_TO_DB: dict[int, str] = {
+    idx: column.db_field
+    for idx, column in enumerate(PARTSELECTOR_COLUMNS)
+    if column.sortable and column.db_field is not None
+}
+
+MODEL_COLUMN_TYPES: list[str] = [column.model_type for column in PARTSELECTOR_COLUMNS]
+
+PARAMS_COLUMN_KEY = "params"


### PR DESCRIPTION
This reduces some boilerplate code and eliminates the need to remember and match index order when changing columns in the parts selector UI. The mappings are stored in partselector_coulumns.py which contains the mapping between the column name, the database source, and the UI parameters. (width, alignment, sortability, etc).

This isn't strictly necessary, but makes the following change (#714) a lot easier - when I was trying
to remove the pins column it was confusing since there was a lot of remembering index offsets.