### PR TITLE
Move JLC database to localappdata on Windows

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -8,6 +8,7 @@ import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
 
 PLUGIN_PATH = Path(__file__).resolve().parent
+PLUGIN_DATA_PATH = os.getenv("LOCALAPPDATA") if os.name == "nt" else PLUGIN_PATH
 
 EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3

--- a/library.py
+++ b/library.py
@@ -20,7 +20,7 @@ from .events import (
     DownloadStartedEvent,
     MessageEvent,
 )
-from .helpers import PLUGIN_PATH, dict_factory, natural_sort_collation
+from .helpers import PLUGIN_DATA_PATH, dict_factory, natural_sort_collation
 from .partselector_columns import DB_FIELDS, SORTABLE_COLUMN_INDEX_TO_DB
 from .unzip_parts import unzip_parts
 
@@ -49,7 +49,7 @@ class Library:
         self.parent = parent
         self.order_by = "LCSC Part"
         self.order_dir = "ASC"
-        self.datadir = os.path.join(PLUGIN_PATH, "jlcpcb")
+        self.datadir = os.path.join(PLUGIN_DATA_PATH, "jlcpcb")
 
         selected_library = self.parent.settings.get("library", {}).get(
             "selected_library", DEFAULT_LIBRARY


### PR DESCRIPTION
I'm using this plugin on Windows and it's awesome but putting the big parts database inside the main plugin directory blows out my free OneDrive quota. After several fruitless hours trying to persuade OneDrive not to sync them, I made this one-liner instead.

NOTE: untested - the change works as expected when applied to the current release of the plugin but I haven't tested with current master branch.