### PR TITLE
Feature/safe bom sync

### DIFF
--- a/schematicexport.py
+++ b/schematicexport.py
@@ -4,6 +4,7 @@ import logging
 import os
 import os.path
 import re
+from typing import Optional
 
 from pcbnew import GetBuildVersion  # pylint: disable=import-error
 
@@ -15,16 +16,158 @@ class SchematicExport:
 
     # This only works with KiCad v6/v7/v8 files, if the format changes, this will probably break
 
+    _IN_BOM_RX = re.compile(r"^(\s*)\(in_bom\s+(yes|no)\)")
+    _REFERENCE_RX = re.compile(r'\(property\s+"Reference"\s+"([^"]*)"')
+    _INSTANCE_REF_RX = re.compile(r'\(reference\s+"([^"]*)"\)')
+    _PROJECT_RX = re.compile(r'\(project\s+"([^"]*)"')
+    _UUID_RX = re.compile(r'\(uuid\s+"?([^"\s)]*)"?\)')
+    _PATH_RX = re.compile(r'\(path\s+"([^"]*)"')
+
     def __init__(self, parent):
         self.logger = logging.getLogger(__name__)
         self.parent = parent
 
-    def load_schematic(self, paths):
+    def _resolved_bom(
+        self, refs: set[str], store_parts: list[dict[str, object]]
+    ) -> Optional[bool]:  # noqa: UP045
+        """Return a shared exclude-from-BOM state, or None when it is unsafe."""
+        matched = {
+            part["reference"]: bool(part["exclude_from_bom"])
+            for part in store_parts
+            if part["reference"] in refs
+        }
+        if not matched:
+            return None
+        if set(matched) != refs:
+            self.logger.warning(
+                "Not updating BOM state for %s; PCB data is missing %s",
+                sorted(refs),
+                sorted(refs - set(matched)),
+            )
+            return None
+        states = set(matched.values())
+        if len(states) != 1:
+            self.logger.warning(
+                "Not updating BOM state for %s; instances disagree", sorted(refs)
+            )
+            return None
+        return states.pop()
+
+    def _symbol_instances6(self) -> dict[str, set[str]]:
+        """Read KiCad 6's project-level symbol instance references by UUID."""
+        root_name = os.path.splitext(self.parent.board_name)[0] + ".kicad_sch"
+        path = os.path.join(self.parent.project_path, root_name)
+        try:
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+        except OSError:
+            lines = []
+
+        refs = {}
+        in_instances = False
+        symbol_uuid = ""
+        for line in lines:
+            if "(symbol_instances" in line:
+                in_instances = True
+                continue
+            if not in_instances:
+                continue
+            if match := self._PATH_RX.search(line):
+                symbol_uuid = match.group(1).rsplit("/", 1)[-1]
+            if symbol_uuid and (match := self._INSTANCE_REF_RX.search(line)):
+                refs.setdefault(symbol_uuid, set()).add(match.group(1))
+                symbol_uuid = ""
+        if in_instances:
+            return refs
+
+        self.logger.warning(
+            "Unable to find KiCad 6 symbol instances; BOM states will not be updated"
+        )
+        return {}
+
+    def _bom_updates(
+        self,
+        lines: list[str],
+        store_parts: list[dict[str, object]],
+        split_symbol: bool = False,
+        instance_refs: Optional[dict[str, set[str]]] = None,  # noqa: UP045
+    ) -> dict[int, str]:
+        """Return in_bom line updates that are safe for every symbol instance."""
+        project_name = os.path.splitext(self.parent.board_name)[0]
+        symbols = []
+        symbol = None
+        symbol_end = ""
+        project = None
+
+        for index, line in enumerate(lines):
+            in_line = line.rstrip()
+            symbol_start = (
+                "(symbol" in in_line
+                and index + 1 < len(lines)
+                and "(lib_id" in lines[index + 1]
+                if split_symbol
+                else "(symbol (lib_id" in in_line
+            )
+            if symbol_start:
+                symbol = {
+                    "bom_line": None,
+                    "uuid": "",
+                    "reference": "",
+                    "instances": None,
+                }
+                symbols.append(symbol)
+                symbol_end = in_line[: in_line.index("(symbol")] + ")"
+                project = None
+                continue
+            if symbol is None:
+                continue
+            if in_line == symbol_end:
+                symbol = None
+                project = None
+                continue
+            if symbol["bom_line"] is None and self._IN_BOM_RX.search(in_line):
+                symbol["bom_line"] = index
+            if not symbol["uuid"] and (match := self._UUID_RX.search(in_line)):
+                symbol["uuid"] = match.group(1)
+            if match := self._REFERENCE_RX.search(in_line):
+                symbol["reference"] = match.group(1)
+            if instance_refs is None:
+                if "(instances" in in_line:
+                    symbol["instances"] = {}
+                if match := self._PROJECT_RX.search(in_line):
+                    project = match.group(1)
+                    if symbol["instances"] is None:
+                        symbol["instances"] = {}
+                    symbol["instances"].setdefault(project, set())
+                if project is not None and (
+                    match := self._INSTANCE_REF_RX.search(in_line)
+                ):
+                    symbol["instances"][project].add(match.group(1))
+
+        updates = {}
+        for symbol in symbols:
+            if instance_refs is not None:
+                refs = instance_refs.get(symbol["uuid"], set())
+            elif symbol["instances"] is None:
+                refs = {symbol["reference"]}
+            else:
+                refs = symbol["instances"].get(project_name)
+                if refs is None and set(symbol["instances"]) == {""}:
+                    refs = symbol["instances"][""]
+                if refs is None:
+                    refs = set()
+            bom = self._resolved_bom(refs, store_parts)
+            if bom is not None and symbol["bom_line"] is not None:
+                updates[symbol["bom_line"]] = "no" if bom else "yes"
+        return updates
+
+    def load_schematic(self, paths: list[str]) -> None:
         """Load schematic file."""
         if is_version6(GetBuildVersion()):
             self.logger.info("Kicad 6...")
+            instance_refs = self._symbol_instances6()
             for path in paths:
-                self._update_schematic6(path)
+                self._update_schematic6(path, instance_refs)
         elif is_version7(GetBuildVersion()):
             self.logger.info("Kicad 7...")
             for path in paths:
@@ -34,7 +177,7 @@ class SchematicExport:
             for path in paths:
                 self._update_schematic(path)
 
-    def _update_schematic6(self, path):
+    def _update_schematic6(self, path: str, instance_refs: dict[str, set[str]]) -> None:
         """Only works with KiCad V6 files."""
         self.logger.info("Reading %s...", path)
         # Regex to look through schematic property, if we hit the pin section without finding a LCSC property, add it
@@ -56,6 +199,11 @@ class SchematicExport:
         newlines = []
         with open(path, encoding="utf-8") as f:
             lines = f.readlines()
+
+        for index, desired in self._bom_updates(
+            lines, store_parts, instance_refs=instance_refs
+        ).items():
+            lines[index] = self._IN_BOM_RX.sub(rf"\1(in_bom {desired})", lines[index])
 
         if os.path.exists(path + "_old"):
             os.remove(path + "_old")
@@ -111,7 +259,7 @@ class SchematicExport:
                 f.write(line + "\n")
         self.logger.info("Added LCSC's to %s(maybe?)", path)
 
-    def _update_schematic7(self, path):
+    def _update_schematic7(self, path: str) -> None:
         """Only works with KiCad V7 files."""
         self.logger.info("Reading %s...", path)
         # Regex to look through schematic property, if we hit the pin section without finding a LCSC property, add it
@@ -132,6 +280,9 @@ class SchematicExport:
         newlines = []
         with open(path, encoding="utf-8") as f:
             lines = f.readlines()
+
+        for index, desired in self._bom_updates(lines, store_parts).items():
+            lines[index] = self._IN_BOM_RX.sub(rf"\1(in_bom {desired})", lines[index])
 
         if os.path.exists(path + "_old"):
             os.remove(path + "_old")
@@ -185,7 +336,7 @@ class SchematicExport:
                 f.write(line + "\n")
         self.logger.info("Added LCSC's to %s (maybe?)", path)
 
-    def _update_schematic(self, path):
+    def _update_schematic(self, path: str) -> None:
         """Only works with KiCad V8+ files."""
         self.logger.info("Reading %s...", path)
         # Regex to look through schematic property, if we hit the pin section without finding a LCSC property, add it
@@ -205,6 +356,11 @@ class SchematicExport:
         newlines = []
         with open(path, encoding="utf-8") as f:
             lines = f.readlines()
+
+        for index, desired in self._bom_updates(
+            lines, store_parts, split_symbol=True
+        ).items():
+            lines[index] = self._IN_BOM_RX.sub(rf"\1(in_bom {desired})", lines[index])
 
         partSection = False
         files_seen = set()  # keeps sheet files already processed.

--- a/schematicexport.py
+++ b/schematicexport.py
@@ -1,5 +1,7 @@
 """Module for exporting LCSC data to schematic."""
 
+from functools import cached_property
+import glob
 import logging
 import os
 import os.path
@@ -14,7 +16,7 @@ from .core.version import is_version6, is_version7
 class SchematicExport:
     """A class to export Schematic files."""
 
-    # This only works with KiCad v6/v7/v8 files, if the format changes, this will probably break
+    # This only works with KiCad v6+ files; if the format changes, this will probably break.
 
     _IN_BOM_RX = re.compile(r"^(\s*)\(in_bom\s+(yes|no)\)")
     _REFERENCE_RX = re.compile(r'\(property\s+"Reference"\s+"([^"]*)"')
@@ -26,6 +28,44 @@ class SchematicExport:
     def __init__(self, parent):
         self.logger = logging.getLogger(__name__)
         self.parent = parent
+
+    @cached_property
+    def _project_name(self) -> Optional[str]:  # noqa: UP045
+        """Return the open board's project name, or None if it cannot be authenticated."""
+        fallback = os.path.splitext(self.parent.board_name)[0]
+        pcbnew = getattr(self.parent, "pcbnew", None)
+        get_manager = getattr(pcbnew, "GetSettingsManager", None)
+        if get_manager is None:
+            return fallback
+
+        board = pcbnew.GetBoard()
+        get_project = getattr(board, "GetProject", None)
+        if get_project is None:
+            return fallback
+        board_project = get_project()
+        if board_project is None:
+            self.logger.warning(
+                "Not updating project-specific BOM states for %s; "
+                "open board has no project identity",
+                self.parent.board_name,
+            )
+            return None
+
+        manager = get_manager()
+        matches = [
+            path
+            for path in glob.glob(os.path.join(self.parent.project_path, "*.kicad_pro"))
+            if manager.GetProject(path) == board_project
+        ]
+        if len(matches) == 1:
+            return os.path.splitext(os.path.basename(matches[0]))[0]
+        self.logger.warning(
+            "Not updating project-specific BOM states for %s; "
+            "expected one matching .kicad_pro file, found %d",
+            self.parent.board_name,
+            len(matches),
+        )
+        return None
 
     def _resolved_bom(
         self, refs: set[str], store_parts: list[dict[str, object]]
@@ -55,7 +95,10 @@ class SchematicExport:
 
     def _symbol_instances6(self) -> dict[str, set[str]]:
         """Read KiCad 6's project-level symbol instance references by UUID."""
-        root_name = os.path.splitext(self.parent.board_name)[0] + ".kicad_sch"
+        project_name = self._project_name
+        if project_name is None:
+            return {}
+        root_name = project_name + ".kicad_sch"
         path = os.path.join(self.parent.project_path, root_name)
         try:
             with open(path, encoding="utf-8") as f:
@@ -89,11 +132,9 @@ class SchematicExport:
         self,
         lines: list[str],
         store_parts: list[dict[str, object]],
-        split_symbol: bool = False,
         instance_refs: Optional[dict[str, set[str]]] = None,  # noqa: UP045
     ) -> dict[int, str]:
         """Return in_bom line updates that are safe for every symbol instance."""
-        project_name = os.path.splitext(self.parent.board_name)[0]
         symbols = []
         symbol = None
         symbol_end = ""
@@ -101,12 +142,9 @@ class SchematicExport:
 
         for index, line in enumerate(lines):
             in_line = line.rstrip()
-            symbol_start = (
-                "(symbol" in in_line
-                and index + 1 < len(lines)
-                and "(lib_id" in lines[index + 1]
-                if split_symbol
-                else "(symbol (lib_id" in in_line
+            stripped = in_line.strip()
+            symbol_start = stripped == "(symbol" or stripped.startswith(
+                ("(symbol (lib_id", "(symbol (lib_name")
             )
             if symbol_start:
                 symbol = {
@@ -144,18 +182,33 @@ class SchematicExport:
                 ):
                     symbol["instances"][project].add(match.group(1))
 
+        project_name = None
+        if instance_refs is None and any(
+            symbol["instances"] is not None and set(symbol["instances"]) != {""}
+            for symbol in symbols
+        ):
+            project_name = self._project_name
+
         updates = {}
         for symbol in symbols:
             if instance_refs is not None:
                 refs = instance_refs.get(symbol["uuid"], set())
             elif symbol["instances"] is None:
                 refs = {symbol["reference"]}
+            elif set(symbol["instances"]) == {""}:
+                refs = symbol["instances"][""]
+            elif project_name is None:
+                refs = set()
             else:
-                refs = symbol["instances"].get(project_name)
-                if refs is None and set(symbol["instances"]) == {""}:
-                    refs = symbol["instances"][""]
-                if refs is None:
-                    refs = set()
+                refs = symbol["instances"].get(project_name, set())
+            if not refs:
+                if instance_refs is None and project_name is not None:
+                    self.logger.warning(
+                        "Not updating BOM state for %s; no instances resolve for project %s",
+                        symbol["reference"] or symbol["uuid"],
+                        project_name,
+                    )
+                continue
             bom = self._resolved_bom(refs, store_parts)
             if bom is not None and symbol["bom_line"] is not None:
                 updates[symbol["bom_line"]] = "no" if bom else "yes"
@@ -357,9 +410,7 @@ class SchematicExport:
         with open(path, encoding="utf-8") as f:
             lines = f.readlines()
 
-        for index, desired in self._bom_updates(
-            lines, store_parts, split_symbol=True
-        ).items():
+        for index, desired in self._bom_updates(lines, store_parts).items():
             lines[index] = self._IN_BOM_RX.sub(rf"\1(in_bom {desired})", lines[index])
 
         partSection = False

--- a/tests/fixtures/kicad9_mixed_projects.kicad_sch
+++ b/tests/fixtures/kicad9_mixed_projects.kicad_sch
@@ -1,0 +1,52 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(lib_symbols)
+	(symbol
+		(lib_id "Device:R")
+		(at 10.16 10.16 0)
+		(unit 1)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "11111111-1111-4111-8111-111111111111")
+		(property "Reference" "R1"
+			(at 12.7 10.16 0)
+		)
+		(property "LCSC" "OLD"
+			(at 10.16 10.16 0)
+		)
+		(instances
+			(project "previous-board"
+				(path "/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 20.32 20.32 0)
+		(unit 1)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "22222222-2222-4222-8222-222222222222")
+		(property "Reference" "R2"
+			(at 22.86 20.32 0)
+		)
+		(property "LCSC" "OLD"
+			(at 20.32 20.32 0)
+		)
+		(instances
+			(project "board"
+				(path "/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/tests/test_schematicexport.py
+++ b/tests/test_schematicexport.py
@@ -1,0 +1,774 @@
+"""Tests for syncing schematic in_bom state from PCB parts."""
+
+from collections.abc import Sequence
+import importlib.util
+from pathlib import Path
+import re
+import sys
+import types
+from typing import Optional
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+# Hand-authored fixture reproducing the mixed-project table shape observed in
+# KiCad's RoyalBlue54L-Feather demo. Geometry and identifiers are synthetic.
+# https://gitlab.com/kicad/code/kicad/-/blob/9.0.5/demos/royalblue54L_feather/RoyalBlue54L-Feather.kicad_sch
+_MIXED_PROJECT_FIXTURE = _ROOT / "tests/fixtures/kicad9_mixed_projects.kicad_sch"
+
+_pcbnew = types.ModuleType("pcbnew")
+_pcbnew.GetBuildVersion = lambda: "8.0"  # type: ignore[attr-defined]
+sys.modules["pcbnew"] = _pcbnew
+
+_package = types.ModuleType("kicadplugin")
+_package.__path__ = [str(_ROOT)]
+sys.modules["kicadplugin"] = _package
+
+_core = types.ModuleType("kicadplugin.core")
+_core.__path__ = [str(_ROOT / "core")]
+sys.modules["kicadplugin.core"] = _core
+
+_version = types.ModuleType("kicadplugin.core.version")
+_version.is_version6 = lambda version: False  # type: ignore[attr-defined]
+_version.is_version7 = lambda version: False  # type: ignore[attr-defined]
+sys.modules["kicadplugin.core.version"] = _version
+
+_spec = importlib.util.spec_from_file_location(
+    "kicadplugin.schematicexport", _ROOT / "schematicexport.py"
+)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_module.__package__ = "kicadplugin"
+sys.modules["kicadplugin.schematicexport"] = _module
+_spec.loader.exec_module(_module)
+
+SchematicExport = _module.SchematicExport
+
+
+def _part(reference: str, lcsc: str, excluded: bool) -> dict[str, object]:
+    """Return one stored PCB part."""
+    return {
+        "reference": reference,
+        "lcsc": lcsc,
+        "exclude_from_bom": excluded,
+    }
+
+
+def _instance_block(
+    refs: Sequence[str],
+    variant: bool = False,
+    project_name: str = "board",
+    include_foreign: bool = True,
+) -> str:
+    """Return nested KiCad 7+ instance groups."""
+    paths = []
+    for index, ref in enumerate(refs):
+        if variant and index == 0:
+            paths.append(
+                f"""        (path "/sheet-{index}"
+          (reference "{ref}")
+          (unit 1)
+          (variant
+            (name "alternate")
+            (in_bom yes)
+          )
+        )"""
+            )
+        else:
+            paths.append(
+                f'        (path "/sheet-{index}" (reference "{ref}") (unit 1))'
+            )
+    paths_text = "\n".join(paths)
+    foreign = (
+        """      (project "foreign"
+        (path "/foreign" (reference "RV99") (unit 1))
+      )
+"""
+        if include_foreign
+        else ""
+    )
+    return f"""    (instances
+{foreign}      (project "{project_name}"
+{paths_text}
+      )
+    )
+"""
+
+
+def _symbol(
+    version: int,
+    initial_bom: str,
+    refs: Sequence[str],
+    variant: bool = False,
+    reference: str = "RV2",
+    project_name: str = "board",
+    include_foreign: bool = True,
+    symbol_uuid: str = "symbol-uuid",
+    instance_text: Optional[str] = None,  # noqa: UP045
+    locally_modified: bool = False,
+) -> str:
+    """Return one placed symbol using the selected KiCad serialization."""
+    if instance_text is None:
+        instances = (
+            ""
+            if version == 6 or (len(refs) == 1 and not variant)
+            else _instance_block(refs, variant, project_name, include_foreign)
+        )
+    else:
+        instances = instance_text
+    inline_lib_name = '(lib_name "Device:R_modified") ' if locally_modified else ""
+    if version == 6:
+        return f"""  (symbol {inline_lib_name}(lib_id "Device:R") (at 0 0 0) (unit 1)
+    (in_bom {initial_bom}) (on_board yes)
+    (uuid "{symbol_uuid}")
+    (property "Reference" "{reference}" (id 0) (at 0 0 0))
+    (property "LCSC" "OLD" (id 1) (at 0 0 0))
+    (pin "1" (uuid "pin-uuid"))
+  )"""
+    if version == 7:
+        return f"""  (symbol {inline_lib_name}(lib_id "Device:R") (at 0 0 0) (unit 1)
+    (in_bom {initial_bom}) (on_board yes) (dnp no)
+    (uuid "{symbol_uuid}")
+    (property "Reference" "{reference}" (at 0 0 0))
+    (property "LCSC" "OLD" (at 0 0 0))
+    (pin "1" (uuid "pin-uuid"))
+{instances}  )"""
+    multiline_lib_name = (
+        '    (lib_name "Device:R_modified")\n' if locally_modified else ""
+    )
+    return f"""  (symbol
+{multiline_lib_name}    (lib_id "Device:R")
+    (at 0 0 0)
+    (unit 1)
+    (in_bom {initial_bom})
+    (on_board yes)
+    (dnp no)
+    (uuid "{symbol_uuid}")
+    (property "Reference" "{reference}"
+      (at 0 0 0)
+    )
+    (property "LCSC" "OLD"
+      (at 0 0 0)
+    )
+    (pin "1" (uuid "pin-uuid"))
+{instances}  )"""
+
+
+def _schematic(
+    version: int,
+    initial_bom: str,
+    refs: Sequence[str],
+    variant: bool = False,
+    reference: str = "RV2",
+    project_name: str = "board",
+    include_foreign: bool = True,
+    instance_text: Optional[str] = None,  # noqa: UP045
+    locally_modified: bool = False,
+) -> str:
+    """Return a minimal schematic using the selected KiCad serialization."""
+    symbol = _symbol(
+        version,
+        initial_bom,
+        refs,
+        variant,
+        reference,
+        project_name,
+        include_foreign,
+        instance_text=instance_text,
+        locally_modified=locally_modified,
+    )
+    return f"""(kicad_sch
+  (lib_symbols)
+{symbol}
+)
+"""
+
+
+def _v6_root(refs: Sequence[str]) -> str:
+    """Return a KiCad 6 root mapping reused child symbols by UUID."""
+    paths = "\n".join(
+        f'    (path "/sheet-{index}/symbol-uuid"\n'
+        f'      (reference "{ref}") (unit 1)\n'
+        "    )"
+        for index, ref in enumerate(refs)
+    )
+    return f"""(kicad_sch
+  (symbol_instances
+{paths}
+    (path "/other/other-uuid"
+      (reference "RV99") (unit 1)
+    )
+  )
+)
+"""
+
+
+def _project_api(
+    board_project: object, loaded_projects: dict[str, object]
+) -> types.SimpleNamespace:
+    """Return a minimal pcbnew API with project identity information."""
+    board = types.SimpleNamespace(GetProject=lambda: board_project)
+    manager = types.SimpleNamespace(
+        GetProject=lambda path: loaded_projects.get(Path(path).name)
+    )
+    return types.SimpleNamespace(
+        GetBoard=lambda: board, GetSettingsManager=lambda: manager
+    )
+
+
+def _ambiguous_project_api(
+    tmp_path: Path,
+    match_count: Optional[int],  # noqa: UP045
+) -> types.SimpleNamespace:
+    """Return project APIs without exactly one authenticated candidate."""
+    if match_count is None:
+        (tmp_path / "renamed_board.kicad_pro").write_text("{}", encoding="utf-8")
+        return _project_api(None, {"renamed_board.kicad_pro": None})
+
+    board_project = object()
+    project_names = (
+        ("renamed_board.kicad_pro",)
+        if match_count == 0
+        else ("renamed_board.kicad_pro", "realproject.kicad_pro")
+    )
+    loaded_projects = {}
+    for project_name in project_names:
+        (tmp_path / project_name).write_text("{}", encoding="utf-8")
+        loaded_projects[project_name] = object() if match_count == 0 else board_project
+    return _project_api(board_project, loaded_projects)
+
+
+def _load_schematic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version: int,
+    paths: Sequence[Path],
+    parts: list[dict[str, object]],
+    board_name: str = "board.kicad_pcb",
+    pcbnew: Optional[types.SimpleNamespace] = None,  # noqa: UP045
+) -> None:
+    """Load selected schematic paths using the requested KiCad version."""
+    store = types.SimpleNamespace(read_all=lambda: parts)
+    parent = types.SimpleNamespace(
+        board_name=board_name,
+        project_path=str(tmp_path),
+        store=store,
+        pcbnew=pcbnew,
+    )
+    exporter = SchematicExport(parent)
+    monkeypatch.setattr(_module, "GetBuildVersion", lambda: str(version))
+    monkeypatch.setattr(_module, "is_version6", lambda _: version == 6)
+    monkeypatch.setattr(_module, "is_version7", lambda _: version == 7)
+    exporter.load_schematic([str(path) for path in paths])
+
+
+def _run_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version: int,
+    initial_bom: str,
+    refs: Sequence[str],
+    parts: list[dict[str, object]],
+    variant: bool = False,
+    reference: str = "RV2",
+    project_name: str = "board",
+    include_foreign: bool = True,
+    instance_text: Optional[str] = None,  # noqa: UP045
+    board_name: str = "board.kicad_pcb",
+    pcbnew: Optional[types.SimpleNamespace] = None,  # noqa: UP045
+    locally_modified: bool = False,
+) -> str:
+    """Run the matching exporter and return the rewritten schematic."""
+    path = tmp_path / "child.kicad_sch"
+    path.write_text(
+        _schematic(
+            version,
+            initial_bom,
+            refs,
+            variant,
+            reference,
+            project_name,
+            include_foreign,
+            instance_text,
+            locally_modified,
+        ),
+        encoding="utf-8",
+    )
+    if version == 6:
+        (tmp_path / f"{project_name}.kicad_sch").write_text(
+            _v6_root(refs), encoding="utf-8"
+        )
+
+    _load_schematic(
+        tmp_path,
+        monkeypatch,
+        version,
+        [path],
+        parts,
+        board_name=board_name,
+        pcbnew=pcbnew,
+    )
+    return path.read_text(encoding="utf-8")
+
+
+CASES = [
+    pytest.param("yes", ("RV2",), [_part("RV2", "NEW", True)], "no", id="single"),
+    pytest.param(
+        "yes",
+        ("RV2", "RV6"),
+        [_part("RV2", "NEW", True), _part("RV6", "SECONDARY", True)],
+        "no",
+        id="reused-agree",
+    ),
+    pytest.param(
+        "yes",
+        ("RV2", "RV6"),
+        [_part("RV2", "NEW", True), _part("RV6", "SECONDARY", False)],
+        "yes",
+        id="reused-disagree",
+    ),
+    pytest.param(
+        "yes",
+        ("RV2", "RV6"),
+        [_part("RV2", "NEW", True)],
+        "yes",
+        id="reused-partial",
+    ),
+    pytest.param(
+        "no",
+        ("RV2", "RV6"),
+        [_part("RV2", "NEW", False), _part("RV6", "SECONDARY", False)],
+        "yes",
+        id="reused-included",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "version",
+    [6, 7, 8],
+    ids=["kicad6", "kicad7", "kicad8+"],
+)
+@pytest.mark.parametrize(("initial_bom", "refs", "parts", "expected_bom"), CASES)
+def test_export_syncs_bom_without_changing_lcsc_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version: int,
+    initial_bom: str,
+    refs: Sequence[str],
+    parts: list[dict[str, object]],
+    expected_bom: str,
+) -> None:
+    """BOM sync handles each format while LCSC still follows the top reference."""
+    parts = [*parts, _part("RV99", "FOREIGN", False)]
+    result = _run_export(tmp_path, monkeypatch, version, initial_bom, refs, parts)
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == [
+        expected_bom
+    ]
+    assert re.findall(r'\(property\s+"LCSC"\s+"([^"]*)"', result) == ["NEW"]
+    if version in {6, 7}:
+        assert f"(in_bom {expected_bom}) (on_board yes)" in result
+
+
+@pytest.mark.parametrize(
+    "version",
+    [6, 7, 8],
+    ids=["kicad6", "kicad7", "kicad8+"],
+)
+def test_export_syncs_bom_for_locally_modified_symbol(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: int
+) -> None:
+    """A lib_name before lib_id does not hide a placed symbol from BOM sync."""
+    result = _run_export(
+        tmp_path,
+        monkeypatch,
+        version,
+        "yes",
+        ("RV2",),
+        [_part("RV2", "NEW", True)],
+        locally_modified=True,
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == ["no"]
+
+
+@pytest.mark.parametrize("version", [8], ids=["kicad8+"])
+def test_export_updates_only_the_base_bom_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: int
+) -> None:
+    """A later per-variant in_bom override remains untouched."""
+    parts = [_part("RV2", "NEW", True), _part("RV99", "FOREIGN", False)]
+    result = _run_export(
+        tmp_path, monkeypatch, version, "yes", ("RV2",), parts, variant=True
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == [
+        "no",
+        "yes",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("secondary_excluded", "expected_bom"),
+    [(True, "no"), (False, "yes")],
+    ids=["agree", "disagree"],
+)
+@pytest.mark.parametrize("version", [8], ids=["kicad8+"])
+def test_export_resolves_instances_in_empty_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    secondary_excluded: bool,
+    expected_bom: str,
+    version: int,
+) -> None:
+    """An empty project name resolves every instance in its sole group."""
+    parts = [
+        _part("RV2", "NEW", True),
+        _part("RV6", "SECONDARY", secondary_excluded),
+    ]
+    result = _run_export(
+        tmp_path,
+        monkeypatch,
+        version,
+        "yes",
+        ("RV2", "RV6"),
+        parts,
+        project_name="",
+        include_foreign=False,
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == [
+        expected_bom
+    ]
+
+
+@pytest.mark.parametrize(
+    "version",
+    [6, 7, 8],
+    ids=["kicad6", "kicad7", "kicad8+"],
+)
+def test_export_ignores_foreign_top_reference_for_bom(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: int
+) -> None:
+    """BOM state follows active instances while LCSC follows the top reference."""
+    parts = [
+        _part("RV2", "ACTIVE", True),
+        _part("RV6", "SECONDARY", True),
+        _part("RV99", "TOP", False),
+    ]
+    result = _run_export(
+        tmp_path,
+        monkeypatch,
+        version,
+        "yes",
+        ("RV2", "RV6"),
+        parts,
+        reference="RV99",
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == ["no"]
+    assert re.findall(r'\(property\s+"LCSC"\s+"([^"]*)"', result) == ["TOP"]
+
+
+def test_kicad6_ignores_selected_instance_tables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A selected file is not assumed to be the active project's root."""
+    child = tmp_path / "child.kicad_sch"
+    child.write_text(_schematic(6, "yes", ("RV2", "RV6")), encoding="utf-8")
+    selected_root = tmp_path / "alternate-root.kicad_sch"
+    selected_root.write_text(_v6_root(("RV2", "RV6")), encoding="utf-8")
+    (tmp_path / "alternate-root.kicad_pro").write_text("{}", encoding="utf-8")
+    parts = [_part("RV2", "NEW", True), _part("RV6", "SECONDARY", True)]
+    pcbnew = _project_api(None, {"alternate-root.kicad_pro": None})
+
+    assert not (tmp_path / "board.kicad_sch").exists()
+    _load_schematic(
+        tmp_path, monkeypatch, 6, [child, selected_root], parts, pcbnew=pcbnew
+    )
+    result = child.read_text(encoding="utf-8")
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == ["yes"]
+    assert re.findall(r'\(property\s+"LCSC"\s+"([^"]*)"', result) == ["NEW"]
+
+
+@pytest.mark.parametrize("version", [7, 8], ids=["kicad7", "kicad8+"])
+@pytest.mark.parametrize(
+    ("board_project", "foreign_project"),
+    [(None, None), (object(), object())],
+    ids=["unloaded", "different-project"],
+)
+@pytest.mark.parametrize(
+    "instance_text",
+    [
+        pytest.param(
+            _instance_block(
+                ("RV2", "RV6"), project_name="foreign", include_foreign=False
+            ),
+            id="sole-foreign-project",
+        ),
+        pytest.param("    (instances\n    )\n", id="empty-instances"),
+        pytest.param(
+            _instance_block(("RV2", "RV6"), project_name="other", include_foreign=True),
+            id="ambiguous-projects",
+        ),
+    ],
+)
+def test_export_skips_unresolved_instances(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version: int,
+    board_project: object,
+    foreign_project: object,
+    instance_text: str,
+) -> None:
+    """Unresolved instance data must not fall back to the top reference."""
+    parts = [
+        _part("RV2", "NEW", True),
+        _part("RV6", "SECONDARY", True),
+        _part("RV99", "FOREIGN", True),
+    ]
+    (tmp_path / "foreign.kicad_pro").write_text("{}", encoding="utf-8")
+    pcbnew = _project_api(board_project, {"foreign.kicad_pro": foreign_project})
+    result = _run_export(
+        tmp_path,
+        monkeypatch,
+        version,
+        "yes",
+        ("RV2", "RV6"),
+        parts,
+        instance_text=instance_text,
+        pcbnew=pcbnew,
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == ["yes"]
+    assert re.findall(r'\(property\s+"LCSC"\s+"([^"]*)"', result) == ["NEW"]
+
+
+def test_export_warns_for_stale_project_instances(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A real-world mixed project table reports a skipped symbol."""
+    path = tmp_path / "board.kicad_sch"
+    path.write_text(_MIXED_PROJECT_FIXTURE.read_text(encoding="utf-8"))
+    parts = [
+        _part("R1", "STALE", False),
+        _part("R2", "CURRENT", False),
+    ]
+
+    _load_schematic(tmp_path, monkeypatch, 9, [path], parts)
+    result = path.read_text(encoding="utf-8")
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == [
+        "no",
+        "yes",
+    ]
+    assert caplog.messages == [
+        "Not updating BOM state for R1; no instances resolve for project board"
+    ]
+
+
+@pytest.mark.parametrize("version", [8], ids=["kicad8+"])
+def test_export_keeps_symbol_resolution_independent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: int
+) -> None:
+    """Instance resolution state does not leak between consecutive symbols."""
+    symbols = "\n".join(
+        [
+            _symbol(version, "yes", ("RV2", "RV6")),
+            _symbol(
+                version,
+                "no",
+                ("RV3",),
+                reference="RV3",
+                symbol_uuid="symbol-uuid-2",
+            ),
+        ]
+    )
+    path = tmp_path / "two-symbols.kicad_sch"
+    path.write_text(
+        f"""(kicad_sch
+  (lib_symbols)
+{symbols}
+)
+""",
+        encoding="utf-8",
+    )
+    parts = [
+        _part("RV2", "FIRST", True),
+        _part("RV6", "SECONDARY", True),
+        _part("RV3", "SECOND", False),
+        _part("RV99", "FOREIGN", False),
+    ]
+
+    _load_schematic(tmp_path, monkeypatch, version, [path], parts)
+    result = path.read_text(encoding="utf-8")
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == [
+        "no",
+        "yes",
+    ]
+
+
+@pytest.mark.parametrize(
+    "version",
+    [6, 7, 8],
+    ids=["kicad6", "kicad7", "kicad8+"],
+)
+def test_export_uses_loaded_project_for_renamed_board(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version: int
+) -> None:
+    """A renamed board resolves instances from its loaded KiCad project."""
+    owner_project = object()
+    foreign_project = object()
+    (tmp_path / "realproject.kicad_pro").write_text("{}", encoding="utf-8")
+    (tmp_path / "foreign.kicad_pro").write_text("{}", encoding="utf-8")
+    pcbnew = _project_api(
+        owner_project,
+        {
+            "realproject.kicad_pro": owner_project,
+            "foreign.kicad_pro": foreign_project,
+        },
+    )
+    parts = [
+        _part("RV2", "NEW", True),
+        _part("RV6", "SECONDARY", True),
+        _part("RV99", "FOREIGN", False),
+    ]
+
+    result = _run_export(
+        tmp_path,
+        monkeypatch,
+        version,
+        "yes",
+        ("RV2", "RV6"),
+        parts,
+        project_name="realproject",
+        board_name="renamed_board.kicad_pcb",
+        pcbnew=pcbnew,
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == ["no"]
+    assert re.findall(r'\(property\s+"LCSC"\s+"([^"]*)"', result) == ["NEW"]
+
+
+@pytest.mark.parametrize(
+    "version",
+    [6, 7, 8],
+    ids=["kicad6", "kicad7", "kicad8+"],
+)
+@pytest.mark.parametrize(
+    "match_count", [None, 0, 2], ids=["unloaded", "no-match", "multiple-matches"]
+)
+def test_export_skips_ambiguous_board_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    version: int,
+    match_count: Optional[int],  # noqa: UP045
+) -> None:
+    """A board-stem instance group is unsafe without one authenticated project."""
+    result = _run_export(
+        tmp_path,
+        monkeypatch,
+        version,
+        "yes",
+        ("RV2", "RV6"),
+        [_part("RV2", "NEW", True), _part("RV6", "SECONDARY", True)],
+        project_name="renamed_board",
+        board_name="renamed_board.kicad_pcb",
+        pcbnew=_ambiguous_project_api(tmp_path, match_count),
+    )
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == ["yes"]
+    reason = (
+        "open board has no project identity"
+        if match_count is None
+        else f"expected one matching .kicad_pro file, found {match_count}"
+    )
+    assert caplog.messages == [
+        f"Not updating project-specific BOM states for renamed_board.kicad_pcb; {reason}"
+    ]
+
+
+@pytest.mark.parametrize("version", [7, 8], ids=["kicad7", "kicad8+"])
+@pytest.mark.parametrize(
+    "match_count", [None, 0, 2], ids=["unloaded", "no-match", "multiple-matches"]
+)
+def test_export_still_syncs_unscoped_symbol_when_project_is_ambiguous(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    version: int,
+    match_count: Optional[int],  # noqa: UP045
+) -> None:
+    """Project authentication is unnecessary for an unscoped symbol."""
+    symbols = "\n".join(
+        [
+            _symbol(
+                version,
+                "yes",
+                ("RV2", "RV6"),
+                project_name="renamed_board",
+                include_foreign=False,
+            ),
+            _symbol(
+                version,
+                "yes",
+                ("RV3",),
+                reference="RV3",
+                symbol_uuid="standalone-uuid",
+            ),
+        ]
+    )
+    path = tmp_path / "mixed-scope.kicad_sch"
+    path.write_text(f"(kicad_sch\n  (lib_symbols)\n{symbols}\n)\n", encoding="utf-8")
+    second_path = tmp_path / "second.kicad_sch"
+    second_path.write_text(
+        _schematic(
+            version,
+            "yes",
+            ("RV2", "RV6"),
+            project_name="renamed_board",
+            include_foreign=False,
+        ),
+        encoding="utf-8",
+    )
+    parts = [
+        _part("RV2", "FIRST", True),
+        _part("RV6", "SECONDARY", True),
+        _part("RV3", "STANDALONE", True),
+    ]
+
+    _load_schematic(
+        tmp_path,
+        monkeypatch,
+        version,
+        [path, second_path],
+        parts,
+        board_name="renamed_board.kicad_pcb",
+        pcbnew=_ambiguous_project_api(tmp_path, match_count),
+    )
+    result = path.read_text(encoding="utf-8")
+
+    assert re.findall(r"^\s*\(in_bom\s+(yes|no)\)", result, re.MULTILINE) == [
+        "yes",
+        "no",
+    ]
+    assert re.findall(
+        r"^\s*\(in_bom\s+(yes|no)\)",
+        second_path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    ) == ["yes"]
+    reason = (
+        "open board has no project identity"
+        if match_count is None
+        else f"expected one matching .kicad_pro file, found {match_count}"
+    )
+    assert caplog.messages == [
+        f"Not updating project-specific BOM states for renamed_board.kicad_pcb; {reason}"
+    ]


### PR DESCRIPTION
Addresses the BOM portion of #328. Position-file exclusion remains a follow-up.

Based on #785 by @jOaSbA.

## Attribution

That work identified two edge cases incorporated here:

- locally modified symbols can place `lib_name` before `lib_id`
- project identity must come from the matching `.kicad_pro`, rather than being inferred from the board filename

Their contribution is recorded with a `Co-authored-by` trailer on the corresponding implementation commit.

## Behavior

This branch synchronizes a schematic symbol's `in_bom` value only when all of its resolved instances are present on the current PCB and agree on the BOM state. It authenticates adjacent `.kicad_pro` candidates against the project attached to the open board.

When authentication is available but the open board has no project identity, or when it finds zero or multiple matches, the exporter warns once per export and leaves project-specific BOM states unchanged. Unscoped symbols continue to synchronize, and the board-stem compatibility fallback remains only for environments without project identity APIs. Existing LCSC behavior is unchanged.

## Verification

- 57 focused cases cover the distinct KiCad 6, KiCad 7, and shared KiCad 8+ serialization paths, including reused symbols, locally modified symbols, ambiguous references, renamed boards, mixed current/stale project data, missing open-board identity, and zero or multiple authenticated project candidates.
- The five missing-identity cases first fail against the prior implementation because it selects a stale board-stem group; they pass after the fail-closed correction. Six multi-file cases also prove that each authentication failure produces one diagnostic per export rather than one per schematic file.
- A compact, hand-authored fixture models the mixed current/stale project condition observed in KiCad's RoyalBlue54L-Feather demo.
- Andy Miller independently verified project-pointer equality with KiCad 10.0.4 and exercised `_bom_updates()` over six real KiCad 9/10 schematics.
- On current `main`: `1579 passed`; Ruff check and format check pass; `git diff --check` passes.

## Remaining gaps and follow-ups

- The full native workflow—rewrite, reopen in Eeschema, and Update PCB from Schematic—has not been exercised end to end.
- The position-file half of #328 is not part of this BOM-focused change. KiCad 10 now serializes schematic-side `in_pos_files`, so that behavior needs separate implementation and native round-trip validation.
- A missing KiCad 6 symbol UUID warning and the pre-existing LCSC `lib_name`-first scanner issue are separate follow-ups.
