### PR TITLE
Prevent the database download from triggering multiple times.

### DIFF
--- a/library.py
+++ b/library.py
@@ -6,7 +6,7 @@ import logging
 import os
 from pathlib import Path
 import sqlite3
-from threading import Thread
+from threading import Lock, Thread
 import time
 from typing import NamedTuple
 
@@ -73,6 +73,7 @@ class Library:
         )
         self.mappingsdb_file = os.path.join(self.datadir, "mappings.db")
         self.state = None
+        self.download_lock = Lock()
         self.category_map = {}
 
         self.logger.debug("partsdb_file %s", self.partsdb_file)
@@ -479,11 +480,40 @@ class Library:
 
     def update(self):
         """Update the sqlite parts database from the JLCPCB CSV."""
-        Thread(target=self.download).start()
+        with self.download_lock:
+            if self.state == LibraryState.DOWNLOAD_RUNNING:
+                self.logger.info(
+                    "Download already running, ignoring duplicate request."
+                )
+                return
+            self.state = LibraryState.DOWNLOAD_RUNNING
+        try:
+            Thread(target=self._download_wrapper).start()
+        except Exception:
+            with self.download_lock:
+                self.state = LibraryState.INITIALIZED
+            raise
+
+    def _download_wrapper(self):
+        """Run the download worker with guaranteed state cleanup."""
+        try:
+            self.download()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.exception("Unexpected error while downloading parts database")
+            wx.PostEvent(
+                self.parent,
+                MessageEvent(
+                    title="Download Error",
+                    text=f"Unexpected error while downloading parts database: {exc}",
+                    style="error",
+                ),
+            )
+        finally:
+            with self.download_lock:
+                self.state = LibraryState.INITIALIZED
 
     def download(self):
         """Actual worker thread that downloads and imports the parts data."""
-        self.state = LibraryState.DOWNLOAD_RUNNING
         start = time.time()
         wx.PostEvent(self.parent, DownloadStartedEvent())
 


### PR DESCRIPTION
I suspect several of the issues in the tracker are caused by the database download being triggered multiple times concurrently.  I think this is actually kind of easy to do because sometimes the download triggers
automatically on a new install and then you can press 'download' again resulting in a corrupted database
at the end.  

(Though some of the corruption issues are probably also the result of editing files on network drives, which is not supported by sqlite3)

Definite fix for:
#318

Possible fixes for:
#661
#668