### PR TITLE
Auto-download global corrections on first run (fixes #349)

### DIFF
--- a/corrections.py
+++ b/corrections.py
@@ -4,7 +4,6 @@ import csv
 import logging
 import os
 
-import requests  # pylint: disable=import-error
 import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
 
@@ -580,30 +579,7 @@ class CorrectionManagerDialog(wx.Dialog):
     def download_correction_data(self, *_):
         """Fetch the latest rotation correction table from Matthew Lai's JLCKicadTool repo."""
         self.parent.library.create_correction_table()
-        try:
-            r = requests.get(
-                "https://raw.githubusercontent.com/matthewlai/JLCKicadTools/master/jlc_kicad_tools/cpl_rotations_db.csv",
-                timeout=5,
-            )
-            corrections = csv.reader(r.text.splitlines(), delimiter=",", quotechar='"')
-            next(corrections)
-            for row in corrections:
-                if not self.parent.library.get_correction_data(row[0]):
-                    if len(row) >= 4:
-                        self.parent.library.insert_correction_data(
-                            row[0], row[1], (row[2], row[3])
-                        )
-                    else:
-                        self.parent.library.insert_correction_data(
-                            row[0], row[1], (0, 0)
-                        )
-                else:
-                    self.logger.info(
-                        "Correction '%s' exists already in database. Leaving this one out.",
-                        row[0],
-                    )
-        except Exception as err:  # pylint: disable=broad-exception-caught
-            self.logger.debug(err)
+        self.parent.library.fetch_remote_corrections()
         self.populate_corrections_list()
         wx.PostEvent(self.parent, PopulateFootprintListEvent())
 

--- a/library.py
+++ b/library.py
@@ -1,6 +1,7 @@
 """Handle the JLCPCB parts database."""
 
 import contextlib
+import csv
 from enum import Enum
 import logging
 import os
@@ -130,12 +131,15 @@ class Library:
             self.state = LibraryState.UPDATE_NEEDED
         else:
             self.state = LibraryState.INITIALIZED
-        if (
-            not os.path.isfile(self.correctionsdb_file)
-            or os.path.getsize(self.correctionsdb_file) == 0
-        ):
+        corrections_file_missing = not os.path.isfile(self.correctionsdb_file)
+        if corrections_file_missing or os.path.getsize(self.correctionsdb_file) == 0:
             self.create_correction_table()
             self.migrate_corrections()
+            if (
+                corrections_file_missing
+                and self.correctionsdb_file == self.globalcorrectionsdb_file
+            ):
+                Thread(target=self.fetch_remote_corrections, daemon=True).start()
         if (
             not os.path.isfile(self.mappingsdb_file)
             or os.path.getsize(self.mappingsdb_file) == 0
@@ -821,6 +825,22 @@ class Library:
         """Migrate existing rotations from old rotation db and parts db to correction db."""
         self.migrate_corrections_from_rotation()
         self.migrate_corrections_from_parts()
+
+    def fetch_remote_corrections(self):
+        """Download rotation corrections from Matthew Lai's JLCKicadTools repo."""
+        url = "https://raw.githubusercontent.com/matthewlai/JLCKicadTools/master/jlc_kicad_tools/cpl_rotations_db.csv"
+        try:
+            r = requests.get(url, timeout=10)
+            r.raise_for_status()
+            corrections = csv.reader(r.text.splitlines(), delimiter=",", quotechar='"')
+            next(corrections)
+            for row in corrections:
+                if not self.get_correction_data(row[0]):
+                    offset = (row[2], row[3]) if len(row) >= 4 else (0, 0)
+                    self.insert_correction_data(row[0], row[1], offset)
+            self.logger.info("Downloaded global corrections from remote source.")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.logger.debug("Failed to download global corrections: %s", exc)
 
     def migrate_mappings(self):
         """Migrate existing mappings from parts db to mappings db."""

--- a/library.py
+++ b/library.py
@@ -139,7 +139,12 @@ class Library:
                 corrections_file_missing
                 and self.correctionsdb_file == self.globalcorrectionsdb_file
             ):
-                Thread(target=self.fetch_remote_corrections, daemon=True).start()
+                db_path = self.globalcorrectionsdb_file
+                Thread(
+                    target=self.fetch_remote_corrections,
+                    args=(db_path,),
+                    daemon=True,
+                ).start()
         if (
             not os.path.isfile(self.mappingsdb_file)
             or os.path.getsize(self.mappingsdb_file) == 0
@@ -351,10 +356,11 @@ class Library:
             )
             cur.commit()
 
-    def get_correction_data(self, regex):
+    def get_correction_data(self, regex, db_path=None):
         """Get the correction data by its regex."""
+        target = db_path if db_path is not None else self.correctionsdb_file
         with (
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as con,
+            contextlib.closing(sqlite3.connect(target)) as con,
             con as cur,
         ):
             return cur.execute(
@@ -381,10 +387,11 @@ class Library:
             )
             cur.commit()
 
-    def insert_correction_data(self, regex, rotation, offset):
+    def insert_correction_data(self, regex, rotation, offset, db_path=None):
         """Insert a correction into the database."""
+        target = db_path if db_path is not None else self.correctionsdb_file
         with (
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as con,
+            contextlib.closing(sqlite3.connect(target)) as con,
             con as cur,
         ):
             cur.execute(
@@ -826,8 +833,9 @@ class Library:
         self.migrate_corrections_from_rotation()
         self.migrate_corrections_from_parts()
 
-    def fetch_remote_corrections(self):
+    def fetch_remote_corrections(self, db_path=None):
         """Download rotation corrections from Matthew Lai's JLCKicadTools repo."""
+        target = db_path if db_path is not None else self.correctionsdb_file
         url = "https://raw.githubusercontent.com/matthewlai/JLCKicadTools/master/jlc_kicad_tools/cpl_rotations_db.csv"
         try:
             r = requests.get(url, timeout=10)
@@ -835,12 +843,14 @@ class Library:
             corrections = csv.reader(r.text.splitlines(), delimiter=",", quotechar='"')
             next(corrections)
             for row in corrections:
-                if not self.get_correction_data(row[0]):
+                if len(row) < 2:
+                    continue
+                if not self.get_correction_data(row[0], db_path=target):
                     offset = (row[2], row[3]) if len(row) >= 4 else (0, 0)
-                    self.insert_correction_data(row[0], row[1], offset)
-            self.logger.info("Downloaded global corrections from remote source.")
+                    self.insert_correction_data(row[0], row[1], offset, db_path=target)
+            self.logger.info("Downloaded corrections to %s.", target)
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            self.logger.debug("Failed to download global corrections: %s", exc)
+            self.logger.debug("Failed to download corrections to %s: %s", target, exc)
 
     def migrate_mappings(self):
         """Migrate existing mappings from parts db to mappings db."""


### PR DESCRIPTION
When the global corrections database file is absent at startup, spawn a background daemon thread to fetch the rotation correction table from Matthew Lai's JLCKicadTools repo.   The path to the database is captured at
thread creation time to avoid races (which required passing the db path to the correction db getter/inserter).

The download is skipped when the file already exists so user-modified or intentionally empty databases are left untouched.

Also consolidates the download logic: CorrectionManagerDialog now delegates to Library.fetch_remote_corrections()  to separate out some of the UI + 'business logic'.
