### PR TITLE
Correct BOM Standard-mode signals and enrichment

### DIFF
--- a/bom_estimation/assembly_mode.py
+++ b/bom_estimation/assembly_mode.py
@@ -1,0 +1,95 @@
+"""Assembly-mode policy decisions for BOM estimation."""
+
+# ruff: noqa: D102, D105, UP045
+# pyupgrade: disable
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class AssemblyModeDecision:
+    """Derive the modeled assembly mode from immutable board facts.
+
+    JLCPCB documents Economic PCBA as supporting 2-50 boards and placement on
+    one side, while Standard supports higher quantities and both sides:
+    https://jlcpcb.com/capabilities/pcb-assembly-capabilities
+
+    Standard Only parts require Standard service or must remain unplaced:
+    https://jlcpcb.com/help/article/common-bom-and-cpl-matching-issues-and-explanations
+
+    ``manual_enabled`` is a local plugin override, not a JLCPCB criterion.
+    """
+
+    board_count: int
+    manual_enabled: bool = False
+    top_refs: frozenset[str] = field(default_factory=frozenset)
+    bottom_refs: frozenset[str] = field(default_factory=frozenset)
+    smt_populated_side_count: int = 0
+    standard_only_refs: frozenset[str] = field(default_factory=frozenset)
+    economic_only_refs: frozenset[str] = field(default_factory=frozenset)
+    classification_missing_refs: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self):
+        for name in (
+            "top_refs",
+            "bottom_refs",
+            "standard_only_refs",
+            "economic_only_refs",
+            "classification_missing_refs",
+        ):
+            object.__setattr__(self, name, frozenset(getattr(self, name)))
+        populated_refs = self.top_refs | self.bottom_refs
+        for name in (
+            "standard_only_refs",
+            "economic_only_refs",
+            "classification_missing_refs",
+        ):
+            object.__setattr__(self, name, getattr(self, name) & populated_refs)
+
+    @property
+    def applicable(self) -> bool:
+        return bool(self.top_refs or self.bottom_refs)
+
+    @property
+    def quantity_over_50(self) -> bool:
+        return self.applicable and self.board_count > 50
+
+    @property
+    def both_sides_populated(self) -> bool:
+        return bool(self.top_refs and self.bottom_refs)
+
+    @property
+    def board_standard(self) -> Optional[bool]:
+        if not self.applicable:
+            return None
+        if (
+            self.manual_enabled
+            or self.quantity_over_50
+            or self.both_sides_populated
+            or self.standard_only_refs
+        ):
+            return True
+        return None if self.classification_missing_refs else False
+
+    @property
+    def economic_only_conflict_refs(self) -> frozenset[str]:
+        return self.economic_only_refs if self.board_standard is True else frozenset()
+
+
+def classify_component_product_type(value: object) -> Optional[int]:
+    """Normalize the observed JLC assembly classification to 0, 1, or 2.
+
+    The numeric mapping is observed API behavior, not a published JLCPCB API
+    contract: 0 is Economic and Standard, 1 is Economic Only, and 2 is
+    Standard Only. Unknown or malformed values deliberately remain unknown.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        return None
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return normalized if normalized in {0, 1, 2} else None

--- a/bom_estimation/pricing.py
+++ b/bom_estimation/pricing.py
@@ -11,6 +11,8 @@ import contextlib
 from dataclasses import dataclass, field
 import json
 
+from .assembly_mode import classify_component_product_type
+
 
 @dataclass
 class AssemblyPricing:
@@ -256,14 +258,12 @@ def _scan_assembly_state(
         lcsc = str(part.get("lcsc") or "")
         details = run_context.get_cached_part_details(lcsc)
 
-        if _safe_int(part.get("component_product_type")) != 0:
-            scan.standard_present = True
-
-        flags = get_assembly_flags(part)
-        exclude_from_pos = bool(flags.get("exclude_from_pos", False))
+        exclude_from_pos = bool(part.get("exclude_from_pos", False))
         tht = is_tht_part(part)
 
         if not exclude_from_pos:
+            if classify_component_product_type(part.get("component_product_type")) == 2:
+                scan.standard_present = True
             scan.populated_part_present = True
             joints = max(0, _safe_int(part.get("pad_count"))) * board_count
             if tht:

--- a/bom_estimation/view.py
+++ b/bom_estimation/view.py
@@ -73,7 +73,7 @@ def standard_signal_reasons(signals: Mapping[str, object]) -> list[str]:
     """Build user-facing reason labels for active Standard-mode triggers."""
     reason_map = [
         ("manual_enabled", "manual"),
-        ("qty_50_plus", "qty≥50"),
+        ("quantity_over_50", "qty>50"),
         ("standard_part_present", "standard part"),
         ("multi_side_populated", "both sides populated"),
     ]
@@ -190,7 +190,7 @@ def build_standard_mode_context(
 
     signals = {
         "manual_enabled": bool(manual_enabled),
-        "qty_50_plus": board_count >= 50,
+        "quantity_over_50": board_count > 50,
         "standard_part_present": bool(standard_part_refs),
         "multi_side_populated": len(populated_sides) > 1,
     }

--- a/bom_widget.py
+++ b/bom_widget.py
@@ -6,14 +6,16 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from contextlib import suppress
-import json
 
 import pcbnew  # pylint: disable=import-error
 import wx  # pylint: disable=import-error
 
-from .bom_estimation.pricing import calculate_bom_estimate
+from .bom_estimation.assembly_mode import (
+    AssemblyModeDecision,
+    classify_component_product_type,
+)
+from .bom_estimation.pricing import calculate_bom_estimate, get_assembly_flags
 from .bom_estimation.view import (
-    build_standard_mode_context,
     format_bom_estimate_summary,
     prepare_bom_price_labels,
     standard_signal_reasons,
@@ -153,28 +155,28 @@ class BomEstimatorController:
         self,
         parts: list[Mapping[str, object]],
         board_count: int,
-    ) -> dict[str, object]:
+    ) -> AssemblyModeDecision:
         """Compute standard-mode trigger signals and assembly side usage.
 
         Walks the board to extract per-reference facts (sides, SMT vs THT,
-        standard-part membership), then delegates the policy-decision portion
-        to ``build_standard_mode_context`` so the signal contract has one home.
+        and JLC assembly classification), then delegates the policy decision to
+        ``AssemblyModeDecision`` so the signal contract has one home.
         """
         board = self._get_board()
-        populated_sides: set[str] = set()
-        populated_refs: set[str] = set()
+        top_refs: set[str] = set()
+        bottom_refs: set[str] = set()
         smt_populated_sides: set[str] = set()
-        standard_part_refs: set[str] = set()
+        standard_only_refs: set[str] = set()
+        economic_only_refs: set[str] = set()
+        classification_missing_refs: set[str] = set()
 
         for part in parts:
             if part.get("exclude_from_bom") or not str(part.get("lcsc") or ""):
                 continue
 
-            flags = {}
-            with suppress(TypeError, ValueError, json.JSONDecodeError):
-                flags = json.loads(part.get("assembly_flags") or "{}")
+            flags = get_assembly_flags(part)
             if bool(flags.get("is_dnp", False)) or bool(
-                flags.get("exclude_from_pos", False)
+                part.get("exclude_from_pos", False)
             ):
                 continue
 
@@ -187,8 +189,8 @@ class BomEstimatorController:
                 continue
 
             side = "bottom" if self._is_on_bottom_side(footprint) else "top"
-            populated_sides.add(side)
-            populated_refs.add(str(reference))
+            reference = str(reference)
+            (bottom_refs if side == "bottom" else top_refs).add(reference)
 
             is_tht = False
             with suppress(TypeError, ValueError):
@@ -196,17 +198,25 @@ class BomEstimatorController:
             if not is_tht:
                 smt_populated_sides.add(side)
 
-            with suppress(TypeError, ValueError):
-                if int(part.get("component_product_type")) != 0:
-                    standard_part_refs.add(str(reference))
+            product_type = classify_component_product_type(
+                part.get("component_product_type")
+            )
+            if product_type == 2:
+                standard_only_refs.add(reference)
+            elif product_type == 1:
+                economic_only_refs.add(reference)
+            elif product_type is None:
+                classification_missing_refs.add(reference)
 
-        return build_standard_mode_context(
+        return AssemblyModeDecision(
             manual_enabled=bool(self._is_force_standard_enabled()),
             board_count=board_count,
-            populated_refs=populated_refs,
-            populated_sides=populated_sides,
-            smt_populated_sides=smt_populated_sides,
-            standard_part_refs=standard_part_refs,
+            top_refs=top_refs,
+            bottom_refs=bottom_refs,
+            smt_populated_side_count=len(smt_populated_sides),
+            standard_only_refs=standard_only_refs,
+            economic_only_refs=economic_only_refs,
+            classification_missing_refs=classification_missing_refs,
         )
 
     def recompute(self, board_count: int):
@@ -218,43 +228,43 @@ class BomEstimatorController:
         """
         raw_parts = self._read_parts()
         parts = raw_parts if isinstance(raw_parts, list) else []
-        if not parts:
-            self._set_trigger_refs(set())
-            self._refresh_rows()
-            self._set_summary_text(f"BOM Estimate ({board_count} boards): no parts")
-            return
-
         bom_parts = [
             part
             for part in parts
             if not part.get("exclude_from_bom") and str(part.get("lcsc") or "")
         ]
-        if not bom_parts:
+        if not parts or not bom_parts:
             self._set_trigger_refs(set())
             self._refresh_rows()
-            self._set_summary_text(
-                f"BOM Estimate ({board_count} boards): no assigned BOM parts"
+            reason = "no parts" if not parts else "no assigned BOM parts"
+            self._set_summary_text(f"BOM Estimate ({board_count} boards): {reason}")
+            return AssemblyModeDecision(
+                board_count, bool(self._is_force_standard_enabled())
             )
-            return
 
-        standard_context = self._get_board_standard_context(parts, board_count)
+        decision = self._get_board_standard_context(parts, board_count)
 
         summary = calculate_bom_estimate(
             parts=parts,
             board_count=board_count,
             get_part_details=self._get_part_details,
-            board_standard=bool(standard_context["board_standard"]),
-            smt_populated_sides=int(standard_context["smt_populated_sides"]),
+            board_standard=decision.board_standard,
+            smt_populated_sides=decision.smt_populated_side_count,
         )
 
-        mode = "Standard" if standard_context["board_standard"] else "Economic"
-        reasons = standard_signal_reasons(standard_context["signals"])
+        mode = "Standard" if decision.board_standard else "Economic"
+        signals = {
+            "manual_enabled": decision.manual_enabled,
+            "quantity_over_50": decision.quantity_over_50,
+            "standard_part_present": bool(decision.standard_only_refs),
+            "multi_side_populated": decision.both_sides_populated,
+        }
+        reasons = standard_signal_reasons(signals)
         reason_text = ", ".join(reasons) if reasons else "none"
-        highlight_refs = (
-            standard_context["trigger_references"]
-            if standard_context["board_standard"]
-            else set()
-        )
+        highlight_refs = set(decision.standard_only_refs)
+        if decision.both_sides_populated:
+            highlight_refs.update(decision.top_refs)
+            highlight_refs.update(decision.bottom_refs)
 
         for reference, price_label in prepare_bom_price_labels(
             parts,
@@ -273,3 +283,4 @@ class BomEstimatorController:
             reason_text,
         )
         self._set_summary_text(f"{overview_line}\n{details_line}")
+        return decision

--- a/common/test_bom_estimator.py
+++ b/common/test_bom_estimator.py
@@ -291,7 +291,7 @@ def test_build_standard_mode_context_combines_policy_signals():
     """Standard mode turns on when any pure policy trigger is active."""
     context = build_standard_mode_context(
         manual_enabled=False,
-        board_count=50,
+        board_count=51,
         populated_refs={"R1", "R2"},
         populated_sides={"top", "bottom"},
         smt_populated_sides={"top"},
@@ -301,7 +301,7 @@ def test_build_standard_mode_context_combines_policy_signals():
     assert context["board_standard"] is True
     assert context["signals"] == {
         "manual_enabled": False,
-        "qty_50_plus": True,
+        "quantity_over_50": True,
         "standard_part_present": True,
         "multi_side_populated": True,
     }

--- a/common/test_bom_estimator.py
+++ b/common/test_bom_estimator.py
@@ -13,22 +13,34 @@ from bom_estimation import (
 )
 
 
+def _part(lcsc="C1", **overrides):
+    """Return a populated SMT BOM row with optional scenario-specific fields."""
+    part = {
+        "lcsc": lcsc,
+        "exclude_from_bom": 0,
+        "pad_count": 1,
+        "has_tht": 0,
+        "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
+    }
+    part.update(overrides)
+    return part
+
+
+def _estimate(parts, board_count=5, price="1-:1.00", part_type="Basic", **options):
+    """Estimate one scenario with a uniform component detail response."""
+    return calculate_bom_estimate(
+        parts,
+        board_count,
+        lambda _lcsc: {"price": price, "type": part_type},
+        **options,
+    )
+
+
 def test_calculate_bom_estimate_missing_price_counts_unknown_lcsc_price():
     """Missing price bands increment diagnostics and keep component cost zero."""
-    parts = [
-        {
-            "lcsc": "C404",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        }
-    ]
+    parts = [_part("C404", pad_count=2)]
 
-    def get_details(_):
-        return {"price": "", "type": "Basic"}
-
-    summary = calculate_bom_estimate(parts, board_count=5, get_part_details=get_details)
+    summary = _estimate(parts, price="")
 
     assert summary.component_cost == 0.0
     assert summary.missing_prices == 1
@@ -36,24 +48,9 @@ def test_calculate_bom_estimate_missing_price_counts_unknown_lcsc_price():
 
 def test_calculate_bom_estimate_computes_fixed_cost_without_policy_kwargs():
     """Fixed costs are computed via the current pricing model inputs only."""
-    parts = [
-        {
-            "lcsc": "C100",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        }
-    ]
+    parts = [_part("C100")]
 
-    def get_details(_):
-        return {"price": "1-:1.00", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
-        parts,
-        board_count=10,
-        get_part_details=get_details,
-    )
+    summary = _estimate(parts, board_count=10)
 
     assert summary.fixed_cost > 0
     assert summary.assembly_cost >= summary.fixed_cost
@@ -63,24 +60,12 @@ def test_calculate_bom_estimate_computes_fixed_cost_without_policy_kwargs():
 def test_standard_fees_apply_for_standard_smt_part():
     """Standard fixed fees apply for standard parts even when assembly process is SMT."""
     parts = [
-        {
-            "lcsc": "CSTD1",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        }
+        _part("CSTD1", pad_count=2, assembly_process="SMT", component_product_type=2)
     ]
 
-    def get_details(_):
-        return {"price": "1-:1.00", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
+    summary = _estimate(
         parts,
         board_count=2,
-        get_part_details=get_details,
         pricing=AssemblyPricing(
             standard_setup_fee=4.0,
             standard_stencil_fee=1.2,
@@ -99,33 +84,20 @@ def test_standard_fees_apply_for_standard_smt_part():
 def test_standard_fees_are_orthogonal_to_tht_fees():
     """Standard and THT fixed-fee policies can apply together when both conditions are true."""
     parts = [
-        {
-            "lcsc": "CSTD2",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 1,
-            "assembly_process": "THT",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-        {
-            "lcsc": "CSMT2",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
+        _part(
+            "CSTD2",
+            pad_count=2,
+            has_tht=1,
+            assembly_process="THT",
+            component_product_type=2,
+        ),
+        _part("CSMT2", assembly_process="SMT", component_product_type=0),
     ]
 
-    def get_details(_lcsc):
-        return {"price": "1-:0.80", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
+    summary = _estimate(
         parts,
         board_count=3,
-        get_part_details=get_details,
+        price="1-:0.80",
         pricing=AssemblyPricing(
             standard_setup_fee=2.0,
             standard_stencil_fee=0.5,
@@ -150,25 +122,12 @@ def test_standard_fees_are_orthogonal_to_tht_fees():
 
 def test_standard_fees_do_not_apply_for_non_standard_parts():
     """Non-standard parts do not incur standard fixed fees."""
-    parts = [
-        {
-            "lcsc": "CNONSTD",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        }
-    ]
+    parts = [_part("CNONSTD", assembly_process="SMT", component_product_type=0)]
 
-    def get_details(_):
-        return {"price": "1-:0.50", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
+    summary = _estimate(
         parts,
         board_count=4,
-        get_part_details=get_details,
+        price="1-:0.50",
         pricing=AssemblyPricing(
             standard_setup_fee=99.0,
             standard_part_fee=99.0,
@@ -188,33 +147,13 @@ def test_standard_fees_do_not_apply_for_non_standard_parts():
 def test_standard_per_side_base_fees_and_all_smt_surcharge_apply():
     """Standard base fees apply per populated SMT side and surcharge all SMT LCSC values."""
     parts = [
-        {
-            "lcsc": "CSTD3",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-        {
-            "lcsc": "CBASIC3",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
+        _part("CSTD3", pad_count=2, assembly_process="SMT", component_product_type=2),
+        _part("CBASIC3", assembly_process="SMT", component_product_type=0),
     ]
 
-    def get_details(_lcsc):
-        return {"price": "1-:1.00", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
+    summary = _estimate(
         parts,
         board_count=1,
-        get_part_details=get_details,
         board_standard=True,
         smt_populated_sides=2,
     )
@@ -233,24 +172,12 @@ def test_standard_per_side_base_fees_and_all_smt_surcharge_apply():
 def test_cost_breakdown_fields_sum_to_total_and_per_board():
     """Breakdown buckets should reconcile with assembly and total costs."""
     parts = [
-        {
-            "lcsc": "C101",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        }
+        _part("C101", pad_count=2, assembly_process="SMT", component_product_type=0)
     ]
 
-    def get_details(_lcsc):
-        return {"price": "1-:1.00", "type": "Extended"}
-
-    summary = calculate_bom_estimate(
+    summary = _estimate(
         parts,
-        board_count=5,
-        get_part_details=get_details,
+        part_type="Extended",
         board_standard=False,
     )
 
@@ -286,33 +213,18 @@ def test_cost_breakdown_fields_sum_to_total_and_per_board():
 def test_standard_surcharge_and_joint_counts_are_reported_separately():
     """UI-facing summary fields expose joint counts and standard surcharge cleanly."""
     parts = [
-        {
-            "lcsc": "CSTDUI",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-        {
-            "lcsc": "CTHTUI",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 1,
-            "assembly_process": "Wave soldering",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
+        _part("CSTDUI", pad_count=2, assembly_process="SMT", component_product_type=2),
+        _part(
+            "CTHTUI",
+            has_tht=1,
+            assembly_process="Wave soldering",
+            component_product_type=2,
+        ),
     ]
 
-    def get_details(_lcsc):
-        return {"price": "1-:1.00", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
+    summary = _estimate(
         parts,
         board_count=2,
-        get_part_details=get_details,
         board_standard=True,
         smt_populated_sides=1,
     )
@@ -327,35 +239,17 @@ def test_standard_surcharge_and_joint_counts_are_reported_separately():
 def test_dnp_parts_are_excluded_from_bom_estimator_counts():
     """DNP rows should not contribute to component or assembly totals."""
     parts = [
-        {
-            "lcsc": "C401",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-        {
-            "lcsc": "C402",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": true}',
-        },
+        _part("C401", pad_count=2, assembly_process="SMT", component_product_type=0),
+        _part(
+            "C402",
+            pad_count=2,
+            assembly_process="SMT",
+            component_product_type=2,
+            assembly_flags='{"exclude_from_pos": false, "is_dnp": true}',
+        ),
     ]
 
-    def get_details(_lcsc):
-        return {"price": "1-:1.00", "type": "Basic"}
-
-    summary = calculate_bom_estimate(
-        parts,
-        board_count=5,
-        get_part_details=get_details,
-        board_standard=False,
-    )
+    summary = _estimate(parts, board_standard=False)
 
     assert summary.component_cost == pytest.approx(5.000, abs=1e-3)
 

--- a/common/test_bom_estimator_enrichment.py
+++ b/common/test_bom_estimator_enrichment.py
@@ -5,6 +5,12 @@ from enrichment.providers import (  # pylint: disable=import-error
     fetch_assembly_processes,
 )
 
+_EMPTY_METADATA = {
+    "assembly_process": "",
+    "component_product_type": None,
+    "is_standard_assembly": False,
+}
+
 
 class _FakeApi:
     def get_part_data(self, lcsc):
@@ -32,11 +38,7 @@ def test_fetch_assembly_processes_uses_provider_contract():
             "component_product_type": 2,
             "is_standard_assembly": True,
         },
-        "C2": {
-            "assembly_process": "",
-            "component_product_type": None,
-            "is_standard_assembly": False,
-        },
+        "C2": _EMPTY_METADATA,
     }
 
 
@@ -52,11 +54,7 @@ def test_normalize_returns_empty_metadata_when_api_raises():
     provider = LCSCAssemblyMetadataProvider(api=_RaisingApi())
     metadata = provider._normalize("C123")
 
-    assert metadata == {
-        "assembly_process": "",
-        "component_product_type": None,
-        "is_standard_assembly": False,
-    }
+    assert metadata == _EMPTY_METADATA
 
 
 def test_fetch_iter_yields_empty_metadata_for_each_failed_code():
@@ -66,8 +64,4 @@ def test_fetch_iter_yields_empty_metadata_for_each_failed_code():
 
     assert set(results) == {"C1", "C2"}
     for value in results.values():
-        assert value == {
-            "assembly_process": "",
-            "component_product_type": None,
-            "is_standard_assembly": False,
-        }
+        assert value == _EMPTY_METADATA

--- a/common/test_bom_estimator_enrichment.py
+++ b/common/test_bom_estimator_enrichment.py
@@ -1,5 +1,7 @@
 """Tests for provider-backed enrichment helpers."""
 
+import pytest
+
 from enrichment.providers import (  # pylint: disable=import-error
     LCSCAssemblyMetadataProvider,
     fetch_assembly_processes,
@@ -13,6 +15,9 @@ _EMPTY_METADATA = {
 
 
 class _FakeApi:
+    def __init__(self, product_type=2):
+        self.product_type = product_type
+
     def get_part_data(self, lcsc):
         if lcsc == "C1":
             return {
@@ -20,7 +25,7 @@ class _FakeApi:
                 "data": {
                     "data": {
                         "assemblyProcess": "SMT",
-                        "componentProductType": 2,
+                        "componentProductType": self.product_type,
                     }
                 },
             }
@@ -65,3 +70,22 @@ def test_fetch_iter_yields_empty_metadata_for_each_failed_code():
     assert set(results) == {"C1", "C2"}
     for value in results.values():
         assert value == _EMPTY_METADATA
+
+
+@pytest.mark.parametrize(
+    ("product_type", "expected_type", "expected_standard"),
+    [
+        (1, 1, False),
+        ("bad", None, False),
+    ],
+)
+def test_normalize_uses_shared_product_type_classifier(
+    product_type, expected_type, expected_standard
+):
+    """Representative values verify provider-to-classifier integration."""
+    provider = LCSCAssemblyMetadataProvider(api=_FakeApi(product_type))
+
+    metadata = provider._normalize("C1")
+
+    assert metadata["component_product_type"] == expected_type
+    assert metadata["is_standard_assembly"] is expected_standard

--- a/common/test_bom_estimator_policy.py
+++ b/common/test_bom_estimator_policy.py
@@ -1,0 +1,85 @@
+"""Tests for the modeled JLCPCB assembly-mode decision."""
+
+import pytest
+
+from bom_estimation.assembly_mode import (  # pylint: disable=import-error
+    AssemblyModeDecision,
+    classify_component_product_type,
+)
+
+
+def _decision(**overrides):
+    """Build a decision with one selected dual-mode TOP part by default."""
+    inputs = {
+        "board_count": 5,
+        "top_refs": {"R1"},
+        "smt_populated_side_count": 1,
+    }
+    inputs.update(overrides)
+    return AssemblyModeDecision(**inputs)
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (0, 0),
+        ("1", 1),
+        (2, 2),
+        (None, None),
+        ("bad", None),
+        (2.5, None),
+        (True, None),
+        (3, None),
+    ],
+)
+def test_component_product_type_accepts_only_the_observed_mapping(raw_value, expected):
+    """Unknown values never become Standard merely because they are nonzero."""
+    assert classify_component_product_type(raw_value) == expected
+
+
+@pytest.mark.parametrize(
+    ("board_count", "standard"), [(49, False), (50, False), (51, True)]
+)
+def test_quantity_above_50_is_the_standard_boundary(board_count, standard):
+    """Economic includes 50 boards; Standard starts at 51."""
+    decision = _decision(board_count=board_count)
+    assert (decision.quantity_over_50, decision.board_standard) == (
+        standard,
+        standard,
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "mode"),
+    [
+        ({}, False),
+        ({"manual_enabled": True}, True),
+        ({"top_refs": set()}, None),
+        ({"classification_missing_refs": {"R1"}}, None),
+        ({"standard_only_refs": {"R1"}}, True),
+        ({"bottom_refs": {"J1"}}, True),
+    ],
+    ids=("economic", "manual", "no-parts", "missing", "standard-part", "both-sides"),
+)
+def test_assembly_mode_scenarios(overrides, mode):
+    """Independent policy signals select Economic, Standard, or unknown."""
+    assert _decision(**overrides).board_standard is mode
+
+
+def test_decision_retains_refs_and_reports_only_active_conflicts():
+    """Normalized facts retain explanation context and active conflicts."""
+    decision = _decision(
+        top_refs={"U1", "Q2"},
+        bottom_refs={"J1"},
+        standard_only_refs={"U1"},
+        economic_only_refs={"J1"},
+        classification_missing_refs={"Q2"},
+    )
+
+    assert decision.standard_only_refs == {"U1"}
+    assert decision.classification_missing_refs == {"Q2"}
+    assert decision.economic_only_conflict_refs == {"J1"}
+    assert decision.both_sides_populated
+    assert (decision.top_refs, decision.bottom_refs) == ({"U1", "Q2"}, {"J1"})
+    assert decision.smt_populated_side_count == 1
+    assert not _decision(economic_only_refs={"R1"}).economic_only_conflict_refs

--- a/common/test_bom_estimator_pricing.py
+++ b/common/test_bom_estimator_pricing.py
@@ -20,6 +20,7 @@ def _part(lcsc="C1", **overrides):
     part = {
         "lcsc": lcsc,
         "exclude_from_bom": 0,
+        "exclude_from_pos": 0,
         "pad_count": 1,
         "has_tht": 0,
         "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
@@ -216,32 +217,30 @@ def test_collect_billable_bom_parts_filters_excluded_unassigned_and_dnp():
 
 
 def test_scan_assembly_state_reports_joints_standard_and_extended_sets():
-    """Scan helper reports joint counts and surcharge sets correctly."""
+    """Scan reports joints/surcharges and trusts current POS over stale JSON."""
     bom_parts = [
-        {
-            "reference": "U1",
-            "lcsc": "C-SMT-STD",
-            "pad_count": 2,
-            "has_tht": 0,
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false}',
-        },
-        {
-            "reference": "J1",
-            "lcsc": "C-THT-EXT",
-            "pad_count": 3,
-            "has_tht": 1,
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false}',
-        },
-        {
-            "reference": "R9",
-            "lcsc": "C-SMT-EXT-NOPOS",
-            "pad_count": 2,
-            "has_tht": 0,
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": true}',
-        },
+        _part(
+            "C-SMT-STD",
+            reference="U1",
+            pad_count=2,
+            component_product_type=2,
+        ),
+        _part(
+            "C-THT-EXT",
+            reference="J1",
+            pad_count=3,
+            has_tht=1,
+            component_product_type=0,
+            assembly_flags='{"exclude_from_pos": true}',
+        ),
+        _part(
+            "C-SMT-EXT-NOPOS",
+            reference="R9",
+            exclude_from_pos=1,
+            pad_count=2,
+            component_product_type=0,
+            assembly_flags='{"exclude_from_pos": false}',
+        ),
     ]
 
     details_map = {
@@ -262,3 +261,23 @@ def test_scan_assembly_state_reports_joints_standard_and_extended_sets():
     assert scan.tht_joints == 15
     assert scan.smt_lcsc == {"C-SMT-STD"}
     assert scan.extended_lcsc == {"C-SMT-EXT-NOPOS"}
+
+
+@pytest.mark.parametrize(
+    ("product_type", "uses_standard"),
+    [("2", True), ("bad", False)],
+)
+def test_pricing_fallback_uses_shared_product_type_classifier(
+    product_type, uses_standard
+):
+    """Representative legacy fallback inputs exercise classifier integration."""
+    part = _part(pad_count=2, component_product_type=product_type)
+
+    summary = _estimate(
+        [part],
+        board_standard=None,
+        smt_populated_sides=1,
+    )
+
+    assert (summary.standard_setup_cost > 0) is uses_standard
+    assert (summary.economic_setup_cost > 0) is (not uses_standard)

--- a/common/test_bom_estimator_pricing.py
+++ b/common/test_bom_estimator_pricing.py
@@ -15,6 +15,29 @@ from bom_estimation.pricing import (  # pylint: disable=import-error
 )
 
 
+def _part(lcsc="C1", **overrides):
+    """Return a populated SMT BOM row with optional scenario-specific fields."""
+    part = {
+        "lcsc": lcsc,
+        "exclude_from_bom": 0,
+        "pad_count": 1,
+        "has_tht": 0,
+        "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
+    }
+    part.update(overrides)
+    return part
+
+
+def _estimate(parts, board_count=5, price="1-:0.10", part_type="Basic", **options):
+    """Estimate a scenario with a uniform component detail response."""
+    return calculate_bom_estimate(
+        parts,
+        board_count,
+        lambda _lcsc: {"price": price, "type": part_type},
+        **options,
+    )
+
+
 def test_get_unit_price_quantity_tiers():
     """Tier parser picks expected unit prices."""
     assert get_unit_price(1, "1-9:0.12,10-99:0.08,100-:0.05") == 0.12
@@ -78,27 +101,9 @@ def test_get_unit_price_returns_negative_one_for_fully_malformed_string():
 
 def test_calculate_bom_estimate_smt_and_extended_once_per_lcsc():
     """Economic mode charges extended surcharge once per distinct LCSC."""
-    parts = [
-        {
-            "lcsc": "C123",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-        {
-            "lcsc": "C123",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-    ]
+    parts = [_part("C123"), _part("C123")]
 
-    def get_details(_):
-        return {"price": "1-9:0.30,10-:0.20", "type": "Extended"}
-
-    summary = calculate_bom_estimate(parts, board_count=5, get_part_details=get_details)
+    summary = _estimate(parts, price="1-9:0.30,10-:0.20", part_type="Extended")
 
     p = DEFAULT_PRICING
     expected_assembly = (
@@ -113,21 +118,9 @@ def test_calculate_bom_estimate_smt_and_extended_once_per_lcsc():
 
 def test_calculate_bom_estimate_tht_setup_and_no_extended_surcharge_for_tht():
     """THT setup/joint fees apply and SMT extended surcharge is skipped for THT."""
-    parts = [
-        {
-            "lcsc": "C777",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 1,
-            "assembly_process": "Wave soldering",
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        }
-    ]
+    parts = [_part("C777", pad_count=2, has_tht=1, assembly_process="Wave soldering")]
 
-    def get_details(_):
-        return {"price": "1-:0.50", "type": "Extended"}
-
-    summary = calculate_bom_estimate(parts, board_count=5, get_part_details=get_details)
+    summary = _estimate(parts, price="1-:0.50", part_type="Extended")
 
     p = DEFAULT_PRICING
     expected_assembly = (
@@ -140,24 +133,8 @@ def test_calculate_bom_estimate_tht_setup_and_no_extended_surcharge_for_tht():
 def test_standard_mode_does_not_charge_extended_surcharge():
     """Standard mode uses std-parts surcharge and does not apply extended fee."""
     parts = [
-        {
-            "lcsc": "CEXT1",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 2,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
-        {
-            "lcsc": "CBAS1",
-            "exclude_from_bom": 0,
-            "pad_count": 1,
-            "has_tht": 0,
-            "assembly_process": "SMT",
-            "component_product_type": 0,
-            "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-        },
+        _part("CEXT1", pad_count=2, assembly_process="SMT", component_product_type=2),
+        _part("CBAS1", assembly_process="SMT", component_product_type=0),
     ]
 
     def get_details(lcsc):
@@ -198,25 +175,14 @@ def test_is_tht_part_uses_assembly_process_fallback():
 
 def test_assembly_pricing_custom_instance_overrides_defaults():
     """Custom pricing inputs propagate through total assembly calculation."""
-    part = {
-        "lcsc": "C1",
-        "exclude_from_bom": 0,
-        "pad_count": 2,
-        "has_tht": 0,
-        "assembly_flags": '{"exclude_from_pos": false, "is_dnp": false}',
-    }
+    part = _part(pad_count=2)
     cheap = AssemblyPricing(
         economic_setup_fee=1.0,
         economic_stencil_fee=0.5,
         extended_part_fee=0.0,
         smt_per_joint_fee=0.001,
     )
-    summary = calculate_bom_estimate(
-        [part],
-        board_count=5,
-        get_part_details=lambda _: {"price": "1-:0.10", "type": "Basic"},
-        pricing=cheap,
-    )
+    summary = _estimate([part], pricing=cheap)
     expected_assembly = 1.0 + 0.5 + 10 * 0.001
     assert summary.assembly_cost == pytest.approx(expected_assembly, abs=1e-4)
 

--- a/common/test_bom_estimator_view.py
+++ b/common/test_bom_estimator_view.py
@@ -74,18 +74,20 @@ def test_standard_signal_reasons_orders_labels_consistently():
     """Signal reason labels are ordered for stable display."""
     reasons = standard_signal_reasons(
         {
-            "qty_50_plus": True,
+            "quantity_over_50": True,
             "manual_enabled": True,
             "multi_side_populated": True,
             "standard_part_present": True,
         }
     )
-    assert reasons == ["manual", "qty≥50", "standard part", "both sides populated"]
+    assert reasons == ["manual", "qty>50", "standard part", "both sides populated"]
 
 
 def test_standard_signal_reasons_ignores_inactive_flags():
     """No active signals yields no labels."""
-    assert standard_signal_reasons({"manual_enabled": False, "qty_50_plus": 0}) == []
+    assert (
+        standard_signal_reasons({"manual_enabled": False, "quantity_over_50": 0}) == []
+    )
 
 
 def test_calculate_part_bom_cost_uses_raw_component_price_only():

--- a/common/test_bom_estimator_view.py
+++ b/common/test_bom_estimator_view.py
@@ -6,7 +6,6 @@ from bom_estimation.pricing import (  # pylint: disable=import-error
 )
 from bom_estimation.view import (  # pylint: disable=import-error
     build_bom_estimate_view_model,
-    build_standard_mode_context,
     format_bom_estimate_summary,
     format_part_bom_price_label,
     prepare_bom_price_labels,
@@ -14,24 +13,31 @@ from bom_estimation.view import (  # pylint: disable=import-error
 )
 
 
+def _summary(**overrides):
+    """Return a representative estimate summary."""
+    values = {
+        "total_cost": 25.50,
+        "cost_per_board": 12.75,
+        "missing_prices": 0,
+        "component_cost": 10.00,
+        "fixed_cost": 8.00,
+        "extended_cost": 3.00,
+        "economic_setup_cost": 8.00,
+        "standard_setup_cost": 0.00,
+        "stencil_cost": 1.50,
+        "tht_setup_cost": 0.00,
+        "variable_assembly_cost": 7.50,
+        "standard_part_surcharge_cost": 0.00,
+        "smt_joint_count": 100,
+        "tht_joint_count": 0,
+    }
+    values.update(overrides)
+    return BomEstimateSummary(**values)
+
+
 def test_format_bom_estimate_summary_basic():
     """Economic summary line shows expected fixed/assembly buckets."""
-    summary = BomEstimateSummary(
-        total_cost=25.50,
-        cost_per_board=12.75,
-        missing_prices=0,
-        component_cost=10.00,
-        fixed_cost=8.00,
-        extended_cost=3.00,
-        economic_setup_cost=8.00,
-        standard_setup_cost=0.00,
-        stencil_cost=1.50,
-        tht_setup_cost=0.00,
-        variable_assembly_cost=7.50,
-        standard_part_surcharge_cost=0.00,
-        smt_joint_count=100,
-        tht_joint_count=0,
-    )
+    summary = _summary()
 
     overview, details = format_bom_estimate_summary(summary, 2, "Economic", "none")
     assert "Mode Economic" in overview
@@ -42,17 +48,13 @@ def test_format_bom_estimate_summary_basic():
 
 def test_format_bom_estimate_summary_with_standard_surcharge():
     """Standard summary line shows std-parts and hides extended label."""
-    summary = BomEstimateSummary(
+    summary = _summary(
         total_cost=35.00,
         cost_per_board=17.50,
         missing_prices=2,
-        component_cost=10.00,
-        fixed_cost=8.00,
-        extended_cost=3.00,
         economic_setup_cost=0.00,
         standard_setup_cost=25.00,
         stencil_cost=7.80,
-        tht_setup_cost=0.00,
         variable_assembly_cost=12.20,
         standard_part_surcharge_cost=1.50,
         smt_joint_count=50,
@@ -133,20 +135,6 @@ def test_build_bom_estimate_view_model_returns_summary_and_highlights():
     assert view_model["mode"] == "Standard"
     assert view_model["reason_text"] == "standard part"
     assert view_model["highlight_refs"] == {"R1"}
-
-
-def test_build_standard_mode_context_highlights_standard_parts_and_multiside_refs():
-    """Policy context includes all populated refs on multi-side boards."""
-    context = build_standard_mode_context(
-        manual_enabled=False,
-        board_count=5,
-        populated_refs={"R1", "R2", "R3"},
-        populated_sides={"top", "bottom"},
-        smt_populated_sides={"top", "bottom"},
-        standard_part_refs={"R2"},
-    )
-
-    assert context["trigger_references"] == {"R1", "R2", "R3"}
 
 
 def test_prepare_bom_price_labels_returns_reference_to_label_mapping():

--- a/common/test_store_pad_filter.py
+++ b/common/test_store_pad_filter.py
@@ -113,6 +113,49 @@ def _store_obj():
     return Store.__new__(Store)
 
 
+def _store_with_enriched_part(
+    tmp_path, *, lcsc="C1", assembly_process="SMT", product_type=2
+):
+    """Create a test store containing one enriched LCSC assignment."""
+    store = _store_obj()
+    store.logger = logging.getLogger(__name__)
+    store.dbfile = str(tmp_path / "project.db")
+    store.create_db()
+    with contextlib.closing(sqlite3.connect(store.dbfile)) as con, con as cur:
+        cur.execute(
+            "INSERT INTO part_info ("
+            "reference, value, footprint, lcsc, stock, exclude_from_bom, "
+            "exclude_from_pos, assembly_process, component_product_type"
+            ") VALUES ('R1', '10k', 'R_0603', ?, 1, 0, 0, ?, ?)",
+            (lcsc, assembly_process, product_type),
+        )
+        cur.commit()
+    return store
+
+
+def _update_part(store, lcsc, value="10k"):
+    store.update_part(
+        {
+            "reference": "R1",
+            "value": value,
+            "footprint": "R_0603",
+            "lcsc": lcsc,
+            "exclude_from_bom": 0,
+            "exclude_from_pos": 0,
+        }
+    )
+
+
+def _part_state(store):
+    part = store.get_part("R1")
+    return (
+        part["lcsc"],
+        part["value"],
+        part["assembly_process"],
+        part["component_product_type"],
+    )
+
+
 def test_count_pad_filters_npth_non_plated_and_attribute_markers():
     """count_pad excludes clearly non-joint pads using multiple API signals."""
     assert not count_pad(_Pad(npth=True))
@@ -161,44 +204,27 @@ def test_footprint_has_tht_detects_plated_drilled_or_holed_pad():
     assert footprint_has_tht(fp_drill)
 
 
-def test_set_lcsc_resets_cached_assembly_metadata(tmp_path):
-    """Changing LCSC clears stale enrichment metadata for re-fetch."""
-    s = _store_obj()
-    s.logger = logging.getLogger(__name__)
-    s.dbfile = str(tmp_path / "project.db")
+def test_assembly_metadata_follows_lcsc_lifecycle(tmp_path):
+    """Metadata survives refreshes, rejects stale results, and clears on reassignment."""
+    store = _store_with_enriched_part(tmp_path)
 
-    s.create_db()
+    _update_part(store, "C1", value="12k")
+    assert _part_state(store) == ("C1", "12k", "SMT", 2)
 
-    with contextlib.closing(sqlite3.connect(s.dbfile)) as con, con as cur:
-        cur.execute(
-            "INSERT INTO part_info ("
-            "reference, value, footprint, lcsc, stock, exclude_from_bom, exclude_from_pos"
-            ") VALUES (:reference, :value, :footprint, :lcsc, :stock, :exclude_from_bom, :exclude_from_pos)",
-            {
-                "reference": "R1",
-                "value": "10k",
-                "footprint": "R_0603",
-                "lcsc": "COLD",
-                "stock": 1,
-                "exclude_from_bom": 0,
-                "exclude_from_pos": 0,
-            },
-        )
-        cur.execute(
-            "UPDATE part_info SET assembly_process = 'SMT', component_product_type = 0 WHERE reference = 'R1'"
-        )
-        cur.commit()
+    assert store.set_assembly_metadata("R1", "SMT updated", None, expected_lcsc="C1")
+    assert _part_state(store) == ("C1", "12k", "SMT updated", 2)
 
-    s.set_lcsc("R1", "CNEW")
+    assert not store.set_assembly_metadata(
+        "R1", "Wave soldering", 0, expected_lcsc="COLD"
+    )
+    assert _part_state(store) == ("C1", "12k", "SMT updated", 2)
 
-    with contextlib.closing(sqlite3.connect(s.dbfile)) as con, con as cur:
-        row = cur.execute(
-            "SELECT lcsc, assembly_process, component_product_type FROM part_info WHERE reference = 'R1'"
-        ).fetchone()
+    _update_part(store, "C2")
+    assert _part_state(store) == ("C2", "10k", "", None)
 
-    assert row[0] == "CNEW"
-    assert row[1] == ""
-    assert row[2] is None
+    assert store.set_assembly_metadata("R1", "SMT", 0, expected_lcsc="C2")
+    store.set_lcsc("R1", "CNEW")
+    assert _part_state(store) == ("CNEW", "10k", "", None)
 
 
 def test_get_assembly_enrichment_targets_uses_or_logic(tmp_path):
@@ -210,21 +236,18 @@ def test_get_assembly_enrichment_targets_uses_or_logic(tmp_path):
     s.create_db()
 
     with contextlib.closing(sqlite3.connect(s.dbfile)) as con, con as cur:
-        cur.execute(
+        cur.executemany(
             "INSERT INTO part_info (reference, value, footprint, lcsc, stock, exclude_from_bom, exclude_from_pos, assembly_process, component_product_type) "
-            "VALUES ('R1', '10k', 'R_0603', 'C1', 1, 0, 0, '', NULL)"
-        )
-        cur.execute(
-            "INSERT INTO part_info (reference, value, footprint, lcsc, stock, exclude_from_bom, exclude_from_pos, assembly_process, component_product_type) "
-            "VALUES ('R2', '1u', 'C_0603', 'C2', 1, 0, 0, 'SMT', NULL)"
-        )
-        cur.execute(
-            "INSERT INTO part_info (reference, value, footprint, lcsc, stock, exclude_from_bom, exclude_from_pos, assembly_process, component_product_type) "
-            "VALUES ('R3', '100n', 'C_0603', 'C3', 1, 0, 0, '', 0)"
-        )
-        cur.execute(
-            "INSERT INTO part_info (reference, value, footprint, lcsc, stock, exclude_from_bom, exclude_from_pos, assembly_process, component_product_type) "
-            "VALUES ('R4', '47k', 'R_0603', 'C4', 1, 0, 0, 'SMT', 0)"
+            "VALUES (?, ?, 'R_0603', ?, 1, 0, 0, ?, ?)",
+            [
+                ("R1", "10k", "C1", "", None),
+                ("R2", "1u", "C2", "SMT", None),
+                ("R3", "100n", "C3", "", 0),
+                ("R4", "47k", "C4", "SMT", 0),
+                ("R5", "22k", "C5", "SMT", 3),
+                ("R6", "4k7", "C6", "SMT", "bad"),
+                ("R7", "1k", "C7", "SMT", 2),
+            ],
         )
         cur.commit()
 
@@ -234,6 +257,8 @@ def test_get_assembly_enrichment_targets_uses_or_logic(tmp_path):
         "C1": ["R1"],
         "C2": ["R2"],
         "C3": ["R3"],
+        "C5": ["R5"],
+        "C6": ["R6"],
     }
 
 

--- a/enrichment/providers.py
+++ b/enrichment/providers.py
@@ -18,13 +18,14 @@ LCSC-backed implementation for now.
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
-import contextlib
 import time
 from typing import Protocol
 
 try:
+    from ..bom_estimation.assembly_mode import classify_component_product_type
     from ..lcsc_api import LCSC_API
 except ImportError:  # pragma: no cover - test import fallback
+    from bom_estimation.assembly_mode import classify_component_product_type
     from lcsc_api import LCSC_API
 
 
@@ -57,16 +58,6 @@ class LCSCAssemblyMetadataProvider:
         self._api = api or LCSC_API()
         self.min_interval_seconds = min_interval_seconds
 
-    @staticmethod
-    def _safe_int(value: object, default: int = 0) -> int:
-        """Best-effort integer conversion helper."""
-        if isinstance(value, bool):
-            return int(value)
-        if isinstance(value, (int, float, str)):
-            with contextlib.suppress(ValueError, TypeError):
-                return int(value)
-        return default
-
     def _normalize(self, code: str) -> dict[str, object]:
         """Fetch and normalize a single part code's metadata."""
         assembly_process = ""
@@ -76,14 +67,14 @@ class LCSCAssemblyMetadataProvider:
             if part_data.get("success"):
                 payload = part_data.get("data", {}).get("data", {})
                 assembly_process = payload.get("assemblyProcess", "")
-                component_product_type = payload.get("componentProductType")
+                component_product_type = classify_component_product_type(
+                    payload.get("componentProductType")
+                )
         except Exception:  # pylint: disable=broad-exception-caught
             assembly_process = ""
             component_product_type = None
 
-        is_standard = False
-        with contextlib.suppress(ValueError, TypeError):
-            is_standard = self._safe_int(component_product_type) != 0
+        is_standard = component_product_type == 2
 
         return {
             "assembly_process": assembly_process,

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -18,6 +18,7 @@ import wx  # pylint: disable=import-error
 import wx.dataview as dv  # pylint: disable=import-error
 from wx import adv  # pylint: disable=import-error
 
+from .bom_estimation.assembly_mode import classify_component_product_type
 from .bom_estimation.help_text import show_bom_estimator_help
 from .bom_widget import BomEstimatorController, BomEstimatorWidget
 from .corrections import CorrectionManagerDialog
@@ -931,11 +932,11 @@ class JLCPCBTools(wx.Dialog):
         if lcsc in self.pending_assembly_enrichment:
             return "Pending"
         if (
-            str(part.get("assembly_process") or "")
-            or part.get("component_product_type") is not None
+            classify_component_product_type(part.get("component_product_type"))
+            is not None
         ):
             return "Done"
-        return "Queued"
+        return "Class missing"
 
     def start_assembly_enrichment(self, references=None):
         """Start background enrichment for missing assembly process metadata."""
@@ -997,19 +998,24 @@ class JLCPCBTools(wx.Dialog):
 
         assembly_process = metadata.get("assembly_process", "")
         component_product_type = metadata.get("component_product_type")
-        status = (
-            "Done"
-            if assembly_process or component_product_type is not None
-            else "No data"
-        )
-
         for reference in refs:
-            self.store.set_assembly_metadata(
+            updated = self.store.set_assembly_metadata(
                 reference,
                 assembly_process,
                 component_product_type,
+                expected_lcsc=lcsc,
             )
-            self.partlist_data_model.set_enrichment_status(reference, status)
+            if updated:
+                current_part = self.store.get_part(reference) or {}
+                status = (
+                    "Done"
+                    if classify_component_product_type(
+                        current_part.get("component_product_type")
+                    )
+                    is not None
+                    else "Class missing"
+                )
+                self.partlist_data_model.set_enrichment_status(reference, status)
 
         self.pending_assembly_enrichment.discard(lcsc)
 

--- a/store.py
+++ b/store.py
@@ -194,11 +194,18 @@ class Store:
             cur.commit()
 
     def update_part(self, part: dict):
-        """Update a part in the database, overwrite lcsc if supplied."""
+        """Update a part, clearing assembly metadata only when LCSC changes."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
             cur.execute(
                 "UPDATE part_info set "
-                "value = :value, footprint = :footprint, lcsc = :lcsc, "
+                "value = :value, footprint = :footprint, "
+                "assembly_process = CASE "
+                "WHEN COALESCE(lcsc, '') != COALESCE(:lcsc, '') THEN '' "
+                "ELSE assembly_process END, "
+                "component_product_type = CASE "
+                "WHEN COALESCE(lcsc, '') != COALESCE(:lcsc, '') THEN NULL "
+                "ELSE component_product_type END, "
+                "lcsc = :lcsc, "
                 "exclude_from_bom = :exclude_from_bom, exclude_from_pos = :exclude_from_pos "
                 "WHERE reference = :reference",
                 part,
@@ -262,21 +269,26 @@ class Store:
         ref: str,
         assembly_process: str,
         component_product_type,
+        expected_lcsc=None,
     ):
-        """Persist assembly metadata for a part."""
+        """Persist metadata if LCSC still matches, preserving known class data."""
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
-            cur.execute(
+            result = cur.execute(
                 "UPDATE part_info SET "
                 "assembly_process = :assembly_process, "
-                "component_product_type = :component_product_type "
-                "WHERE reference = :reference",
+                "component_product_type = COALESCE("
+                ":component_product_type, component_product_type) "
+                "WHERE reference = :reference "
+                "AND (:expected_lcsc IS NULL OR lcsc = :expected_lcsc)",
                 {
                     "reference": ref,
                     "assembly_process": assembly_process,
                     "component_product_type": component_product_type,
+                    "expected_lcsc": expected_lcsc,
                 },
             )
             cur.commit()
+            return result.rowcount > 0
 
     def get_assembly_enrichment_targets(self, references=None) -> dict:
         """Get references grouped by LCSC that still need assembly process enrichment."""
@@ -285,7 +297,8 @@ class Store:
             "WHERE lcsc IS NOT NULL AND lcsc != '' "
             "AND ("
             "assembly_process IS NULL OR assembly_process = '' "
-            "OR component_product_type IS NULL"
+            "OR component_product_type IS NULL "
+            "OR component_product_type NOT IN (0, 1, 2)"
             ")"
         )
         params = []

--- a/tests/test_bom_estimator_controller.py
+++ b/tests/test_bom_estimator_controller.py
@@ -1,14 +1,6 @@
-"""Integration tests for BomEstimatorController.recompute.
+"""Integration tests for BomEstimatorController without wx/KiCad."""
 
-The controller lives in `bom_widget.py` which imports wx/pcbnew at module
-load. We follow the same mock-then-import bootstrap as
-`test_bom_designator_split.py` so the controller can be exercised in
-non-wx environments.
-
-These tests inject fakes for every callback the controller depends on,
-so each scenario is observable without touching real UI or board state.
-"""
-
+import importlib
 from pathlib import Path
 import sys
 import types
@@ -16,77 +8,73 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Bootstrap: stub KiCad / wx modules and load bom_widget under a fake package.
-# ---------------------------------------------------------------------------
 _ROOT = Path(__file__).parent.parent
+_pcbnew = sys.modules.setdefault("pcbnew", MagicMock())
+_pcbnew.F_Cu = 0
+for _module in ("wx", "wx.dataview"):
+    sys.modules.setdefault(_module, MagicMock())
 
-_pcbnew_stub = sys.modules.setdefault("pcbnew", MagicMock())
-# Force-set F_Cu even if pcbnew was already stubbed by an earlier test —
-# bom_widget._is_on_bottom_side compares against this sentinel.
-_pcbnew_stub.F_Cu = 0
-for _mod in ["wx", "wx.dataview"]:
-    sys.modules.setdefault(_mod, MagicMock())
-
-_pkg_name = "kicadplugin"
-if _pkg_name not in sys.modules:
-    _pkg = types.ModuleType(_pkg_name)
-    _pkg.__path__ = [str(_ROOT)]
-    sys.modules[_pkg_name] = _pkg
-
+_PACKAGE = "kicadplugin"
+if _PACKAGE not in sys.modules:
+    package = types.ModuleType(_PACKAGE)
+    package.__path__ = [str(_ROOT)]
+    sys.modules[_PACKAGE] = package
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-# Load bom_widget under the kicadplugin namespace so its relative imports work.
-import importlib  # noqa: E402
-
-bom_widget = importlib.import_module("kicadplugin.bom_widget")
-BomEstimatorController = bom_widget.BomEstimatorController
+BomEstimatorController = importlib.import_module(
+    f"{_PACKAGE}.bom_widget"
+).BomEstimatorController
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-class _FakeFootprint:
-    def __init__(self, layer=0, flipped=False):
-        self._layer = layer
-        self._flipped = flipped
+class _Footprint:
+    def __init__(self, layer=0):
+        self.layer = layer
 
     def IsFlipped(self):
-        return self._flipped
+        return False
 
     def GetLayer(self):
-        return self._layer
+        return self.layer
 
 
-class _FakeBoard:
-    def __init__(self, footprints):
-        self._footprints = footprints
+class _Board:
+    def __init__(self, footprints=None):
+        self.footprints = footprints or {}
 
-    def FindFootprintByReference(self, ref):
-        return self._footprints.get(ref)
+    def FindFootprintByReference(self, reference):
+        return self.footprints.get(reference)
 
 
-def _part(reference="R1", **values):
+_MISSING = object()
+
+
+def _part(reference="R1", *, component_product_type=0, **values):
     """Return a placed, billable part with concise per-test overrides."""
     part = {
         "reference": reference,
         "lcsc": "C1",
         "exclude_from_bom": 0,
+        "exclude_from_pos": 0,
         "pad_count": 2,
         "has_tht": 0,
+        "component_product_type": component_product_type,
         "assembly_flags": "{}",
     }
     part.update(values)
+    if component_product_type is _MISSING:
+        part.pop("component_product_type")
     return part
 
 
 def _board(**layers):
-    """Build a board from ``reference=layer`` entries."""
-    return _FakeBoard(
-        {reference: _FakeFootprint(layer) for reference, layer in layers.items()}
+    """Build a board from reference=layer entries; None means absent."""
+    return _Board(
+        {
+            reference: _Footprint(layer)
+            for reference, layer in layers.items()
+            if layer is not None
+        }
     )
 
 
@@ -97,123 +85,92 @@ def _details(**prices):
     }
 
 
-def _make_controller(
-    *,
-    parts,
-    board=None,
-    details_map=None,
-    force_standard=False,
-):
-    """Build a controller with capturing fakes for every callback."""
+def _make_controller(*, parts, board=None, details=None, force_standard=False):
+    """Build a controller and capture each observable callback."""
     captured = {
-        "summary_text": [],
-        "price_labels": [],
+        "summary": [],
+        "prices": [],
         "trigger_refs": [],
-        "refresh_rows_count": 0,
+        "refresh_count": 0,
     }
 
     def refresh_rows():
-        captured["refresh_rows_count"] += 1
-
-    def set_summary_text(text):
-        captured["summary_text"].append(text)
-
-    def set_price_label(ref, label):
-        captured["price_labels"].append((ref, label))
-
-    def set_trigger_refs(refs):
-        captured["trigger_refs"].append(set(refs))
+        captured["refresh_count"] += 1
 
     controller = BomEstimatorController(
         read_parts=lambda: parts,
-        get_part_details=lambda lcsc: (details_map or {}).get(lcsc, {}),
-        get_board=lambda: board if board is not None else _FakeBoard({}),
+        get_part_details=lambda lcsc: (details or {}).get(lcsc, {}),
+        get_board=lambda: board or _Board(),
         is_force_standard_enabled=lambda: force_standard,
-        set_price_label=set_price_label,
-        set_trigger_refs=set_trigger_refs,
+        set_price_label=lambda *args: captured["prices"].append(args),
+        set_trigger_refs=lambda refs: captured["trigger_refs"].append(set(refs)),
         refresh_rows=refresh_rows,
-        set_summary_text=set_summary_text,
+        set_summary_text=captured["summary"].append,
     )
     return controller, captured
 
 
-# ---------------------------------------------------------------------------
-# Scenarios
-# ---------------------------------------------------------------------------
-
-
-def test_recompute_empty_parts_short_circuits_with_no_parts_summary():
-    """Empty input emits the 'no parts' summary and clears trigger refs."""
-    controller, captured = _make_controller(parts=[])
-    controller.recompute(board_count=10)
-
-    assert captured["summary_text"] == ["BOM Estimate (10 boards): no parts"]
-    assert captured["trigger_refs"] == [set()]
-    assert captured["refresh_rows_count"] == 1
-    assert captured["price_labels"] == []
-
-
-def test_recompute_all_excluded_from_bom_short_circuits_with_no_assigned_summary():
-    """All-excluded input emits the 'no assigned BOM parts' summary."""
-    parts = [
-        _part("R1", exclude_from_bom=1),
-        _part("R2", lcsc="C2", exclude_from_bom=1),
-    ]
+@pytest.mark.parametrize(
+    ("parts", "board_count", "expected"),
+    [
+        ([], 10, "BOM Estimate (10 boards): no parts"),
+        (
+            [_part(exclude_from_bom=1)],
+            5,
+            "BOM Estimate (5 boards): no assigned BOM parts",
+        ),
+    ],
+)
+def test_recompute_empty_states_clear_outputs(parts, board_count, expected):
+    """Empty and unassigned BOMs clear every dependent output."""
     controller, captured = _make_controller(parts=parts)
-    controller.recompute(board_count=5)
 
-    assert captured["summary_text"] == [
-        "BOM Estimate (5 boards): no assigned BOM parts"
-    ]
-    assert captured["trigger_refs"] == [set()]
-    assert captured["price_labels"] == []
+    controller.recompute(board_count)
+
+    assert captured == {
+        "summary": [expected],
+        "prices": [],
+        "trigger_refs": [set()],
+        "refresh_count": 1,
+    }
 
 
-def test_recompute_all_dnp_short_circuits_when_all_rows_filtered():
-    """All-DNP rows still produce a summary line and per-part labels.
-
-    Rows with is_dnp pass the bom_parts filter (have lcsc, not excluded) so
-    the controller does not short-circuit; calculate_bom_estimate drops them
-    later in its billable filter, yielding zero assembly cost.
-    """
-    parts = [_part(assembly_flags='{"is_dnp": true}')]
+def test_recompute_dnp_part_still_receives_a_price_label():
+    """Keep the table price label current even when its part is DNP."""
     controller, captured = _make_controller(
-        parts=parts,
+        parts=[_part(assembly_flags='{"is_dnp": true}')],
         board=_board(R1=0),
-        details_map=_details(C1="0.10"),
+        details=_details(C1="0.10"),
     )
-    controller.recompute(board_count=5)
 
-    # Summary line is rendered (no short-circuit) but assembly cost should be 0
-    # because the only row is DNP.
-    assert len(captured["summary_text"]) == 1
-    assert "BOM Estimate" in captured["summary_text"][0]
-    # Each part still gets a price label set.
-    refs_with_labels = {ref for ref, _ in captured["price_labels"]}
-    assert refs_with_labels == {"R1"}
+    controller.recompute(5)
+
+    assert "BOM Estimate" in captured["summary"][0]
+    assert {reference for reference, _ in captured["prices"]} == {"R1"}
 
 
-def test_recompute_normal_mixed_emits_summary_and_per_part_price_labels():
-    """A normal mixed BOM produces a multi-line summary and one label per ref."""
+def test_recompute_prices_each_reference_in_a_mixed_bom():
+    """Price every distinct reference in a mixed BOM."""
     parts = [
         _part("R1"),
         _part("R2"),
         _part("U1", lcsc="C2", pad_count=8),
     ]
-    board = _board(R1=0, R2=0, U1=0)
-    details_map = _details(C1="0.05", C2="0.40")
     controller, captured = _make_controller(
-        parts=parts, board=board, details_map=details_map
+        parts=parts,
+        board=_board(R1=0, R2=0, U1=0),
+        details=_details(C1="0.05", C2="0.40"),
     )
-    controller.recompute(board_count=10)
 
-    # Summary text gets the multi-line overview/details format.
-    assert len(captured["summary_text"]) == 1
-    assert "BOM Estimate" in captured["summary_text"][0]
-    # Price labels emitted for every distinct reference.
-    refs_labelled = {ref for ref, _ in captured["price_labels"]}
-    assert refs_labelled == {"R1", "R2", "U1"}
-    assert captured["refresh_rows_count"] == 1
+    decision = controller.recompute(10)
+
+    assert decision.board_standard is False
+    assert {reference for reference, _ in captured["prices"]} == {
+        "R1",
+        "R2",
+        "U1",
+    }
+    assert captured["refresh_count"] == 1
 
 
 @pytest.mark.parametrize(
@@ -221,34 +178,102 @@ def test_recompute_normal_mixed_emits_summary_and_per_part_price_labels():
     [(_board(R1=0, R2=0), False), (_board(R1=0, R2=31), True)],
     ids=("one-side", "two-sides"),
 )
-def test_get_board_standard_context_detects_populated_sides(board, expected):
+def test_board_context_detects_populated_sides(board, expected):
     """Distinguish one-sided from two-sided placement."""
     parts = [_part("R1"), _part("R2", lcsc="C2")]
     controller, _ = _make_controller(parts=parts, board=board)
-    context = controller._get_board_standard_context(parts, board_count=10)
 
-    assert context["signals"]["multi_side_populated"] is expected
-    assert context["board_standard"] is expected
+    decision = controller._get_board_standard_context(parts, board_count=10)
+
+    assert decision.both_sides_populated is expected
+    assert decision.board_standard is expected
 
 
-def test_recompute_enrichment_pending_uses_available_metadata_and_no_assembly_data():
-    """Recompute still produces a summary while assembly enrichment is pending.
+@pytest.mark.parametrize(
+    ("product_type", "expected_mode", "expected_standard", "expected_missing"),
+    [
+        (0, False, set(), set()),
+        (1, False, set(), set()),
+        (2, True, {"U1"}, set()),
+        (None, None, set(), {"U1"}),
+        ("bad", None, set(), {"U1"}),
+        (2.5, None, set(), {"U1"}),
+    ],
+)
+def test_board_context_maps_raw_component_product_types_exactly(
+    product_type,
+    expected_mode,
+    expected_standard,
+    expected_missing,
+):
+    """Only exact type 2 checks the part and forces Standard."""
+    parts = [_part("U1", component_product_type=product_type)]
+    controller, _ = _make_controller(parts=parts, board=_board(U1=0))
 
-    Simulates the enrichment-pending state: get_part_details returns price
-    info but the part rows themselves have no assembly_process / product_type
-    (those would be filled in once enrichment finishes).
-    """
-    parts = [_part()]
-    board = _board(R1=0)
-    details_map = _details(C1="0.20")
-    controller, captured = _make_controller(
-        parts=parts, board=board, details_map=details_map
+    decision = controller._get_board_standard_context(parts, board_count=5)
+
+    assert decision.board_standard is expected_mode
+    assert decision.standard_only_refs == frozenset(expected_standard)
+    assert decision.classification_missing_refs == frozenset(expected_missing)
+
+
+def test_board_context_reports_economic_only_conflict_with_known_trigger():
+    """An Economic Only selected part conflicts when quantity requires Standard."""
+    parts = [_part("D1", component_product_type=1)]
+    controller, _ = _make_controller(parts=parts, board=_board(D1=0))
+
+    decision = controller._get_board_standard_context(parts, board_count=51)
+
+    assert decision.board_standard is True
+    assert decision.economic_only_conflict_refs == frozenset({"D1"})
+
+
+def test_board_context_uses_direct_pos_and_filters_dnp_and_absent_footprints():
+    """Use direct POS data and ignore DNP or absent footprints."""
+    parts = [
+        _part("R1"),
+        _part(
+            "U1",
+            lcsc="C2",
+            component_product_type=2,
+            exclude_from_pos=1,
+            assembly_flags='{"exclude_from_pos": false}',
+        ),
+        _part(
+            "U2",
+            lcsc="C3",
+            component_product_type=2,
+            assembly_flags='{"exclude_from_pos": true}',
+        ),
+        _part(
+            "U3",
+            lcsc="C4",
+            component_product_type=2,
+            assembly_flags='{"is_dnp": true}',
+        ),
+        _part("U4", lcsc="C5", component_product_type=2),
+    ]
+    controller, _ = _make_controller(
+        parts=parts,
+        board=_board(R1=0, U1=0, U2=0, U3=0),
     )
-    controller.recompute(board_count=8)
 
-    # Controller still produces a summary and per-part labels even with
-    # missing enrichment metadata.
-    assert len(captured["summary_text"]) == 1
-    refs_labelled = {ref for ref, _ in captured["price_labels"]}
-    assert refs_labelled == {"R1"}
-    assert captured["refresh_rows_count"] == 1
+    decision = controller._get_board_standard_context(parts, board_count=5)
+
+    assert decision.standard_only_refs == frozenset({"U2"})
+    assert decision.top_refs == frozenset({"R1", "U2"})
+
+
+def test_recompute_enrichment_pending_uses_available_metadata():
+    """Recompute still produces output while assembly enrichment is pending."""
+    controller, captured = _make_controller(
+        parts=[_part(component_product_type=_MISSING)],
+        board=_board(R1=0),
+        details=_details(C1="0.20"),
+    )
+
+    controller.recompute(8)
+
+    assert len(captured["summary"]) == 1
+    assert {reference for reference, _ in captured["prices"]} == {"R1"}
+    assert captured["refresh_count"] == 1

--- a/tests/test_bom_estimator_controller.py
+++ b/tests/test_bom_estimator_controller.py
@@ -14,6 +14,8 @@ import sys
 import types
 from unittest.mock import MagicMock
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # Bootstrap: stub KiCad / wx modules and load bom_widget under a fake package.
 # ---------------------------------------------------------------------------
@@ -65,6 +67,34 @@ class _FakeBoard:
 
     def FindFootprintByReference(self, ref):
         return self._footprints.get(ref)
+
+
+def _part(reference="R1", **values):
+    """Return a placed, billable part with concise per-test overrides."""
+    part = {
+        "reference": reference,
+        "lcsc": "C1",
+        "exclude_from_bom": 0,
+        "pad_count": 2,
+        "has_tht": 0,
+        "assembly_flags": "{}",
+    }
+    part.update(values)
+    return part
+
+
+def _board(**layers):
+    """Build a board from ``reference=layer`` entries."""
+    return _FakeBoard(
+        {reference: _FakeFootprint(layer) for reference, layer in layers.items()}
+    )
+
+
+def _details(**prices):
+    return {
+        lcsc: {"price": f"1-:{price}", "type": "Basic"}
+        for lcsc, price in prices.items()
+    }
 
 
 def _make_controller(
@@ -126,22 +156,8 @@ def test_recompute_empty_parts_short_circuits_with_no_parts_summary():
 def test_recompute_all_excluded_from_bom_short_circuits_with_no_assigned_summary():
     """All-excluded input emits the 'no assigned BOM parts' summary."""
     parts = [
-        {
-            "reference": "R1",
-            "lcsc": "C1",
-            "exclude_from_bom": 1,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-        {
-            "reference": "R2",
-            "lcsc": "C2",
-            "exclude_from_bom": 1,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
+        _part("R1", exclude_from_bom=1),
+        _part("R2", lcsc="C2", exclude_from_bom=1),
     ]
     controller, captured = _make_controller(parts=parts)
     controller.recompute(board_count=5)
@@ -160,20 +176,11 @@ def test_recompute_all_dnp_short_circuits_when_all_rows_filtered():
     the controller does not short-circuit; calculate_bom_estimate drops them
     later in its billable filter, yielding zero assembly cost.
     """
-    parts = [
-        {
-            "reference": "R1",
-            "lcsc": "C1",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_flags": '{"is_dnp": true}',
-        },
-    ]
+    parts = [_part(assembly_flags='{"is_dnp": true}')]
     controller, captured = _make_controller(
         parts=parts,
-        board=_FakeBoard({"R1": _FakeFootprint(layer=0)}),
-        details_map={"C1": {"price": "1-:0.10", "type": "Basic"}},
+        board=_board(R1=0),
+        details_map=_details(C1="0.10"),
     )
     controller.recompute(board_count=5)
 
@@ -189,42 +196,12 @@ def test_recompute_all_dnp_short_circuits_when_all_rows_filtered():
 def test_recompute_normal_mixed_emits_summary_and_per_part_price_labels():
     """A normal mixed BOM produces a multi-line summary and one label per ref."""
     parts = [
-        {
-            "reference": "R1",
-            "lcsc": "C1",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-        {
-            "reference": "R2",
-            "lcsc": "C1",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-        {
-            "reference": "U1",
-            "lcsc": "C2",
-            "exclude_from_bom": 0,
-            "pad_count": 8,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
+        _part("R1"),
+        _part("R2"),
+        _part("U1", lcsc="C2", pad_count=8),
     ]
-    board = _FakeBoard(
-        {
-            "R1": _FakeFootprint(layer=0),
-            "R2": _FakeFootprint(layer=0),
-            "U1": _FakeFootprint(layer=0),
-        }
-    )
-    details_map = {
-        "C1": {"price": "1-:0.05", "type": "Basic"},
-        "C2": {"price": "1-:0.40", "type": "Basic"},
-    }
+    board = _board(R1=0, R2=0, U1=0)
+    details_map = _details(C1="0.05", C2="0.40")
     controller, captured = _make_controller(
         parts=parts, board=board, details_map=details_map
     )
@@ -239,66 +216,19 @@ def test_recompute_normal_mixed_emits_summary_and_per_part_price_labels():
     assert captured["refresh_rows_count"] == 1
 
 
-def test_get_board_standard_context_multi_side_triggers_when_split_across_sides():
-    """multi_side_populated is True when footprints are on both F_Cu and B_Cu."""
-    parts = [
-        {
-            "reference": "R1",
-            "lcsc": "C1",
-            "exclude_from_bom": 0,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-        {
-            "reference": "R2",
-            "lcsc": "C2",
-            "exclude_from_bom": 0,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-    ]
-    # R1 on top (F_Cu == 0), R2 on bottom (any non-zero layer)
-    board = _FakeBoard(
-        {
-            "R1": _FakeFootprint(layer=0),
-            "R2": _FakeFootprint(layer=31),
-        }
-    )
+@pytest.mark.parametrize(
+    ("board", "expected"),
+    [(_board(R1=0, R2=0), False), (_board(R1=0, R2=31), True)],
+    ids=("one-side", "two-sides"),
+)
+def test_get_board_standard_context_detects_populated_sides(board, expected):
+    """Distinguish one-sided from two-sided placement."""
+    parts = [_part("R1"), _part("R2", lcsc="C2")]
     controller, _ = _make_controller(parts=parts, board=board)
     context = controller._get_board_standard_context(parts, board_count=10)
 
-    assert context["signals"]["multi_side_populated"] is True
-    assert context["board_standard"] is True
-
-
-def test_get_board_standard_context_unified_side_does_not_trigger_multi_side():
-    """multi_side_populated is False when all footprints share one side."""
-    parts = [
-        {
-            "reference": "R1",
-            "lcsc": "C1",
-            "exclude_from_bom": 0,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-        {
-            "reference": "R2",
-            "lcsc": "C2",
-            "exclude_from_bom": 0,
-            "has_tht": 0,
-            "assembly_flags": "{}",
-        },
-    ]
-    board = _FakeBoard(
-        {
-            "R1": _FakeFootprint(layer=0),
-            "R2": _FakeFootprint(layer=0),
-        }
-    )
-    controller, _ = _make_controller(parts=parts, board=board)
-    context = controller._get_board_standard_context(parts, board_count=10)
-
-    assert context["signals"]["multi_side_populated"] is False
+    assert context["signals"]["multi_side_populated"] is expected
+    assert context["board_standard"] is expected
 
 
 def test_recompute_enrichment_pending_uses_available_metadata_and_no_assembly_data():
@@ -308,19 +238,9 @@ def test_recompute_enrichment_pending_uses_available_metadata_and_no_assembly_da
     info but the part rows themselves have no assembly_process / product_type
     (those would be filled in once enrichment finishes).
     """
-    parts = [
-        {
-            "reference": "R1",
-            "lcsc": "C1",
-            "exclude_from_bom": 0,
-            "pad_count": 2,
-            "has_tht": 0,
-            # No assembly_process / component_product_type at all
-            "assembly_flags": "{}",
-        },
-    ]
-    board = _FakeBoard({"R1": _FakeFootprint(layer=0)})
-    details_map = {"C1": {"price": "1-:0.20", "type": "Basic"}}
+    parts = [_part()]
+    board = _board(R1=0)
+    details_map = _details(C1="0.20")
     controller, captured = _make_controller(
         parts=parts, board=board, details_map=details_map
     )


### PR DESCRIPTION
## Summary

- streamline existing BOM-estimator fixtures in a behavior-neutral prerequisite commit
- correct the Economic/Standard boundary, selected-side handling, and exact component classification
- report missing classifications and Economic Only conflicts without guessing
- preserve enrichment across unchanged assignments, reject stale results, and retry invalid legacy classifications

Superseded by #797, which includes all commits from this PR along with the Std indicator and assembly-mode details UI. All related work will be reviewed together in #797.

## Validation

- 90 focused foundation tests passed
- ruff passed on all changed Python files
- git diff --check passed
