### PR TITLE
Write Excellon drill files in millimetres

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -373,7 +373,9 @@ class Fabrication:
         offset = self.board.GetDesignSettings().GetAuxOrigin()
         mergeNPTH = False
         drlwriter.SetOptions(mirror, minimalHeader, offset, mergeNPTH)
-        drlwriter.SetFormat(False)
+        # JLCPCB asks for Excellon drill data in metric units.
+        metric = True
+        drlwriter.SetFormat(metric)
         genDrl = True
         genMap = True
         drlwriter.CreateDrillandMapFilesSet(self.gerberdir, genDrl, genMap)


### PR DESCRIPTION
EXCELLON_WRITER.SetFormat takes aMetric as its first argument:

```
SetFormat(EXCELLON_WRITER self, bool aMetric,
          GENDRILL_WRITER_BASE::ZEROS_FMT aZerosFmt=DECIMAL_FORMAT, ...)
```

generate_excellon calls SetFormat(False), so drill files come out in inches. JLCPCB documents millimetres with a decimal format for drill data.

Checked the actual output on a board, and header goes from `INCH` to `METRIC`, and tools from `T1C0.0079` to `T1C0.200`. Since minimalHeader is False the unit is declared either way, so this has been parsed fine and nothing was mis-drilled. It just does not match the documented format.