### PR TITLE
Add KiCad 10 design variant support

### DIFF
--- a/common/test_footprint_helpers_variants.py
+++ b/common/test_footprint_helpers_variants.py
@@ -1,0 +1,637 @@
+"""Tests for design-variant-aware footprint helpers.
+
+The fakes below mirror the KiCad 10 variant API semantics (verified against
+KiCad 10.0.3): ``*ForVariant`` getters fall back to the base state when the
+footprint has no override object for the variant (or when the variant name
+is empty), field overrides are sparse with per-field fallback, and creating
+a footprint variant override snapshots the base flags at creation time.
+"""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).parent.parent
+PACKAGE = "kicad_jlcpcb_tools"
+
+if PACKAGE not in sys.modules:
+    pkg = types.ModuleType(PACKAGE)
+    pkg.__path__ = [str(ROOT)]
+    sys.modules[PACKAGE] = pkg
+
+
+def _load_root_module(name):
+    """Load a root module as part of a synthetic package for relative imports."""
+    module_name = f"{PACKAGE}.{name}"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    spec = importlib.util.spec_from_file_location(module_name, str(ROOT / f"{name}.py"))
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module spec for {module_name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+helpers = _load_root_module("footprint_helpers")
+
+EXCLUDE_FROM_POS_BIT = 1 << helpers.EXCLUDE_FROM_POS
+EXCLUDE_FROM_BOM_BIT = 1 << helpers.EXCLUDE_FROM_BOM
+
+
+class FakeField:
+    """A footprint field with a name and base text."""
+
+    def __init__(self, name, text):
+        self._name = name
+        self._text = text
+        self.visible = True
+
+    def GetName(self):
+        """Return the field name."""
+        return self._name
+
+    def GetText(self):
+        """Return the base field text."""
+        return self._text
+
+    def SetText(self, text):
+        """Set the base field text."""
+        self._text = text
+
+    def SetVisible(self, visible):
+        """Set field visibility."""
+        self.visible = visible
+
+
+class FakeFootprintVariant:
+    """Mirror of FOOTPRINT_VARIANT: explicit flags plus sparse field overrides."""
+
+    def __init__(self, name, dnp=False, bom=False, pos=False):
+        self._name = name
+        self._dnp = dnp
+        self._bom = bom
+        self._pos = pos
+        self._fields = {}
+
+    def GetDNP(self):
+        """Return the DNP flag."""
+        return self._dnp
+
+    def SetDNP(self, dnp):
+        """Set the DNP flag."""
+        self._dnp = dnp
+
+    def GetExcludedFromBOM(self):
+        """Return the exclude-from-BOM flag."""
+        return self._bom
+
+    def SetExcludedFromBOM(self, exclude):
+        """Set the exclude-from-BOM flag."""
+        self._bom = exclude
+
+    def GetExcludedFromPosFiles(self):
+        """Return the exclude-from-POS flag."""
+        return self._pos
+
+    def SetExcludedFromPosFiles(self, exclude):
+        """Set the exclude-from-POS flag."""
+        self._pos = exclude
+
+    def HasFieldValue(self, name):
+        """Return True when the variant overrides the given field."""
+        return name in self._fields
+
+    def GetFieldValue(self, name):
+        """Return the override value for a field ("" when absent)."""
+        return self._fields.get(name, "")
+
+    def SetFieldValue(self, name, value):
+        """Set a field override."""
+        self._fields[name] = value
+
+    def GetFields(self):
+        """Return the {name: value} override map."""
+        return dict(self._fields)
+
+
+class FakeBoard:
+    """Board exposing the KiCad 10 current-variant getter."""
+
+    def __init__(self, variant=""):
+        self._variant = variant
+
+    def GetCurrentVariant(self):
+        """Return the active variant name."""
+        return self._variant
+
+
+class FakeFootprint:
+    """Footprint with the KiCad 10 variant API and probe-verified fallbacks."""
+
+    def __init__(self, board=None, value="", fields=None, attributes=0, dnp=False):
+        self._board = board
+        self._value = value
+        self._fields = list(fields or [])
+        self._attributes = attributes
+        self._dnp = dnp
+        self._variants = {}
+
+    def GetBoard(self):
+        """Return the owning board."""
+        return self._board
+
+    def GetValue(self):
+        """Return the base Value field text."""
+        return self._value
+
+    def GetFields(self):
+        """Return the base fields."""
+        return list(self._fields)
+
+    # KiCad 10 has no FOOTPRINT.GetFieldByName; keep this fake accurate so
+    # tests exercise the GetFields-loop branch of set_lcsc_value.
+    def _field_by_name(self, name):
+        """Return the base field with the given name, or None (test helper)."""
+        for field in self._fields:
+            if field.GetName() == name:
+                return field
+        return None
+
+    def SetField(self, name, text):
+        """Update an existing base field or append a new one."""
+        field = self._field_by_name(name)
+        if field:
+            field.SetText(text)
+        else:
+            self._fields.append(FakeField(name, text))
+
+    def GetAttributes(self):
+        """Return the base attribute bits."""
+        return self._attributes
+
+    def SetAttributes(self, attributes):
+        """Set the base attribute bits."""
+        self._attributes = attributes
+
+    def IsDNP(self):
+        """Return the base DNP state."""
+        return self._dnp
+
+    def HasVariant(self, name):
+        """Return True when the footprint has an override for the variant."""
+        return name in self._variants
+
+    def GetVariant(self, name):
+        """Return the override object for the variant, or None."""
+        return self._variants.get(name)
+
+    def AddVariant(self, name):
+        """Create an override snapshotting the current base flags."""
+        variant = FakeFootprintVariant(
+            name,
+            dnp=self._dnp,
+            bom=bool(self._attributes & EXCLUDE_FROM_BOM_BIT),
+            pos=bool(self._attributes & EXCLUDE_FROM_POS_BIT),
+        )
+        self._variants[name] = variant
+        return variant
+
+    def DeleteVariant(self, name):
+        """Remove the override object for a variant."""
+        self._variants.pop(name, None)
+
+    def GetDNPForVariant(self, name):
+        """Return the DNP state resolved for a variant (base fallback)."""
+        if name in self._variants:
+            return self._variants[name].GetDNP()
+        return self._dnp
+
+    def GetExcludedFromBOMForVariant(self, name):
+        """Return the exclude-from-BOM state resolved for a variant."""
+        if name in self._variants:
+            return self._variants[name].GetExcludedFromBOM()
+        return bool(self._attributes & EXCLUDE_FROM_BOM_BIT)
+
+    def GetExcludedFromPosFilesForVariant(self, name):
+        """Return the exclude-from-POS state resolved for a variant."""
+        if name in self._variants:
+            return self._variants[name].GetExcludedFromPosFiles()
+        return bool(self._attributes & EXCLUDE_FROM_POS_BIT)
+
+    def GetFieldValueForVariant(self, name, field_name):
+        """Return a field's text resolved for a variant (per-field fallback)."""
+        variant = self._variants.get(name)
+        if variant is not None and variant.HasFieldValue(field_name):
+            return variant.GetFieldValue(field_name)
+        field = self._field_by_name(field_name)
+        if field is None:
+            return ""
+        return field.GetText()
+
+
+class LegacyFootprint:
+    """KiCad 8/9 style footprint without any variant API."""
+
+    def __init__(self, value="", fields=None, attributes=0, dnp=False):
+        self._value = value
+        self._fields = list(fields or [])
+        self._attributes = attributes
+        self._dnp = dnp
+
+    def GetValue(self):
+        """Return the Value field text."""
+        return self._value
+
+    def GetFields(self):
+        """Return the fields."""
+        return list(self._fields)
+
+    def GetAttributes(self):
+        """Return the attribute bits."""
+        return self._attributes
+
+    def SetAttributes(self, attributes):
+        """Set the attribute bits."""
+        self._attributes = attributes
+
+    def IsDNP(self):
+        """Return the DNP state."""
+        return self._dnp
+
+
+class PropertiesFootprint:
+    """KiCad <=6 style footprint with GetProperties instead of GetFields."""
+
+    def __init__(self, properties):
+        self._properties = properties
+
+    def GetProperties(self):
+        """Return the {name: value} property map."""
+        return dict(self._properties)
+
+
+# ---------------------------------------------------------------------------
+# get_current_variant / get_footprint_variant
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_variant_returns_active_name():
+    """The active variant name is read from the board."""
+    assert helpers.get_current_variant(FakeBoard("VarA")) == "VarA"
+
+
+def test_get_current_variant_defaults_to_empty():
+    """Default variant, missing API, and missing board all map to ""."""
+    assert helpers.get_current_variant(FakeBoard("")) == ""
+    assert helpers.get_current_variant(object()) == ""
+    assert helpers.get_current_variant(None) == ""
+
+
+def test_get_footprint_variant_without_board_api():
+    """A footprint without GetBoard resolves to the default variant."""
+    assert helpers.get_footprint_variant(LegacyFootprint()) == ""
+
+
+# ---------------------------------------------------------------------------
+# get_resolved_value
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_value_base_when_no_variant_active():
+    """With the default variant active the base value is returned."""
+    fp = FakeFootprint(FakeBoard(""), value="10k")
+    fp.SetField("Value", "10k")
+    assert helpers.get_resolved_value(fp) == "10k"
+
+
+def test_resolved_value_uses_variant_override():
+    """A variant Value override wins over the base value."""
+    fp = FakeFootprint(FakeBoard("VarA"), value="10k")
+    fp.SetField("Value", "10k")
+    fp.AddVariant("VarA").SetFieldValue("Value", "22k")
+    assert helpers.get_resolved_value(fp) == "22k"
+
+
+def test_resolved_value_falls_back_without_override():
+    """Without an override the variant resolves to the base value."""
+    fp = FakeFootprint(FakeBoard("VarA"), value="10k")
+    fp.SetField("Value", "10k")
+    assert helpers.get_resolved_value(fp) == "10k"
+
+
+def test_resolved_value_legacy_footprint():
+    """Footprints without the variant API return GetValue()."""
+    assert helpers.get_resolved_value(LegacyFootprint(value="4k7")) == "4k7"
+
+
+# ---------------------------------------------------------------------------
+# get_lcsc_value
+# ---------------------------------------------------------------------------
+
+
+def test_lcsc_value_from_base_field():
+    """The base LCSC field is found on the default variant."""
+    fp = FakeFootprint(FakeBoard(""), fields=[FakeField("LCSC", "C123")])
+    assert helpers.get_lcsc_value(fp) == "C123"
+
+
+def test_lcsc_value_resolves_variant_override():
+    """A variant override of the LCSC field wins over the base value."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "C999")
+    assert helpers.get_lcsc_value(fp) == "C999"
+
+
+def test_lcsc_value_variant_fallback_to_base():
+    """Without an override the base LCSC number is used in a variant."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    assert helpers.get_lcsc_value(fp) == "C123"
+
+
+def test_lcsc_value_explicit_empty_override_clears_number():
+    """An explicit empty override hides the base number in that variant."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "")
+    assert helpers.get_lcsc_value(fp) == ""
+
+
+def test_lcsc_value_from_variant_only_field():
+    """An LCSC override without a base field counterpart is still found."""
+    fp = FakeFootprint(FakeBoard("VarA"))
+    fp.AddVariant("VarA").SetFieldValue("JLC Part", "C777")
+    assert helpers.get_lcsc_value(fp) == "C777"
+
+
+def test_lcsc_value_legacy_properties_fallback():
+    """KiCad <=6 footprints resolve through GetProperties."""
+    fp = PropertiesFootprint({"lcsc": "C55"})
+    assert helpers.get_lcsc_value(fp) == "C55"
+
+
+def test_lcsc_value_ignores_non_matching_fields():
+    """Fields with non-LCSC names or invalid numbers are skipped."""
+    fp = FakeFootprint(
+        FakeBoard(""),
+        fields=[FakeField("MPN", "C123"), FakeField("LCSC", "not-a-number")],
+    )
+    assert helpers.get_lcsc_value(fp) == ""
+
+
+# ---------------------------------------------------------------------------
+# set_lcsc_value
+# ---------------------------------------------------------------------------
+
+
+def test_set_lcsc_value_updates_base_field():
+    """On the default variant the existing base field is updated."""
+    fp = FakeFootprint(FakeBoard(""), fields=[FakeField("LCSC", "C123")])
+    helpers.set_lcsc_value(fp, "C456")
+    assert fp._field_by_name("LCSC").GetText() == "C456"
+
+
+def test_set_lcsc_value_creates_hidden_field():
+    """Without an existing field a hidden LCSC base field is created."""
+    fp = FakeFootprint(FakeBoard(""))
+    helpers.set_lcsc_value(fp, "C456")
+    field = fp._field_by_name("LCSC")
+    assert field.GetText() == "C456"
+    assert field.visible is False
+
+
+def test_set_lcsc_value_updates_variant_override_when_present():
+    """An explicit variant override is updated instead of the base field."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "C999")
+    helpers.set_lcsc_value(fp, "C456")
+    assert fp.GetVariant("VarA").GetFieldValue("LCSC") == "C456"
+    assert fp._field_by_name("LCSC").GetText() == "C123"
+
+
+def test_set_lcsc_value_writes_base_when_variant_has_no_override():
+    """Without an override the base field is written and inherited."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    helpers.set_lcsc_value(fp, "C456")
+    assert fp._field_by_name("LCSC").GetText() == "C456"
+    assert not fp.HasVariant("VarA")
+
+
+def test_set_lcsc_value_updates_variant_only_field():
+    """A variant-only LCSC override is updated in place."""
+    fp = FakeFootprint(FakeBoard("VarA"))
+    fp.AddVariant("VarA").SetFieldValue("JLC Part", "C777")
+    helpers.set_lcsc_value(fp, "C456")
+    assert fp.GetVariant("VarA").GetFieldValue("JLC Part") == "C456"
+    assert fp._field_by_name("LCSC") is None
+
+
+def test_set_lcsc_value_updates_cleared_override_not_base():
+    """An explicitly cleared override is updated, never the shadowed base field."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "")
+    helpers.set_lcsc_value(fp, "C456")
+    assert fp.GetVariant("VarA").GetFieldValue("LCSC") == "C456"
+    assert fp._field_by_name("LCSC").GetText() == "C123"
+    assert helpers.get_lcsc_value(fp) == "C456"
+
+
+def test_set_lcsc_value_remove_then_reassign_round_trip():
+    """Removing and re-assigning in a variant keeps the override in charge."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "C999")
+    helpers.set_lcsc_value(fp, "")
+    assert helpers.get_lcsc_value(fp) == ""
+    helpers.set_lcsc_value(fp, "C456")
+    assert helpers.get_lcsc_value(fp) == "C456"
+    # The base field and thus other variants never changed.
+    assert fp._field_by_name("LCSC").GetText() == "C123"
+
+
+def test_set_lcsc_value_placeholder_override_updated():
+    """A non-part placeholder override (e.g. 'TBD') is updated in place."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "TBD")
+    helpers.set_lcsc_value(fp, "C456")
+    assert fp.GetVariant("VarA").GetFieldValue("LCSC") == "C456"
+    assert fp._field_by_name("LCSC").GetText() == "C123"
+
+
+# ---------------------------------------------------------------------------
+# lcsc_override_cleared
+# ---------------------------------------------------------------------------
+
+
+def test_lcsc_override_cleared_detects_explicit_clear():
+    """An explicit empty override marks the part as cleared for the variant."""
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "")
+    assert helpers.lcsc_override_cleared(fp) is True
+
+
+def test_lcsc_override_cleared_false_cases():
+    """No variant, no override, or a valid override are not 'cleared'."""
+    fp = FakeFootprint(FakeBoard(""), fields=[FakeField("LCSC", "C123")])
+    assert helpers.lcsc_override_cleared(fp) is False
+    fp = FakeFootprint(FakeBoard("VarA"), fields=[FakeField("LCSC", "C123")])
+    assert helpers.lcsc_override_cleared(fp) is False
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "C999")
+    assert helpers.lcsc_override_cleared(fp) is False
+
+
+# ---------------------------------------------------------------------------
+# flag getters
+# ---------------------------------------------------------------------------
+
+
+def test_flag_getters_base_state_on_default_variant():
+    """Attribute bits and IsDNP drive the default variant state."""
+    fp = FakeFootprint(
+        FakeBoard(""),
+        attributes=EXCLUDE_FROM_BOM_BIT | EXCLUDE_FROM_POS_BIT,
+        dnp=True,
+    )
+    assert helpers.get_exclude_from_bom(fp) is True
+    assert helpers.get_exclude_from_pos(fp) is True
+    assert helpers.get_is_dnp(fp) is True
+
+
+def test_flag_getters_resolve_variant_override():
+    """Explicit variant overrides win over the base flags."""
+    fp = FakeFootprint(FakeBoard("VarA"))
+    override = fp.AddVariant("VarA")
+    override.SetDNP(True)
+    override.SetExcludedFromBOM(True)
+    override.SetExcludedFromPosFiles(True)
+    assert helpers.get_is_dnp(fp) is True
+    assert helpers.get_exclude_from_bom(fp) is True
+    assert helpers.get_exclude_from_pos(fp) is True
+    # The base state is untouched.
+    assert fp.IsDNP() is False
+    assert fp.GetAttributes() == 0
+
+
+def test_flag_getters_fall_back_without_override():
+    """Without an override object the base flags shine through."""
+    fp = FakeFootprint(
+        FakeBoard("VarA"),
+        attributes=EXCLUDE_FROM_BOM_BIT,
+        dnp=True,
+    )
+    assert helpers.get_is_dnp(fp) is True
+    assert helpers.get_exclude_from_bom(fp) is True
+    assert helpers.get_exclude_from_pos(fp) is False
+
+
+def test_flag_getters_legacy_footprint():
+    """Footprints without the variant API use base attribute bits."""
+    fp = LegacyFootprint(attributes=EXCLUDE_FROM_POS_BIT, dnp=True)
+    assert helpers.get_exclude_from_pos(fp) is True
+    assert helpers.get_exclude_from_bom(fp) is False
+    assert helpers.get_is_dnp(fp) is True
+
+
+def test_flag_getters_none_footprint():
+    """None footprints return the documented defaults."""
+    assert helpers.get_exclude_from_bom(None) is None
+    assert helpers.get_exclude_from_pos(None) is None
+    assert helpers.get_is_dnp(None) is False
+
+
+# ---------------------------------------------------------------------------
+# flag toggles
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_bom_flips_base_bit_on_default_variant():
+    """On the default variant the base attribute bit is flipped."""
+    fp = FakeFootprint(FakeBoard(""))
+    assert helpers.toggle_exclude_from_bom(fp) is True
+    assert fp.GetAttributes() == EXCLUDE_FROM_BOM_BIT
+    assert helpers.toggle_exclude_from_bom(fp) is False
+    assert fp.GetAttributes() == 0
+
+
+def test_toggle_pos_flips_base_bit_on_default_variant():
+    """On the default variant the base attribute bit is flipped."""
+    fp = FakeFootprint(FakeBoard(""))
+    assert helpers.toggle_exclude_from_pos(fp) is True
+    assert fp.GetAttributes() == EXCLUDE_FROM_POS_BIT
+
+
+def test_toggle_bom_creates_override_and_preserves_base():
+    """Toggling in a variant creates an override and leaves the base alone."""
+    fp = FakeFootprint(FakeBoard("VarA"), attributes=EXCLUDE_FROM_POS_BIT, dnp=True)
+    assert helpers.toggle_exclude_from_bom(fp) is True
+    override = fp.GetVariant("VarA")
+    assert override.GetExcludedFromBOM() is True
+    # The snapshot keeps the effective state of the other flags.
+    assert override.GetExcludedFromPosFiles() is True
+    assert override.GetDNP() is True
+    # Base attributes stay untouched.
+    assert fp.GetAttributes() == EXCLUDE_FROM_POS_BIT
+
+
+def test_toggle_bom_flips_existing_override():
+    """Toggling in a variant flips the existing override state."""
+    fp = FakeFootprint(FakeBoard("VarA"))
+    fp.AddVariant("VarA").SetExcludedFromBOM(True)
+    assert helpers.toggle_exclude_from_bom(fp) is False
+    assert helpers.get_exclude_from_bom(fp) is False
+    # The flipped override mirrored the base exactly and was dropped.
+    assert not fp.HasVariant("VarA")
+    assert fp.GetAttributes() == 0
+
+
+def test_toggle_pos_flips_existing_override():
+    """Toggling POS in a variant flips the override, not the base bits."""
+    fp = FakeFootprint(FakeBoard("VarA"), attributes=EXCLUDE_FROM_POS_BIT)
+    assert helpers.toggle_exclude_from_pos(fp) is False
+    assert fp.GetVariant("VarA").GetExcludedFromPosFiles() is False
+    assert fp.GetAttributes() == EXCLUDE_FROM_POS_BIT
+
+
+def test_toggle_legacy_footprint_uses_base_bits():
+    """Footprints without the variant API keep the old toggle behavior."""
+    fp = LegacyFootprint()
+    assert helpers.toggle_exclude_from_bom(fp) is True
+    assert fp.GetAttributes() == EXCLUDE_FROM_BOM_BIT
+
+
+def test_toggle_none_footprint():
+    """None footprints return None."""
+    assert helpers.toggle_exclude_from_bom(None) is None
+    assert helpers.toggle_exclude_from_pos(None) is None
+
+
+def test_toggle_round_trip_drops_redundant_override():
+    """Toggling twice removes the override so inheritance is restored."""
+    fp = FakeFootprint(FakeBoard("VarA"), attributes=EXCLUDE_FROM_POS_BIT)
+    assert helpers.toggle_exclude_from_bom(fp) is True
+    assert fp.HasVariant("VarA")
+    assert helpers.toggle_exclude_from_bom(fp) is False
+    assert not fp.HasVariant("VarA")
+    # Base attributes never changed along the way.
+    assert fp.GetAttributes() == EXCLUDE_FROM_POS_BIT
+
+
+def test_toggle_round_trip_keeps_override_with_other_changes():
+    """An override that still differs from base survives a toggle round trip."""
+    fp = FakeFootprint(FakeBoard("VarA"))
+    fp.AddVariant("VarA").SetDNP(True)
+    assert helpers.toggle_exclude_from_bom(fp) is True
+    assert helpers.toggle_exclude_from_bom(fp) is False
+    assert fp.HasVariant("VarA")
+    assert fp.GetVariant("VarA").GetDNP() is True
+
+
+def test_toggle_round_trip_keeps_override_with_field_overrides():
+    """An override carrying field overrides survives a toggle round trip."""
+    fp = FakeFootprint(FakeBoard("VarA"))
+    fp.AddVariant("VarA").SetFieldValue("LCSC", "C999")
+    assert helpers.toggle_exclude_from_pos(fp) is True
+    assert helpers.toggle_exclude_from_pos(fp) is False
+    assert fp.HasVariant("VarA")
+    assert fp.GetVariant("VarA").GetFieldValue("LCSC") == "C999"

--- a/fabrication.py
+++ b/fabrication.py
@@ -32,7 +32,7 @@ from pcbnew import (  # pylint: disable=import-error
     wxPoint,
 )
 
-from .footprint_helpers import get_is_dnp
+from .footprint_helpers import get_is_dnp, get_resolved_value
 
 # Compatibility hack for V6 / V7 / V7.99
 try:
@@ -163,7 +163,7 @@ class Fabrication:
             rotation = (180 - rotation) % 360
         for getter in (
             lambda: str(footprint.GetReference()),
-            lambda: str(footprint.GetValue()),
+            lambda: str(get_resolved_value(footprint)),
             lambda: str(footprint.GetFPID().GetLibItemName()),
         ):
             match = self._find_correction(getter())
@@ -177,7 +177,7 @@ class Fabrication:
         self.logger.info(
             "Fixed rotation of %s (%s / %s) on %s Layer by %d degrees",
             footprint.GetReference(),
-            footprint.GetValue(),
+            get_resolved_value(footprint),
             footprint.GetFPID().GetLibItemName(),
             "Top" if footprint.GetLayer() == 0 else "Bottom",
             correction,
@@ -210,7 +210,7 @@ class Fabrication:
             self.logger.info(
                 "Fixed position of %s (%s / %s) on %s Layer by %f/%f",
                 footprint.GetReference(),
-                footprint.GetValue(),
+                get_resolved_value(footprint),
                 footprint.GetFPID().GetLibItemName(),
                 "Top" if footprint.GetLayer() == 0 else "Bottom",
                 offset[0],
@@ -223,7 +223,7 @@ class Fabrication:
         """Fix the position of footprints in order to be correct for JLCPCB."""
         for getter in (
             lambda: str(footprint.GetReference()),
-            lambda: str(footprint.GetValue()),
+            lambda: str(get_resolved_value(footprint)),
             lambda: str(footprint.GetFPID().GetLibItemName()),
         ):
             match = self._find_correction(getter())

--- a/footprint_helpers.py
+++ b/footprint_helpers.py
@@ -1,46 +1,228 @@
-"""Helpers for reading and mutating KiCad footprint and board state."""
+"""Helpers for reading and mutating KiCad footprint and board state.
+
+KiCad 10 introduced design variants: footprint fields, DNP and the
+exclude-from-BOM/POS flags can be overridden per variant, and the plain
+getters (``GetValue``, ``IsDNP``, ``GetAttributes``, field text) always
+return the base (default variant) state. The helpers in this module
+resolve state through the ``*ForVariant`` APIs so the plugin reflects the
+variant that is active in pcbnew, while falling back to the base state on
+KiCad versions without variant support.
+"""
 
 import re
+
+LCSC_NAME_REGEX = re.compile(r"lcsc|jlc", re.IGNORECASE)
+LCSC_VALUE_REGEX = re.compile(r"^C\d+$")
 
 EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
 
 
+def get_current_variant(board) -> str:
+    """Get the active design variant name of a board, "" for the default variant."""
+    if not board:
+        return ""
+    getter = getattr(board, "GetCurrentVariant", None)
+    if not callable(getter):
+        return ""
+    return str(getter() or "")
+
+
+def get_footprint_variant(footprint) -> str:
+    """Get the active design variant of the board the footprint belongs to."""
+    get_board = getattr(footprint, "GetBoard", None)
+    if not callable(get_board):
+        return ""
+    return get_current_variant(get_board())
+
+
+def resolve_field_value(footprint, field_name: str, variant: str):
+    """Resolve a field's text for a variant, or None when unsupported.
+
+    KiCad falls back to the base field text when the variant does not
+    override the field, so the result is always the effective text.
+    """
+    if not variant:
+        return None
+    resolver = getattr(footprint, "GetFieldValueForVariant", None)
+    if not callable(resolver):
+        return None
+    return str(resolver(variant, field_name))
+
+
+def get_variant_field_overrides(footprint, variant: str):
+    """Get the {name: value} field overrides a footprint defines for a variant."""
+    get_variant = getattr(footprint, "GetVariant", None)
+    if not variant or not callable(get_variant):
+        return {}
+    fp_variant = get_variant(variant)
+    if fp_variant is None:
+        return {}
+    return {str(name): str(value) for name, value in fp_variant.GetFields().items()}
+
+
+def get_resolved_value(footprint) -> str:
+    """Get the footprint's Value field resolved for the active design variant."""
+    resolved = resolve_field_value(footprint, "Value", get_footprint_variant(footprint))
+    if resolved is None:
+        return footprint.GetValue()
+    return resolved
+
+
 def get_lcsc_value(fp):
-    """Get the first lcsc number (C123456 for example) from the properties of the footprint."""
+    """Get the first lcsc number (C123456 for example) from the properties of the footprint.
+
+    Field values are resolved for the active design variant, including
+    fields that only exist as a variant override.
+    """
+    variant = get_footprint_variant(fp)
     try:
         for field in fp.GetFields():
-            if re.match(r"lcsc|jlc", field.GetName(), re.IGNORECASE) and re.match(
-                r"^C\d+$", field.GetText()
-            ):
-                return field.GetText()
+            name = field.GetName()
+            if not LCSC_NAME_REGEX.match(name):
+                continue
+            text = resolve_field_value(fp, name, variant)
+            if text is None:
+                text = field.GetText()
+            if LCSC_VALUE_REGEX.match(text):
+                return text
     except AttributeError:
         for key, value in fp.GetProperties().items():
-            if re.match(r"lcsc|jlc", key, re.IGNORECASE) and re.match(r"^C\d+$", value):
+            if LCSC_NAME_REGEX.match(key) and LCSC_VALUE_REGEX.match(value):
                 return value
+        return ""
+    # The variant may override a field that has no base counterpart.
+    for name, value in get_variant_field_overrides(fp, variant).items():
+        if LCSC_NAME_REGEX.match(name) and LCSC_VALUE_REGEX.match(value):
+            return value
     return ""
 
 
 def set_lcsc_value(fp, lcsc: str):
-    """Set an lcsc number on the footprint, using LCSC as property name if needed."""
+    """Set an lcsc number on the footprint, using LCSC as property name if needed.
+
+    When the active design variant explicitly overrides an lcsc-named
+    field — even with an empty or placeholder text — that override is
+    updated so the assignment is what the active variant shows; otherwise
+    the base field is written and inherited by all variants without an
+    override.
+    """
+    variant = get_footprint_variant(fp)
     lcsc_field = None
     for field in fp.GetFields():
-        if re.match(r"lcsc|jlc", field.GetName(), re.IGNORECASE) and re.match(
-            r"^C\d+$", field.GetText()
-        ):
+        name = field.GetName()
+        if not LCSC_NAME_REGEX.match(name):
+            continue
+        text = resolve_field_value(fp, name, variant)
+        if text is None:
+            text = field.GetText()
+        if LCSC_VALUE_REGEX.match(text):
             lcsc_field = field
 
     if lcsc_field:
-        fp.SetField(lcsc_field.GetName(), lcsc)
+        field_name = lcsc_field.GetName()
+        if _set_variant_field_override(fp, variant, field_name, lcsc):
+            return
+        fp.SetField(field_name, lcsc)
+        return
+
+    # Nothing resolves to a part number right now, but an lcsc-named
+    # override (e.g. explicitly cleared for this variant) still owns the
+    # value shown in the active variant and must be updated in place lest
+    # the base write stays shadowed.
+    override_name = None
+    for name, value in get_variant_field_overrides(fp, variant).items():
+        if not LCSC_NAME_REGEX.match(name):
+            continue
+        if LCSC_VALUE_REGEX.match(value):
+            override_name = name
+            break
+        if override_name is None:
+            override_name = name
+    if override_name is not None:
+        fp.GetVariant(variant).SetFieldValue(override_name, lcsc)
+        return
+
+    fp.SetField("LCSC", lcsc)
+    if hasattr(fp, "GetFieldByName"):
+        fp.GetFieldByName("LCSC").SetVisible(False)
     else:
-        fp.SetField("LCSC", lcsc)
-        if hasattr(fp, "GetFieldByName"):
-            fp.GetFieldByName("LCSC").SetVisible(False)
-        else:
-            for field in fp.GetFields():
-                if field.GetName() == "LCSC":
-                    field.SetVisible(False)
-                    break
+        for field in fp.GetFields():
+            if field.GetName() == "LCSC":
+                field.SetVisible(False)
+                break
+
+
+def lcsc_override_cleared(fp) -> bool:
+    """Return True when the active variant shadows the LCSC field with a non-part text.
+
+    Used to distinguish "this variant explicitly has no part assigned"
+    from "the footprint has no LCSC field at all" when syncing the board
+    into the project database.
+    """
+    variant = get_footprint_variant(fp)
+    if not variant:
+        return False
+    for name, value in get_variant_field_overrides(fp, variant).items():
+        if LCSC_NAME_REGEX.match(name) and not LCSC_VALUE_REGEX.match(value):
+            return True
+    return False
+
+
+def _set_variant_field_override(fp, variant: str, field_name: str, value: str) -> bool:
+    """Update an existing variant field override, return True when done."""
+    get_variant = getattr(fp, "GetVariant", None)
+    if not variant or not callable(get_variant):
+        return False
+    fp_variant = get_variant(variant)
+    if fp_variant is None or not fp_variant.HasFieldValue(field_name):
+        return False
+    fp_variant.SetFieldValue(field_name, value)
+    return True
+
+
+def _get_or_create_variant_override(footprint, variant: str):
+    """Get the footprint's override object for a variant, creating it if needed.
+
+    KiCad initializes a new footprint variant with a snapshot of the
+    current base flags, so creating one to change a single flag preserves
+    the effective state of the others.
+    """
+    get_variant = getattr(footprint, "GetVariant", None)
+    add_variant = getattr(footprint, "AddVariant", None)
+    if not callable(get_variant) or not callable(add_variant):
+        return None
+    existing = get_variant(variant)
+    if existing is not None:
+        return existing
+    return add_variant(variant)
+
+
+def _drop_variant_override_if_redundant(footprint, variant: str):
+    """Delete a variant override that mirrors the base state exactly.
+
+    Flag overrides are snapshots that stop inheriting later base changes,
+    so a toggle round-trip would otherwise leave a behavior-changing
+    override in the saved board file.
+    """
+    get_variant = getattr(footprint, "GetVariant", None)
+    delete_variant = getattr(footprint, "DeleteVariant", None)
+    if not callable(get_variant) or not callable(delete_variant):
+        return
+    override = get_variant(variant)
+    if override is None or get_variant_field_overrides(footprint, variant):
+        return
+    is_dnp = getattr(footprint, "IsDNP", None)
+    if override.GetDNP() != bool(is_dnp() if callable(is_dnp) else False):
+        return
+    attributes = footprint.GetAttributes()
+    if override.GetExcludedFromBOM() != bool(get_bit(attributes, EXCLUDE_FROM_BOM)):
+        return
+    if override.GetExcludedFromPosFiles() != bool(
+        get_bit(attributes, EXCLUDE_FROM_POS)
+    ):
+        return
+    delete_variant(variant)
 
 
 def get_valid_footprints(board):
@@ -63,25 +245,37 @@ def toggle_bit(value, bit):
 
 
 def get_exclude_from_pos(footprint):
-    """Get the 'exclude from POS' property of a footprint."""
+    """Get the 'exclude from POS' property of a footprint for the active variant."""
     if not footprint:
         return None
+    variant = get_footprint_variant(footprint)
+    getter = getattr(footprint, "GetExcludedFromPosFilesForVariant", None)
+    if variant and callable(getter):
+        return bool(getter(variant))
     val = footprint.GetAttributes()
     return bool(get_bit(val, EXCLUDE_FROM_POS))
 
 
 def get_exclude_from_bom(footprint):
-    """Get the 'exclude from BOM' property of a footprint."""
+    """Get the 'exclude from BOM' property of a footprint for the active variant."""
     if not footprint:
         return None
+    variant = get_footprint_variant(footprint)
+    getter = getattr(footprint, "GetExcludedFromBOMForVariant", None)
+    if variant and callable(getter):
+        return bool(getter(variant))
     val = footprint.GetAttributes()
     return bool(get_bit(val, EXCLUDE_FROM_BOM))
 
 
 def get_is_dnp(footprint):
-    """Get the runtime 'Do not place' state of a footprint."""
+    """Get the 'Do not place' state of a footprint for the active variant."""
     if not footprint:
         return False
+    variant = get_footprint_variant(footprint)
+    getter = getattr(footprint, "GetDNPForVariant", None)
+    if variant and callable(getter):
+        return bool(getter(variant))
     is_dnp = getattr(footprint, "IsDNP", None)
     if not callable(is_dnp):
         return False
@@ -89,9 +283,22 @@ def get_is_dnp(footprint):
 
 
 def toggle_exclude_from_pos(footprint):
-    """Toggle the 'exclude from POS' property of a footprint."""
+    """Toggle the 'exclude from POS' property of a footprint.
+
+    With a non-default variant active the flag is flipped on the
+    footprint's override for that variant, leaving the base state and
+    other variants untouched.
+    """
     if not footprint:
         return None
+    variant = get_footprint_variant(footprint)
+    if variant:
+        override = _get_or_create_variant_override(footprint, variant)
+        if override is not None:
+            new_state = not get_exclude_from_pos(footprint)
+            override.SetExcludedFromPosFiles(new_state)
+            _drop_variant_override_if_redundant(footprint, variant)
+            return new_state
     val = footprint.GetAttributes()
     val = toggle_bit(val, EXCLUDE_FROM_POS)
     footprint.SetAttributes(val)
@@ -99,9 +306,22 @@ def toggle_exclude_from_pos(footprint):
 
 
 def toggle_exclude_from_bom(footprint):
-    """Toggle the 'exclude from BOM' property of a footprint."""
+    """Toggle the 'exclude from BOM' property of a footprint.
+
+    With a non-default variant active the flag is flipped on the
+    footprint's override for that variant, leaving the base state and
+    other variants untouched.
+    """
     if not footprint:
         return None
+    variant = get_footprint_variant(footprint)
+    if variant:
+        override = _get_or_create_variant_override(footprint, variant)
+        if override is not None:
+            new_state = not get_exclude_from_bom(footprint)
+            override.SetExcludedFromBOM(new_state)
+            _drop_variant_override_if_redundant(footprint, variant)
+            return new_state
     val = footprint.GetAttributes()
     val = toggle_bit(val, EXCLUDE_FROM_BOM)
     footprint.SetAttributes(val)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -53,6 +53,7 @@ from .events import (
 )
 from .fabrication import Fabrication
 from .footprint_helpers import (
+    get_current_variant,
     get_is_dnp,
     set_lcsc_value,
     toggle_exclude_from_bom,
@@ -136,6 +137,8 @@ class JLCPCBTools(wx.Dialog):
         self.schematic_name = f"{self.board_name.split('.')[0]}.kicad_sch"
         self.hide_bom_parts = False
         self.hide_pos_parts = False
+        self.synced_variant = ""
+        self.title_base = f"JLCPCB Tools [ {getVersion()} ]"
         self.library: Library
         self.store: Store
         self.settings = {}
@@ -645,6 +648,7 @@ class JLCPCBTools(wx.Dialog):
             self.on_assembly_enrichment_completed,
         )
         self.Bind(EVT_BOM_DATA_CHANGED_EVENT, self.on_bom_data_changed)
+        self.Bind(wx.EVT_ACTIVATE, self.on_activate)
 
         self.enable_part_specific_toolbar_buttons(False)
 
@@ -711,8 +715,8 @@ class JLCPCBTools(wx.Dialog):
         meta = self.library.get_parts_db_info()
         if meta is not None:
             last_update = dt.fromisoformat(meta.last_update).strftime("%Y-%m-%d %H:%M")
-            self.SetTitle(
-                f"JLCPCB Tools [ {getVersion()} ] | Last database update: {last_update}",
+            self.title_base = (
+                f"JLCPCB Tools [ {getVersion()} ] | Last database update: {last_update}"
             )
             self.logger.debug(
                 "JLCPCB version %s, last database update %s, part count %d, size (bytes) %d",
@@ -722,13 +726,49 @@ class JLCPCBTools(wx.Dialog):
                 meta.size,
             )
         else:
-            self.SetTitle(
-                f"JLCPCB Tools [ {getVersion()} ] | Last database update: No DB found",
+            self.title_base = (
+                f"JLCPCB Tools [ {getVersion()} ] | Last database update: No DB found"
             )
             self.logger.debug("JLCPCB version %s, no parts db info found", getVersion())
+        self.update_title()
+
+    def update_title(self):
+        """Set the window title, appending the active design variant if any."""
+        title = self.title_base
+        if self.synced_variant:
+            title += f" | Variant: {self.synced_variant}"
+        self.SetTitle(title)
+
+    def on_activate(self, e):
+        """Handle window activation, e.g. when switching back from pcbnew."""
+        e.Skip()
+        if e.GetActive():
+            self.refresh_if_variant_changed()
+
+    def refresh_if_variant_changed(self):
+        """Re-sync part data when the active design variant changed in pcbnew."""
+        if getattr(self, "store", None) is None:
+            return
+        library = getattr(self, "library", None)
+        if library is None or library.state != LibraryState.INITIALIZED:
+            return
+        variant = get_current_variant(self.pcbnew.GetBoard())
+        if variant == self.synced_variant:
+            return
+        self.logger.info(
+            "Design variant changed from '%s' to '%s', refreshing part data",
+            self.synced_variant or "<Default>",
+            variant or "<Default>",
+        )
+        self.synced_variant = variant
+        self.update_title()
+        self.store.update_from_board()
+        self.populate_footprint_list()
 
     def init_store(self):
         """Initialize the store of part assignments."""
+        self.synced_variant = get_current_variant(self.pcbnew.GetBoard())
+        self.update_title()
         self.store = Store(self, self.project_path, self.pcbnew.GetBoard())
         if self.library.state == LibraryState.INITIALIZED:
             self.populate_footprint_list()
@@ -1520,6 +1560,7 @@ class JLCPCBTools(wx.Dialog):
 
     def generate_fabrication_data(self, *_):
         """Generate fabrication data."""
+        self.refresh_if_variant_changed()
         self.generate_button.Enable(False)
         self.reset_gauge()
         wx.BeginBusyCursor()
@@ -1753,6 +1794,7 @@ class JLCPCBTools(wx.Dialog):
         if success:
             if (lcsc := self.sanitize_lcsc(text_data.GetText())) != "":
                 updated_references = []
+                board = self.pcbnew.GetBoard()
                 for item in self.footprint_list.GetSelections():
                     details = self.library.get_part_details(lcsc)
                     params = params_for_part(details)
@@ -1761,6 +1803,8 @@ class JLCPCBTools(wx.Dialog):
                         reference, lcsc, details["type"], details["stock"], params
                     )
                     self.store.set_lcsc(reference, lcsc)
+                    if fp := board.FindFootprintByReference(reference):
+                        set_lcsc_value(fp, lcsc)
                     updated_references.append(reference)
                 self.start_assembly_enrichment(updated_references)
                 wx.PostEvent(self, BomDataChangedEvent(source="paste_part_lcsc"))
@@ -1797,6 +1841,19 @@ class JLCPCBTools(wx.Dialog):
 
     def export_to_schematic(self, *_):
         """Dialog to select schematics."""
+        variant = get_current_variant(self.pcbnew.GetBoard())
+        if variant:
+            result = wx.MessageBox(
+                f"The design variant '{variant}' is active. Schematic fields are "
+                "variant-independent, so the exported LCSC numbers are the ones "
+                "resolved for this variant and will apply to all variants.\n\n"
+                "Switch to the default variant first if that is not intended. "
+                "Continue anyway?",
+                "Design variant active",
+                wx.OK | wx.CANCEL | wx.CENTER,
+            )
+            if result == wx.CANCEL:
+                return
         with wx.FileDialog(
             self,
             "Select Schematics",
@@ -1824,6 +1881,7 @@ class JLCPCBTools(wx.Dialog):
 
     def search_foot_mapping(self, *_):
         """Search for a footprint mapping."""
+        board = self.pcbnew.GetBoard()
         for item in self.footprint_list.GetSelections():
             reference = self.partlist_data_model.get_reference(item)
             footprint = self.partlist_data_model.get_footprint(item)
@@ -1832,6 +1890,8 @@ class JLCPCBTools(wx.Dialog):
                 if self.library.get_mapping_data(footprint, value):
                     lcsc = self.library.get_mapping_data(footprint, value)[2]
                     self.store.set_lcsc(reference, lcsc)
+                    if fp := board.FindFootprintByReference(reference):
+                        set_lcsc_value(fp, lcsc)
                     self.logger.info("Found %s", lcsc)
                     details = self.library.get_part_details(lcsc)
                     params = params_for_part(self.library.get_part_details(lcsc))

--- a/store.py
+++ b/store.py
@@ -12,7 +12,9 @@ from .footprint_helpers import (
     get_exclude_from_bom,
     get_exclude_from_pos,
     get_lcsc_value,
+    get_resolved_value,
     get_valid_footprints,
+    lcsc_override_cleared,
 )
 from .footprint_metadata import (
     footprint_has_tht,
@@ -364,7 +366,7 @@ class Store:
         for fp in get_valid_footprints(self.board):
             board_part = {
                 "reference": fp.GetReference(),
-                "value": fp.GetValue(),
+                "value": get_resolved_value(fp),
                 "footprint": str(fp.GetFPID().GetLibItemName()),
                 "lcsc": get_lcsc_value(fp),
                 "exclude_from_bom": get_exclude_from_bom(fp),
@@ -415,6 +417,13 @@ class Store:
                             "Part %s is already in the database and has a lcsc value, the value supplied from the board will overwrite that in the database.",
                             board_part["reference"],
                         )
+                    self.update_part(board_part)
+                # the active design variant explicitly clears the part
+                elif db_part and db_part["lcsc"] and lcsc_override_cleared(fp):
+                    self.logger.debug(
+                        "Part %s has its lcsc value explicitly cleared in the active design variant, clearing it in the database.",
+                        board_part["reference"],
+                    )
                     self.update_part(board_part)
             else:
                 # If something changed, we overwrite the part and dump the lcsc value or use the one supplied by the board

--- a/tests/test_bom_designator_split.py
+++ b/tests/test_bom_designator_split.py
@@ -33,6 +33,7 @@ sys.modules["kicadplugin"] = _pkg
 
 _footprint_helpers = types.ModuleType("kicadplugin.footprint_helpers")
 _footprint_helpers.get_is_dnp = lambda fp: False  # type: ignore[attr-defined]
+_footprint_helpers.get_resolved_value = lambda fp: fp.GetValue()  # type: ignore[attr-defined]
 sys.modules["kicadplugin.footprint_helpers"] = _footprint_helpers
 
 _spec = importlib.util.spec_from_file_location(

--- a/tests/test_fabrication_corrections.py
+++ b/tests/test_fabrication_corrections.py
@@ -19,6 +19,7 @@ sys.modules["kicadplugin"] = _pkg
 
 _footprint_helpers = types.ModuleType("kicadplugin.footprint_helpers")
 _footprint_helpers.get_is_dnp = lambda fp: False  # type: ignore[attr-defined]
+_footprint_helpers.get_resolved_value = lambda fp: fp.GetValue()  # type: ignore[attr-defined]
 sys.modules["kicadplugin.footprint_helpers"] = _footprint_helpers
 
 _spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
The plugin previously read only base footprint state (GetValue, IsDNP, GetAttributes, field text), which in KiCad 10 always reflects the default variant, so the part list, project database, and generated BOM/CPL files ignored the active design variant.

- footprint_helpers: resolve LCSC/Value fields, DNP, and the exclude-from-BOM/POS flags through the KiCad 10 *ForVariant APIs for the board's current variant, with getattr guards so KiCad 8/9 and the standalone stubs keep the old behavior.
- Writes are variant-aware too: BOM/POS toggles flip the footprint's variant override (created on demand, deleted again when it ends up mirroring the base so inheritance is restored); LCSC assignment updates an existing lcsc-named override - including one explicitly cleared or holding a placeholder - and otherwise writes the base field, which variants without an override inherit.
- store: sync variant-resolved values into the project database and clear the stored LCSC number when the active variant explicitly blanks the part (lcsc_override_cleared).
- mainwindow: re-sync the store and part list when the active variant changes (on window activation and before Generate), show the active variant in the window title, write the board LCSC field from the paste and mapping-search flows like the part selector does, and warn before exporting LCSC numbers to the variant-independent schematic fields while a variant is active.
- fabrication: match rotation/position corrections against the variant-resolved value and log the same.
- tests: variant helper test suite with fakes mirroring the probed KiCad 10.0.3 semantics (base fallback, flag snapshot on override creation, sparse field overrides, explicit empty override shadowing).