### PR TITLE
Copper zones that pour no copper are exported silently

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -127,12 +127,28 @@ class Fabrication:
         }
 
     def fill_zones(self):
-        """Refill copper zones following user prompt."""
+        """Refill copper zones, returning the zone layers that poured no copper."""
+        zones = self.board.Zones()
+        # Refilling mutates the board, reporting does not, so only the refill is optional.
         if self.parent.settings.get("gerber", {}).get("fill_zones", True):
-            filler = ZONE_FILLER(self.board)
-            zones = self.board.Zones()
-            filler.Fill(zones)
+            ZONE_FILLER(self.board).Fill(zones)
             Refresh()
+
+        empty_pours = []
+        for zone in zones:
+            # Rule areas are keepouts, so they never hold copper.
+            if zone.GetIsRuleArea():
+                continue
+            # The filler pours each layer of a zone separately, so check them the same way.
+            for layer in zone.GetLayerSet().Seq():
+                # Zones on technical layers are graphics, not copper.
+                if not IsCopperLayer(layer):
+                    continue
+                if zone.GetFilledPolysList(layer).Area() > 0:
+                    continue
+                name = self.board.GetLayerName(layer)
+                empty_pours.append(f"{zone.GetNetname() or 'no net'} on {name}")
+        return empty_pours
 
     def _find_correction(self, value):
         """Return (rotation, offset) for the first correction matching value.

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -1575,10 +1575,33 @@ class JLCPCBTools(wx.Dialog):
                         )
                         return
 
-            self.run_generation_step(
-                "Filling copper zones",
+            refill = self.settings.get("gerber", {}).get("fill_zones", True)
+            empty_pours = self.run_generation_step(
+                "Filling copper zones" if refill else "Checking copper zone fills",
                 self.fabrication.fill_zones,
             )
+            if empty_pours:
+                listed = "\n".join(f"  {pour}" for pour in empty_pours)
+                dialog = wx.MessageDialog(
+                    self,
+                    f"These copper zones contain no filled copper:\n\n{listed}\n\n"
+                    "Plotting now ships the board without that copper.",
+                    "Empty copper zones",
+                    wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING | wx.CENTER,
+                )
+                try:
+                    dialog.SetYesNoLabels("Continue Anyway", "Cancel Export")
+                    result = dialog.ShowModal()
+                finally:
+                    dialog.Destroy()
+                self.logger.warning(
+                    "Copper zones with no filled copper, user chose to %s export:\n%s",
+                    "continue" if result == wx.ID_YES else "stop",
+                    listed,
+                )
+                if result != wx.ID_YES:
+                    self.report_generation_step("Export stopped by empty copper zones")
+                    return
 
             drc_ok = self.run_generation_step(
                 "Running pre-export DRC check",


### PR DESCRIPTION
`fill_zones` refills and moves on:

```
filler = ZONE_FILLER(self.board)
zones = self.board.Zones()
filler.Fill(zones)      # bool, dropped
Refresh()
```

So a zone that pours to nothing goes to the plotter unfilled, with no logs, and looks the same as a good export.

Fill() cannot report it, since it only returns false on paths this plugin does not reach, and SetIsFilled(true) is set on every non rule area zone whatever the result. GetFilledArea() does not work either, since it sums the layers and hides a zone that fills on F.Cu but comes out empty on B.Cu. So the check is the filled polygon area per layer.