### PR TITLE
gitgnore settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,13 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Ignore the settings.json file -- when doing local development it's easy
+# to keep accruing changes to this file as you test which adds a bunch of
+# irrelevant diffs, and we may want to hardcode some recommended settings
+# for users to start with.  We can always force-add it with `git add -f`
+# when we are intentionally making changes.
+/settings.json
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.


### PR DESCRIPTION

I notice this file gets changed a lot since the fastest way to do development is to symlink the repository
directory under the plugins directory so that changes are reflected immediately. Of course, that means
that any time you change the settings, it edits the settings.json and creates a diff.

Adding this to .gitignore will ignore these changes.  We should probably have some 'opinionated'
default settings and force commit new changes (git add -f settings.json) when we intentionally want
to change the default settings.
