### PR TITLE
fix(store): insert part_info with explicit columns for schema compat

### DIFF
--- a/store.py
+++ b/store.py
@@ -158,7 +158,9 @@ class Store:
         """Create a part in the database."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
-                "INSERT INTO part_info VALUES (:reference, :value, :footprint, :lcsc, '', :exclude_from_bom, :exclude_from_pos)",
+                "INSERT INTO part_info ("
+                "reference, value, footprint, lcsc, stock, exclude_from_bom, exclude_from_pos"
+                ") VALUES (:reference, :value, :footprint, :lcsc, '', :exclude_from_bom, :exclude_from_pos)",
                 part,
             )
             cur.commit()


### PR DESCRIPTION

This writes the column names into the stored database explicitly -- so if at any point in the future that columns
get added to the database, it won't break an older version.  (Ideally the migrate script runs, but there's
always the possibility of a bug or rollback).
