### PR TITLE
Add DNP visibility to the UI

### DIFF
--- a/datamodel.py
+++ b/datamodel.py
@@ -24,9 +24,10 @@ class PartListDataModel(dv.PyDataViewModel):
             "STOCK_COL": 5,
             "BOM_COL": 6,
             "POS_COL": 7,
-            "ROT_COL": 8,
-            "SIDE_COL": 9,
-            "PARAMS_COL": 10,
+            "DNP_COL": 8,
+            "ROT_COL": 9,
+            "SIDE_COL": 10,
+            "PARAMS_COL": 11,
         }
 
         self.bom_pos_icons = [
@@ -74,6 +75,7 @@ class PartListDataModel(dv.PyDataViewModel):
             "string",
             "wxDataViewIconText",
             "wxDataViewIconText",
+            "wxDataViewIconText",
             "string",
             "wxDataViewIconText",
             "string",
@@ -102,6 +104,7 @@ class PartListDataModel(dv.PyDataViewModel):
         if col in [
             self.columns["BOM_COL"],
             self.columns["POS_COL"],
+            self.columns["DNP_COL"],
             self.columns["SIDE_COL"],
         ]:
             icon = row[col]
@@ -114,6 +117,7 @@ class PartListDataModel(dv.PyDataViewModel):
         if col in [
             self.columns["BOM_COL"],
             self.columns["POS_COL"],
+            self.columns["DNP_COL"],
             self.columns["SIDE_COL"],
         ]:
             return False
@@ -155,6 +159,9 @@ class PartListDataModel(dv.PyDataViewModel):
         )
         data[self.columns["POS_COL"]] = self.get_bom_pos_icon(
             data[self.columns["POS_COL"]]
+        )
+        data[self.columns["DNP_COL"]] = self.get_bom_pos_icon(
+            data[self.columns["DNP_COL"]]
         )
         data[self.columns["SIDE_COL"]] = self.get_side_icon(
             data[self.columns["SIDE_COL"]]

--- a/fabrication.py
+++ b/fabrication.py
@@ -32,6 +32,8 @@ from pcbnew import (  # pylint: disable=import-error
     wxPoint,
 )
 
+from .helpers import get_is_dnp
+
 # Compatibility hack for V6 / V7 / V7.99
 try:
     from pcbnew import DRILL_MARKS_NO_DRILL_SHAPE  # pylint: disable=import-error
@@ -340,6 +342,12 @@ class Fabrication:
             )
             footprints = sorted(self.board.Footprints(), key=lambda x: x.GetReference())
             for fp in footprints:
+                if get_is_dnp(fp):
+                    self.logger.info(
+                        "Component %s has 'Do not place' enabled: removing from CPL",
+                        fp.GetReference(),
+                    )
+                    continue
                 part = self.parent.store.get_part(fp.GetReference())
                 if not part:  # No matching part in the database, continue
                     continue

--- a/fabrication.py
+++ b/fabrication.py
@@ -383,37 +383,35 @@ class Fabrication:
         add_without_lcsc = self.parent.settings.get("gerber", {}).get(
             "lcsc_bom_cpl", True
         )
+        footprints = {fp.GetReference(): fp for fp in self.board.Footprints()}
         with open(
             os.path.join(self.outputdir, bomname), "w", newline="", encoding="utf-8"
         ) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(["Comment", "Designator", "Footprint", "LCSC", "Quantity"])
             for part in self.parent.store.read_bom_parts():
-                components = part["refs"].split(",")
-                for component in components:
-                    for fp in self.board.Footprints():
-                        if (
-                            fp.GetReference() == component
-                            and hasattr(fp, "IsDNP")
-                            and callable(fp.IsDNP)
-                            and fp.IsDNP()
-                        ):
-                            components.remove(component)
-                            part["refs"] = ",".join(components)
-                            self.logger.info(
-                                "Component %s has 'Do not place' enabled: removing from BOM",
-                                component,
-                            )
                 if not add_without_lcsc and not part["lcsc"]:
                     self.logger.info(
-                        "Component %s has no LCSC number assigned and the setting Add parts without LCSC is disabled: removing from BOM",
-                        component,
+                        "Component group %s has no LCSC number assigned and the setting Add parts without LCSC is disabled: removing from BOM",
+                        part["refs"],
                     )
+                    continue
+                components = []
+                for component in part["refs"].split(","):
+                    fp = footprints.get(component)
+                    if fp and get_is_dnp(fp):
+                        self.logger.info(
+                            "Component %s has 'Do not place' enabled: removing from BOM",
+                            component,
+                        )
+                        continue
+                    components.append(component)
+                if not components:
                     continue
                 writer.writerow(
                     [
                         part["value"],
-                        part["refs"],
+                        ",".join(components),
                         part["footprint"],
                         part["lcsc"],
                         len(components),

--- a/helpers.py
+++ b/helpers.py
@@ -177,6 +177,16 @@ def get_exclude_from_bom(footprint):
     return bool(get_bit(val, EXCLUDE_FROM_BOM))
 
 
+def get_is_dnp(footprint):
+    """Get the runtime 'Do not place' state of a footprint."""
+    if not footprint:
+        return False
+    is_dnp = getattr(footprint, "IsDNP", None)
+    if not callable(is_dnp):
+        return False
+    return bool(is_dnp())
+
+
 def toggle_exclude_from_pos(footprint):
     """Toggle the 'exclude from POS' property of a footprint."""
     if not footprint:

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -38,6 +38,7 @@ from .helpers import (
     PLUGIN_PATH,
     GetScaleFactor,
     HighResWxSize,
+    get_is_dnp,
     getVersion,
     loadBitmapScaled,
     set_lcsc_value,
@@ -403,7 +404,7 @@ class JLCPCBTools(wx.Dialog):
         )
         params = self.footprint_list.AppendTextColumn(
             "LCSC Params",
-            10,
+            11,
             width=150,
             mode=dv.DATAVIEW_CELL_INERT,
             align=wx.ALIGN_CENTER,
@@ -423,15 +424,18 @@ class JLCPCBTools(wx.Dialog):
         pos = self.footprint_list.AppendIconTextColumn(
             "POS", 7, width=50, mode=dv.DATAVIEW_CELL_INERT
         )
+        dnp = self.footprint_list.AppendIconTextColumn(
+            "POP", 8, width=50, mode=dv.DATAVIEW_CELL_INERT
+        )
         correction = self.footprint_list.AppendTextColumn(
             "Correction",
-            8,
+            9,
             width=120,
             mode=dv.DATAVIEW_CELL_INERT,
             align=wx.ALIGN_CENTER,
         )
         side = self.footprint_list.AppendIconTextColumn(
-            "Side", 9, width=50, mode=dv.DATAVIEW_CELL_INERT
+            "Side", 10, width=50, mode=dv.DATAVIEW_CELL_INERT
         )
 
         reference.SetSortable(True)
@@ -442,6 +446,7 @@ class JLCPCBTools(wx.Dialog):
         stock.SetSortable(True)
         bom.SetSortable(True)
         pos.SetSortable(False)
+        dnp.SetSortable(True)
         correction.SetSortable(True)
         side.SetSortable(True)
         params.SetSortable(True)
@@ -669,6 +674,7 @@ class JLCPCBTools(wx.Dialog):
         corrections = self.library.get_all_correction_data()
         for part in self.store.read_all():
             fp = self.pcbnew.GetBoard().FindFootprintByReference(part["reference"])
+            is_dnp = get_is_dnp(fp)
             # Get part stock and type from library, skip if part number was already looked up before
             if part["lcsc"] and part["lcsc"] not in details:
                 details[part["lcsc"]] = self.library.get_part_details(part["lcsc"])
@@ -688,6 +694,7 @@ class JLCPCBTools(wx.Dialog):
                     details.get(part["lcsc"], {}).get("stock", ""),  # stock
                     part["exclude_from_bom"],
                     part["exclude_from_pos"],
+                    int(is_dnp),
                     str(self.get_correction(part, corrections)),
                     str(fp.GetLayer()),
                     params_for_part(details.get(part["lcsc"], {})),


### PR DESCRIPTION
Honestly I'm kind of torn on this one.   DNP items get ignored when generating the BOM
(and the CPL when the parent PR is merged) -- it does log something to the info log that
it's skipping the item but otherwise there's no feedback that items were skipped due
to DNP.  Adding a column to the main window at least exposes that information.
OTOH I don't know that many people use the DNP feature, and it is starting to crowd the
UI a little bit, so I'm not sure how valuable it is.    I could add some 'show column'
selectors into the settings easily enough, but I think there's a good number of users
that don't even know the settings menu is there.

Anyhoo, I think it might be helpful for some users but it won't hurt my feelings
if you think it crowds the UI for a less-used feature.

<img width="1632" height="864" alt="Screenshot 2026-04-08 at 1 00 47 AM" src="https://github.com/user-attachments/assets/91c053b3-9b1a-4b7e-8525-cfa49b92e448" />
