### PR TITLE
Make Part Details and Part Selector dialogs modeless

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -1270,19 +1270,15 @@ class JLCPCBTools(wx.Dialog):
             self.select_alike_parts()
 
     def get_part_details(self, *_):
-        """Fetch part details from LCSC and show them one after another each in a modal."""
+        """Show Part Details for each selected footprint (modeless windows)."""
         for item in self.footprint_list.GetSelections():
             if lcsc := self.partlist_data_model.get_lcsc(item):
                 self.show_part_details_dialog(lcsc)
 
     def show_part_details_dialog(self, part):
-        """Show the part details modal dialog."""
-        wx.BeginBusyCursor()
-        try:
-            dialog = PartDetailsDialog(self, part)
-            dialog.ShowModal()
-        finally:
-            wx.EndBusyCursor()
+        """Show the part details dialog (modeless so it doesn't block the app)."""
+        dialog = PartDetailsDialog(self, part)
+        dialog.Show()
 
     def update_library(self, *_):
         """Update the library from the JLCPCB CSV file."""

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -169,6 +169,10 @@ class JLCPCBTools(wx.Dialog):
             self.settings.get("general", {}).get("select_alike_auto", False)
         )
         self.select_alike_in_progress = False
+        # Singleton reference for the modeless PartSelectorDialog. Re-invoking
+        # "Select Part" while one is open re-targets it instead of opening a
+        # second window.
+        self._part_selector = None
         self.pending_assembly_enrichment = set()
         # Monotonic counter incremented each time assembly enrichment is started.
         # Worker threads capture the value at spawn; progress events with a stale
@@ -1388,7 +1392,17 @@ class JLCPCBTools(wx.Dialog):
             if simplified_footprint := simplify_footprint_name(footprint):
                 value += f" {simplified_footprint}"
             selection[ref] = value
-        PartSelectorDialog(self, selection).ShowModal()
+        if self._part_selector is not None:
+            # Already open — re-target it at the new selection rather than
+            # spawning a second window.
+            self._part_selector.update_for(selection)
+            self._part_selector.Raise()
+            return
+        # The selector clears self._part_selector itself from its EVT_CLOSE
+        # handler before it destroys — no need for a destroy hook here.
+        self._part_selector = PartSelectorDialog(self, selection)
+        self._part_selector.Show()
+        self._part_selector.Raise()
 
     def count_order_number_placeholders(self):
         """Count the JLC order/serial number placeholders."""

--- a/partdetails.py
+++ b/partdetails.py
@@ -2,6 +2,7 @@
 
 import logging
 from pathlib import Path
+import threading
 import webbrowser
 
 import wx  # pylint: disable=import-error
@@ -163,7 +164,15 @@ class PartDetailsDialog(wx.Dialog):
         self.Layout()
         self.Centre(wx.BOTH)
 
-        self.get_part_data()
+        # Show a loading placeholder row; the fetch runs on a background
+        # thread and replaces this once the API responds. Keeps the dialog
+        # paintable and closeable while the network call is in flight.
+        self.data_list.AppendItem(["Status", "Loading part details…"])
+        threading.Thread(
+            target=self._fetch_part_data,
+            name="PartDetailsFetch",
+            daemon=True,
+        ).start()
 
     def quit_dialog(self, *_):
         """Close the dialog (via EVT_CLOSE → _on_close → Destroy)."""
@@ -208,19 +217,58 @@ class PartDetailsDialog(wx.Dialog):
         self.logger.info("opening LCSC page for %s", str(self.part))
         webbrowser.open(str(self.pageurl))
 
-    def get_scaled_bitmap(self, url, width, height):
-        """Download a picture from a URL and convert it into a wx Bitmap."""
-        io_bytes = self.lcsc_api.download_bitmap(url)
-        image = wx.Image(io_bytes)
-        image = image.Scale(width, height, wx.IMAGE_QUALITY_HIGH)
-        result = wx.Bitmap(image)
-        return result
+    def _fetch_part_data(self):
+        """Fetch part data and image bytes on a background thread.
 
-    def get_part_data(self):
-        """Get part data from JLCPCB API and parse it into the table, set picture and PDF link."""
-        result = self.lcsc_api.get_part_data(self.part)
-        if not result["success"]:
-            self.report_part_data_fetch_error(result["msg"])
+        Network work happens off the UI thread so the dialog can paint and
+        stay responsive while the API call is in flight. Results are handed
+        back to the UI thread via wx.CallAfter.
+        """
+        try:
+            result = self.lcsc_api.get_part_data(self.part)
+        except Exception as exc:
+            self.logger.exception("Part data fetch failed")
+            result = {"success": False, "msg": str(exc)}
+        image_bytes = None
+        if result.get("success"):
+            url = self._picture_url(result)
+            if url:
+                try:
+                    image_bytes = self.lcsc_api.download_bitmap(url)
+                except Exception as exc:
+                    self.logger.warning("Part image fetch failed: %s", exc)
+        wx.CallAfter(self._apply_part_data, result, image_bytes)
+
+    @staticmethod
+    def _picture_url(result):
+        """Extract the part picture URL from the API response, if any."""
+        data = result["data"].get("data", {})
+        picture = data.get("minImage")
+        if picture:
+            # Substitute the full resolution image for the thumbnail.
+            return picture.replace("96x96", "900x900")
+        image_id = data.get("productBigImageAccessId")
+        if image_id:
+            return f"https://jlcpcb.com/api/file/downloadByFileSystemAccessId/{image_id}"
+        return None
+
+    def _apply_part_data(self, result, image_bytes):
+        """Populate the dialog from fetched data. Runs on the UI thread.
+
+        Scheduled via wx.CallAfter from the background thread, so by the time
+        this runs the user may have already closed the dialog.
+        """
+        if not self:
+            # The underlying wx.Dialog has been destroyed (user closed before
+            # the fetch returned). wxPython's bool override on the Python
+            # proxy returns False once the C++ window is gone.
+            return
+
+        # Drop the "Loading…" placeholder row.
+        self.data_list.DeleteAllItems()
+
+        if not result.get("success"):
+            self.report_part_data_fetch_error(result.get("msg", "unknown error"))
             return
 
         parameters = {
@@ -239,82 +287,45 @@ class PartDetailsDialog(wx.Dialog):
             "leastNumber": "Minimal Quantity",
             "leastNumberPrice": "Minimum price",
         }
-        parttype = result["data"].get("data", {}).get("componentLibraryType")
-        if parttype and parttype == "base":
+        data = result["data"].get("data", {})
+        parttype = data.get("componentLibraryType")
+        if parttype == "base":
             self.data_list.AppendItem(["Type", "Basic"])
-        elif parttype and parttype == "expand":
+        elif parttype == "expand":
             self.data_list.AppendItem(["Type", "Extended"])
-        for k, v in parameters.items():
-            val = result["data"].get("data", {}).get(k)
+        for k, label in parameters.items():
+            val = data.get(k)
             if val:
-                self.data_list.AppendItem([v, str(val)])
-        prices = result["data"].get("data", {}).get("jlcPrices", [])
-        if prices:
-            for price in prices:
-                start = price.get("startNumber")
-                end = price.get("endNumber")
-                if end == -1:
-                    self.data_list.AppendItem(
-                        [
-                            f"JLC Price for >{start}",
-                            str(price.get("productPrice")),
-                        ]
-                    )
-                else:
-                    self.data_list.AppendItem(
-                        [
-                            f"JLC Price for {start}-{end}",
-                            str(price.get("productPrice")),
-                        ]
-                    )
-        prices = result["data"].get("data", {}).get("prices", [])
-        if prices:
-            for price in prices:
-                start = price.get("startNumber")
-                end = price.get("endNumber")
-                if end == -1:
-                    self.data_list.AppendItem(
-                        [
-                            f"LCSC Price for >{start}",
-                            str(price.get("productPrice")),
-                        ]
-                    )
-                else:
-                    self.data_list.AppendItem(
-                        [
-                            f"LCSC Price for {start}-{end}",
-                            str(price.get("productPrice")),
-                        ]
-                    )
-        for attribute in result["data"].get("data", {}).get("attributes", []):
+                self.data_list.AppendItem([label, str(val)])
+        for price in data.get("jlcPrices", []) or []:
+            start = price.get("startNumber")
+            end = price.get("endNumber")
+            label = f"JLC Price for >{start}" if end == -1 else f"JLC Price for {start}-{end}"
+            self.data_list.AppendItem([label, str(price.get("productPrice"))])
+        for price in data.get("prices", []) or []:
+            start = price.get("startNumber")
+            end = price.get("endNumber")
+            label = f"LCSC Price for >{start}" if end == -1 else f"LCSC Price for {start}-{end}"
+            self.data_list.AppendItem([label, str(price.get("productPrice"))])
+        for attribute in data.get("attributes", []) or []:
             self.data_list.AppendItem(
                 [
                     attribute.get("attribute_name_en"),
                     str(attribute.get("attribute_value_name")),
                 ]
             )
-        picture = result["data"].get("data", {}).get("minImage")
-        if picture:
-            # get the full resolution image instead of the thumbnail
-            picture = picture.replace("96x96", "900x900")
-        else:
-            imageId = result["data"].get("data", {}).get("productBigImageAccessId")
-            picture = (
-                f"https://jlcpcb.com/api/file/downloadByFileSystemAccessId/{imageId}"
-            )
-        self.image.SetBitmap(
-            self.get_scaled_bitmap(
-                picture,
-                int(200 * self.parent.scale_factor),
-                int(200 * self.parent.scale_factor),
-            )
-        )
 
-        self.pdfurl = result["data"].get("data", {}).get("dataManualUrl")
-        self.pageurl = result["data"].get("data", {}).get("lcscGoodsUrl")
+        if image_bytes is not None:
+            image = wx.Image(image_bytes)
+            size = int(200 * self.parent.scale_factor)
+            image = image.Scale(size, size, wx.IMAGE_QUALITY_HIGH)
+            self.image.SetBitmap(wx.Bitmap(image))
+
+        self.pdfurl = data.get("dataManualUrl")
+        self.pageurl = data.get("lcscGoodsUrl")
 
     def report_part_data_fetch_error(self, reason):
-        """Spawn a message box with an erro message if the fetch fails."""
+        """Spawn a message box with an error message if the fetch fails."""
         wx.MessageBox(
             f"Failed to download part detail from the JLCPCB API ({reason})\r\n"
             f"We looked for a part named:\r\n{self.part}\r\n[hint: did you fill in the LCSC field correctly?]",

--- a/partdetails.py
+++ b/partdetails.py
@@ -1,4 +1,4 @@
-"""Contains the part details modal dialog."""
+"""Contains the part details dialog."""
 
 import logging
 from pathlib import Path
@@ -23,7 +23,7 @@ class PartDetailsDialog(wx.Dialog):
             title="JLCPCB Part Details",
             pos=wx.DefaultPosition,
             size=HighResWxSize(parent.window, wx.Size(1000, 800)),
-            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.STAY_ON_TOP,
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
         )
 
         self.logger = logging.getLogger(__name__)
@@ -34,6 +34,12 @@ class PartDetailsDialog(wx.Dialog):
         self.pdfurl = ""
         self.pageurl = ""
         self.picture = None
+
+        # The default EVT_CLOSE handler for a modeless wx.Dialog hides the
+        # window instead of destroying it. Override so the X-button actually
+        # destroys, otherwise hidden dialogs accumulate every time the user
+        # closes one via the title bar.
+        self.Bind(wx.EVT_CLOSE, self._on_close)
 
         # ---------------------------------------------------------------------
         # ---------------------------- Hotkeys --------------------------------
@@ -160,9 +166,12 @@ class PartDetailsDialog(wx.Dialog):
         self.get_part_data()
 
     def quit_dialog(self, *_):
-        """Close the dialog."""
+        """Close the dialog (via EVT_CLOSE → _on_close → Destroy)."""
+        self.Close()
+
+    def _on_close(self, _event):
+        """Destroy on close so a modeless wx.Dialog doesn't merely hide."""
         self.Destroy()
-        self.EndModal(0)
 
     def savepdf(self, *_):
         """Download a datasheet from The LCSC API."""
@@ -312,4 +321,4 @@ class PartDetailsDialog(wx.Dialog):
             "Error",
             style=wx.ICON_ERROR,
         )
-        self.EndModal(-1)
+        self.Destroy()

--- a/partselector.py
+++ b/partselector.py
@@ -51,6 +51,11 @@ class PartSelectorDialog(wx.Dialog):
         self.search_timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self.search)
 
+        # The default EVT_CLOSE handler for a modeless wx.Dialog hides the
+        # window instead of destroying it. Override so X-button / Close() do
+        # what we want — actually destroy, so the singleton ref clears.
+        self.Bind(wx.EVT_CLOSE, self._on_close)
+
         # ---------------------------------------------------------------------
         # ---------------------------- Hotkeys --------------------------------
         # ---------------------------------------------------------------------
@@ -580,9 +585,28 @@ class PartSelectorDialog(wx.Dialog):
         return list(s)[0]
 
     def quit_dialog(self, *_):
-        """Close this window."""
+        """Close this window (via EVT_CLOSE → _on_close → Destroy)."""
+        self.Close()
+
+    def _on_close(self, _event):
+        """Destroy on close and clear the parent's singleton ref."""
+        # Tell the main window we're going away so it doesn't try to update
+        # a destroyed dialog the next time "Select Part" is clicked.
+        if getattr(self.parent, "_part_selector", None) is self:
+            self.parent._part_selector = None
         self.Destroy()
-        self.EndModal(0)
+
+    def update_for(self, parts):
+        """Re-target this open selector at a new set of footprints.
+
+        Called when the user invokes "Select Part" again from the main window
+        while the selector is already open. We swap in the new parts, refresh
+        the initial search keyword, and re-run the search so the visible list
+        reflects what the user just clicked.
+        """
+        self.parts = parts
+        self.keyword.ChangeValue(self.get_existing_selection(parts))
+        self.search(None)
 
     def OnSortPartList(self, e):
         """Set order_by to the clicked column and trigger list refresh."""
@@ -737,7 +761,7 @@ class PartSelectorDialog(wx.Dialog):
                     references=self.parts.keys(),
                 ),
             )
-            self.EndModal(wx.ID_OK)
+            self.Close()
 
     def get_part_details(self, *_):
         """Fetch part details from LCSC and show them in a modeless dialog."""

--- a/partselector.py
+++ b/partselector.py
@@ -740,13 +740,11 @@ class PartSelectorDialog(wx.Dialog):
             self.EndModal(wx.ID_OK)
 
     def get_part_details(self, *_):
-        """Fetch part details from LCSC and show them in a modal."""
+        """Fetch part details from LCSC and show them in a modeless dialog."""
         if self.part_list.GetSelectedItemsCount() > 0:
             item = self.part_list.GetSelection()
-            busy_cursor = wx.BusyCursor()
             dialog = PartDetailsDialog(self.parent, self.part_list_model.get_lcsc(item))
-            del busy_cursor
-            dialog.ShowModal()
+            dialog.Show()
 
     def help(self, *_):
         """Show message box with help instructions."""


### PR DESCRIPTION
## Summary

I picked this one up because #764 has annoyed me in the past, too - where it'll spawn a partdetail underneath a bunch of stuff and you have to find it and close it before any window works again.

Note that this makes a change in a way the application windows work -- PartSelector is not longer a model dialog, you can switch to the mainwindow with it open, but if you click on a new part, it will send an update to the partselector to refresh the search and link it to the new part.

## The Fix

This PR fixes #764. The reported symptom — KiCad becomes unresponsive when the Part Details window loses focus — is caused by `PartDetailsDialog` being a modal dialog with `wx.STAY_ON_TOP` set. On wxGTK/Wayland the always-on-top hint is unreliable, so the modal can slip behind the main JLCPCB window. Because `ShowModal()` disables every other top-level window in the application while it's running, the user can't reach the hidden modal to dismiss it — KiCad appears frozen and the user has to kill it from the command line.

The minimal patch (drop `STAY_ON_TOP`, switch to `Show()`) fixes the hang on Wayland, but it surfaces a related fragility: with no modal in the chain, a modeless `PartDetailsDialog` can be sent behind its parent `PartSelectorDialog` (which was modal) and is unreachable on macOS; with `STAY_ON_TOP` it always-obscures the selector on Windows. These z-order interactions between stacked dialogs are platform-specific and difficult to get right.

This PR fixes the bug at a structural level by making **both** dialogs modeless, removing the modal stack entirely. The Part Selector becomes a singleton so it can't be opened twice, and the Part Details fetch moves to a background thread so the dialog never blocks the UI on network I/O.

## Changes

### Commit 1 — `PartDetailsDialog` modeless

This commit on its own fixes the reported bug and could be cherry-picked alone if the rest of the change is too much.

- Drop `wx.STAY_ON_TOP` from the dialog style.
- Replace `ShowModal()` with `Show()` at both call sites (`mainwindow.py`, `partselector.py`).
- Bind `EVT_CLOSE` to a handler that calls `Destroy()`. The default `EVT_CLOSE` handler for a modeless `wx.Dialog` calls `Show(False)` — it *hides* the window instead of destroying it, which would leak hidden dialogs every time the user closes one via the title bar.
- Route `quit_dialog()` through `Close()` so accelerator paths (Ctrl+W / Ctrl+Q / Shift+Esc) and the X-button all run the same teardown.
- Drop the `wx.BusyCursor` wrappers at the call sites — `Show()` returns immediately so the busy state was misleading.

### Commit 2 — `PartSelectorDialog` modeless + singleton

The selector itself doesn't actually need to be modal — `mainwindow.py` never reads its return value, and the selector already communicates its outcome by posting an `AssignPartsEvent` before closing. Making it modeless removes the only remaining modal in this chain and eliminates the cross-platform z-order problems entirely.

- `select_part()` and `quit_dialog()` route through `self.Close()`, which fires `EVT_CLOSE`. The new `_on_close` handler destroys the dialog and clears the main window's singleton ref.
- New `update_for(parts)` method re-targets an already-open selector at a new footprint selection — refreshes the keyword field and re-runs the search.
- `JLCPCBTools` tracks `self._part_selector`; re-invoking ""Select Part"" while one is already open re-targets and raises it rather than spawning a second window — necessary because otherwise the user could leave the selector open for footprint R1, click R2 in the main list, and accidentally have their next pick assigned to R1.

### Commit 3 — Fetch Part Details data on a background thread

Independent of the modeless conversion. `PartDetailsDialog.__init__` called `get_part_data()` synchronously, which issues two HTTP requests (JLCPCB metadata + the part picture). Everything ran on the UI thread, so the dialog couldn't paint or accept input until both network calls finished, and the rest of the plugin was frozen too. Modeless vs modal didn't change that — the dialog still couldn't appear until both requests completed.

- `_fetch_part_data()` runs on a daemon thread, makes both HTTP calls (wrapped in try/except so timeouts/network errors surface as a failed result), and hands the result back to the UI thread via `wx.CallAfter`.
- `_apply_part_data()` runs on the UI thread to populate the data view and image. Guards against the user closing the dialog before the fetch returns (`if not self: return`).
- The dialog now appears immediately with a "Loading part details…" placeholder row that's replaced once the fetch lands.

## Side benefits beyond the bug fix

- Part Details and Part Selector windows can be left open while continuing to work in the main JLCPCB window.
- Multiple Part Details windows can be open at once for side-by-side comparison (only the selector is singleton).
- The plugin stays responsive while Part Details data is fetching — previously a slow LCSC response would freeze the whole plugin.
- No modal-on-modal interactions remain anywhere in the plugin.

## Test plan

Tested on macOS (KiCad 9.0) and Windows-via-Crossover. I don't have a Linux/Wayland setup to verify the original hang scenario directly — would appreciate someone with that environment confirming.

- [ ] **Linux/Wayland (original bug repro from #764):** Open Part Details from main window → click main JLCPCB window. KiCad stays responsive. Part Details remains reachable.
- [x] **macOS:** Part Details opens above main window; both stay interactable.
- [x] **macOS:** Part Selector open → ""Show Part Details"" → both selector and details stay usable. No grey-box / unresponsive states.
- [x] **macOS:** With selector open for R1, click R2 → ""Select Part"" raises the same selector with R2's keyword and refreshed results. No second window.
- [x] **macOS:** All close paths (X / Ctrl+W / Ctrl+Q / Shift+Esc) destroy the window cleanly. Re-opening produces a fresh selector / details window. No leaked hidden dialogs.
- [x] **macOS:** Pick a part in the selector → assignment fires (`AssignPartsEvent` path), selector destroys, main window updates.
- [x] **macOS:** Open Part Details on a part — dialog appears immediately with "Loading…" row, populates after the fetch.
- [x] **macOS:** Open Part Details, immediately close it before the fetch lands — no crash.
- [x] **Windows (Crossover):** Same flows as macOS. Without `STAY_ON_TOP`, Part Details no longer obscures the selector.

## Notes

The three commits are logically independent — commit 1 alone is the minimal fix for #764, commit 2 is the structural fix for cross-platform z-order issues, commit 3 is an independent responsiveness improvement that fell out of the same investigation. Either of 2 or 3 could be split into a follow-up PR if reviewers prefer.