### PR TITLE
Change license from WTFPL to MIT in the PCM metadata

### DIFF
--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -17,7 +17,7 @@
             "twitter": "@bouni2016"
         }
     },
-    "license": "WTFPL",
+    "license": "MIT",
     "resources": {
         "homepage": "https://github.com/bouni/kicad-jlcpcb-tools"
     },


### PR DESCRIPTION
I noticed that the license defined here is WTFPL but the license in the base directory of the project and the pyproject.toml is listed as MIT.  IIUC these licenses are at least kind-of equivalent, so I chose to standardize on the MIT license. 
I can send a PR if you want to go the other way, too, but it should probably be consistent.
I think this just affects what shows up in the KiCad plugin installer UI thingie.
