### PR TITLE
Clean up the PCM archival command.

### DIFF
--- a/PCM/create_pcm_archive.sh
+++ b/PCM/create_pcm_archive.sh
@@ -1,52 +1,81 @@
 #!/bin/sh
 
 # heavily inspired by https://github.com/4ms/4ms-kicad-lib/blob/master/PCM/make_archive.sh
+set -eu
+
+if [ $# -lt 1 ]; then
+	echo "Usage: $0 <version>"
+	exit 1
+fi
 
 VERSION=$1
+ARCHIVE_DIR="PCM/archive"
+PLUGINS_DIR="$ARCHIVE_DIR/plugins"
+RESOURCES_DIR="$ARCHIVE_DIR/resources"
+ZIP_FILE="PCM/KiCAD-PCM-$VERSION.zip"
+METADATA_FILE="$ARCHIVE_DIR/metadata.json"
+
+sed_inplace() {
+	sed -i.bak "$1" "$2"
+	rm -f "$2.bak"
+}
 
 echo "Clean up old files"
 rm -f PCM/*.zip
-rm -rf PCM/archive
-
+rm -rf "$ARCHIVE_DIR"
 
 echo "Create folder structure for ZIP"
-mkdir -p PCM/archive/plugins
-mkdir -p PCM/archive/resources
+mkdir -p "$PLUGINS_DIR" "$RESOURCES_DIR"
 
-echo "Copy files to destination"
-cp VERSION PCM/archive/plugins
-cp *.py PCM/archive/plugins
-cp *.png PCM/archive/plugins
-cp settings.json PCM/archive/plugins
-cp -r icons PCM/archive/plugins
-cp -r lib PCM/archive/plugins
-cp -r dblib PCM/archive/plugins
-cp -r common PCM/archive/plugins
-mkdir PCM/archive/plugins/core
-cp core/*.py PCM/archive/plugins/core
-cp PCM/icon.png PCM/archive/resources
-cp PCM/metadata.template.json PCM/archive/metadata.json
+echo "Copy top-level files"
+for file in VERSION settings.json ./*.py ./*.png; do
+	[ -e "$file" ] || continue
+	cp "$file" "$PLUGINS_DIR"
+done
+
+echo "Copy directories"
+for dir in icons lib common dblib core; do
+	cp -R "$dir" "$PLUGINS_DIR"
+done
+
+echo "Prune tests and caches from packaged plugin"
+find "$PLUGINS_DIR/common" "$PLUGINS_DIR/dblib" "$PLUGINS_DIR/core" -type f \( -name 'test_*.py' -o -name 'pytest.ini' \) -delete
+find "$PLUGINS_DIR" -type d -name '__pycache__' -prune -exec rm -rf {} +
+find "$PLUGINS_DIR" -type f -name '*.pyc' -delete
+
+cp PCM/icon.png "$RESOURCES_DIR"
+cp PCM/metadata.template.json "$METADATA_FILE"
 
 echo "Write version info to file"
-echo $VERSION > PCM/archive/plugins/VERSION
+echo "$VERSION" > "$PLUGINS_DIR/VERSION"
 
 echo "Modify archive metadata.json"
-sed -i "s/VERSION_HERE/$VERSION/g" PCM/archive/metadata.json
-sed -i "s/\"kicad_version\": \"6.0\",/\"kicad_version\": \"6.0\"/g" PCM/archive/metadata.json
-sed -i "/SHA256_HERE/d" PCM/archive/metadata.json
-sed -i "/DOWNLOAD_SIZE_HERE/d" PCM/archive/metadata.json
-sed -i "/DOWNLOAD_URL_HERE/d" PCM/archive/metadata.json
-sed -i "/INSTALL_SIZE_HERE/d" PCM/archive/metadata.json
+sed_inplace "s/VERSION_HERE/$VERSION/g" "$METADATA_FILE"
+sed_inplace "s/\"kicad_version\": \"6.0\",/\"kicad_version\": \"6.0\"/g" "$METADATA_FILE"
+for placeholder in SHA256_HERE DOWNLOAD_SIZE_HERE DOWNLOAD_URL_HERE INSTALL_SIZE_HERE; do
+	sed_inplace "/$placeholder/d" "$METADATA_FILE"
+done
 
 echo "Zip PCM archive"
-cd PCM/archive
-zip -r ../KiCAD-PCM-$VERSION.zip .
-cd ../..
+(cd "$ARCHIVE_DIR" && zip -r "../KiCAD-PCM-$VERSION.zip" .)
 
 echo "Gather data for repo rebuild"
-echo VERSION=$VERSION >> $GITHUB_ENV
-echo DOWNLOAD_SHA256=$(shasum --algorithm 256 PCM/KiCAD-PCM-$VERSION.zip | xargs | cut -d' ' -f1) >> $GITHUB_ENV
-echo DOWNLOAD_SIZE=$(ls -l PCM/KiCAD-PCM-$VERSION.zip | xargs | cut -d' ' -f5) >> $GITHUB_ENV
-echo DOWNLOAD_URL="https:\/\/github.com\/Bouni\/kicad-jlcpcb-tools\/releases\/download\/$VERSION\/KiCAD-PCM-$VERSION.zip" >> $GITHUB_ENV
-echo INSTALL_SIZE=$(unzip -l PCM/KiCAD-PCM-$VERSION.zip | tail -1 | xargs | cut -d' ' -f1) >> $GITHUB_ENV
+DOWNLOAD_SHA256=$(shasum --algorithm 256 "$ZIP_FILE" | awk '{print $1}')
+DOWNLOAD_SIZE=$(wc -c < "$ZIP_FILE" | tr -d '[:space:]')
+DOWNLOAD_URL="https:\/\/github.com\/Bouni\/kicad-jlcpcb-tools\/releases\/download\/$VERSION\/KiCAD-PCM-$VERSION.zip"
+INSTALL_SIZE=$(unzip -l "$ZIP_FILE" | awk 'END{print $1}')
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+	echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+	echo "DOWNLOAD_SHA256=$DOWNLOAD_SHA256" >> "$GITHUB_ENV"
+	echo "DOWNLOAD_SIZE=$DOWNLOAD_SIZE" >> "$GITHUB_ENV"
+	echo "DOWNLOAD_URL=$DOWNLOAD_URL" >> "$GITHUB_ENV"
+	echo "INSTALL_SIZE=$INSTALL_SIZE" >> "$GITHUB_ENV"
+else
+	echo "VERSION=$VERSION"
+	echo "DOWNLOAD_SHA256=$DOWNLOAD_SHA256"
+	echo "DOWNLOAD_SIZE=$DOWNLOAD_SIZE"
+	echo "DOWNLOAD_URL=$DOWNLOAD_URL"
+	echo "INSTALL_SIZE=$INSTALL_SIZE"
+fi
 


### PR DESCRIPTION
 - Add a few safety checks
 - Do some cleanup before archive (remove tests and caches and such)
 - Remove some duplicate code and replace with loops
 - Print to stdout if no github_env

I tested this (and PR #733) by creating an archive locally and installing it via the
'Install from File' workflow in the Kicad PCM manager.
