### PR TITLE
ui(settings): static checkbox labels and an LCSC priority dropdown

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,19 @@ LCSC_PRIORITY_DATABASE = "Database"
 LCSC_PRIORITY_CHOICES = [LCSC_PRIORITY_SCHEMATIC, LCSC_PRIORITY_DATABASE]
 
 
+def _add_setting_row(grid, image, control, flags=wx.ALIGN_CENTER_VERTICAL):
+    """Add an icon | control pair to the settings grid so the controls line up.
+
+    Every row gets an icon cell, empty when the setting has no icon, so the
+    checkboxes and captions share one left edge regardless of icon size.
+    """
+    if image is None:
+        grid.Add((0, 0))
+    else:
+        grid.Add(image, 0, wx.ALL | wx.ALIGN_CENTER, 5)
+    grid.Add(control, 0, wx.ALL | flags, 5)
+
+
 class SettingsDialog(wx.Dialog):
     """Dialog for plugin settings."""
 
@@ -76,10 +89,6 @@ class SettingsDialog(wx.Dialog):
 
         self.tented_vias_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
 
-        tented_vias_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        tented_vias_sizer.Add(self.tented_vias_image, 10, wx.ALL | wx.EXPAND, 5)
-        tented_vias_sizer.Add(self.tented_vias_setting, 100, wx.ALL | wx.EXPAND, 5)
-
         ##### Fill zones #####
 
         self.fill_zones_setting = wx.CheckBox(
@@ -106,10 +115,6 @@ class SettingsDialog(wx.Dialog):
         )
 
         self.fill_zones_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
-
-        fill_zones_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        fill_zones_sizer.Add(self.fill_zones_image, 10, wx.ALL | wx.EXPAND, 5)
-        fill_zones_sizer.Add(self.fill_zones_setting, 100, wx.ALL | wx.EXPAND, 5)
 
         ##### Force DRC before Gerber export #####
 
@@ -142,10 +147,6 @@ class SettingsDialog(wx.Dialog):
 
         self.force_drc_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
 
-        force_drc_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        force_drc_sizer.Add(self.force_drc_image, 10, wx.ALL | wx.EXPAND, 5)
-        force_drc_sizer.Add(self.force_drc_setting, 100, wx.ALL | wx.EXPAND, 5)
-
         ##### Plot values #####
 
         self.plot_values_setting = wx.CheckBox(
@@ -172,10 +173,6 @@ class SettingsDialog(wx.Dialog):
         )
 
         self.plot_values_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
-
-        plot_values_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        plot_values_sizer.Add(self.plot_values_image, 10, wx.ALL | wx.EXPAND, 5)
-        plot_values_sizer.Add(self.plot_values_setting, 100, wx.ALL | wx.EXPAND, 5)
 
         ##### Plot references #####
 
@@ -204,12 +201,6 @@ class SettingsDialog(wx.Dialog):
 
         self.plot_references_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
 
-        plot_references_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        plot_references_sizer.Add(self.plot_references_image, 10, wx.ALL | wx.EXPAND, 5)
-        plot_references_sizer.Add(
-            self.plot_references_setting, 100, wx.ALL | wx.EXPAND, 5
-        )
-
         ##### Subtract mask from silkscreen #####
 
         self.subtract_mask_from_silk_setting = wx.CheckBox(
@@ -229,11 +220,6 @@ class SettingsDialog(wx.Dialog):
         )
 
         self.subtract_mask_from_silk_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
-
-        subtract_mask_from_silk_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        subtract_mask_from_silk_sizer.Add(
-            self.subtract_mask_from_silk_setting, 100, wx.ALL | wx.EXPAND, 5
-        )
 
         ##### LCSC priority #####
 
@@ -274,14 +260,10 @@ class SettingsDialog(wx.Dialog):
         self.lcsc_priority_setting.Bind(wx.EVT_COMBOBOX, self.update_settings)
 
         lcsc_priority_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        lcsc_priority_sizer.Add(self.lcsc_priority_image, 10, wx.ALL | wx.EXPAND, 5)
         lcsc_priority_sizer.Add(
-            lcsc_priority_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
+            lcsc_priority_label, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5
         )
-        lcsc_priority_sizer.Add(
-            self.lcsc_priority_setting, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
-        )
-        lcsc_priority_sizer.AddStretchSpacer(100)
+        lcsc_priority_sizer.Add(self.lcsc_priority_setting, 0, wx.ALIGN_CENTER_VERTICAL)
 
         ##### Only parts with LCSC number in BOM/CPL #####
 
@@ -310,10 +292,6 @@ class SettingsDialog(wx.Dialog):
 
         self.lcsc_bom_cpl_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
 
-        lcsc_bom_cpl_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        lcsc_bom_cpl_sizer.Add(self.lcsc_bom_cpl_image, 10, wx.ALL | wx.EXPAND, 5)
-        lcsc_bom_cpl_sizer.Add(self.lcsc_bom_cpl_setting, 100, wx.ALL | wx.EXPAND, 5)
-
         ##### Check if order/serial number placeholder is present #####
 
         self.order_number_setting = wx.CheckBox(
@@ -341,10 +319,6 @@ class SettingsDialog(wx.Dialog):
 
         self.order_number_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
 
-        order_number_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        order_number_sizer.Add(self.order_number_image, 10, wx.ALL | wx.EXPAND, 5)
-        order_number_sizer.Add(self.order_number_setting, 100, wx.ALL | wx.EXPAND, 5)
-
         ##### Highlight text matches ######
 
         self.highlight_matches_setting = wx.CheckBox(
@@ -364,11 +338,6 @@ class SettingsDialog(wx.Dialog):
         )
 
         self.highlight_matches_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
-
-        highlight_matches_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        highlight_matches_sizer.Add(
-            self.highlight_matches_setting, 100, wx.ALL | wx.EXPAND, 5
-        )
 
         ##### Library Selection #####
 
@@ -399,8 +368,8 @@ class SettingsDialog(wx.Dialog):
         self.library_selected_setting.Bind(wx.EVT_COMBOBOX, self.update_settings)
 
         library_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        library_sizer.Add(library_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-        library_sizer.Add(self.library_selected_setting, 1, wx.ALL | wx.EXPAND, 5)
+        library_sizer.Add(library_label, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5)
+        library_sizer.Add(self.library_selected_setting, 1, wx.EXPAND)
 
         ##### Library Data Directory #####
 
@@ -438,11 +407,9 @@ class SettingsDialog(wx.Dialog):
 
         library_data_path_sizer = wx.BoxSizer(wx.HORIZONTAL)
         library_data_path_sizer.Add(
-            library_data_path_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
+            library_data_path_label, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5
         )
-        library_data_path_sizer.Add(
-            self.library_data_path_setting, 1, wx.ALL | wx.EXPAND, 5
-        )
+        library_data_path_sizer.Add(self.library_data_path_setting, 1, wx.EXPAND)
 
         ##### Generation hooks #####
 
@@ -621,39 +588,53 @@ class SettingsDialog(wx.Dialog):
 
         bom_estimator_show_sizer = wx.BoxSizer(wx.HORIZONTAL)
         bom_estimator_show_sizer.Add(
-            self.bom_estimator_show_image, 10, wx.ALL | wx.EXPAND, 5
+            self.bom_estimator_show_setting, 0, wx.RIGHT | wx.ALIGN_CENTER_VERTICAL, 5
         )
+        bom_estimator_show_sizer.AddStretchSpacer()
         bom_estimator_show_sizer.Add(
-            self.bom_estimator_show_setting, 100, wx.ALL | wx.EXPAND, 5
-        )
-        bom_estimator_show_sizer.Add(
-            self.bom_estimator_help_button,
-            0,
-            wx.ALL | wx.ALIGN_CENTER_VERTICAL,
-            5,
+            self.bom_estimator_help_button, 0, wx.ALIGN_CENTER_VERTICAL
         )
 
         # ---------------------------------------------------------------------
         # ---------------------- Main Layout Sizer ----------------------------
         # ---------------------------------------------------------------------
 
-        settings_grid = wx.GridSizer(0, 2, 0, 0)
-        settings_grid.Add(tented_vias_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(fill_zones_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(force_drc_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(plot_values_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(plot_references_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(subtract_mask_from_silk_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(lcsc_priority_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(lcsc_bom_cpl_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(order_number_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(highlight_matches_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(bom_estimator_show_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(library_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        settings_grid.Add(library_data_path_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        # Two settings columns, each an icon cell plus a control cell, so the
+        # checkboxes line up whatever the icon size (or absence of an icon).
+        settings_grid = wx.FlexGridSizer(0, 4, 0, 0)
+        settings_grid.AddGrowableCol(1, 1)
+        settings_grid.AddGrowableCol(3, 1)
+        _add_setting_row(
+            settings_grid, self.tented_vias_image, self.tented_vias_setting
+        )
+        _add_setting_row(settings_grid, self.fill_zones_image, self.fill_zones_setting)
+        _add_setting_row(settings_grid, self.force_drc_image, self.force_drc_setting)
+        _add_setting_row(
+            settings_grid, self.plot_values_image, self.plot_values_setting
+        )
+        _add_setting_row(
+            settings_grid, self.plot_references_image, self.plot_references_setting
+        )
+        _add_setting_row(settings_grid, None, self.subtract_mask_from_silk_setting)
+        _add_setting_row(settings_grid, self.lcsc_priority_image, lcsc_priority_sizer)
+        _add_setting_row(
+            settings_grid, self.lcsc_bom_cpl_image, self.lcsc_bom_cpl_setting
+        )
+        _add_setting_row(
+            settings_grid, self.order_number_image, self.order_number_setting
+        )
+        _add_setting_row(settings_grid, None, self.highlight_matches_setting)
+        _add_setting_row(
+            settings_grid,
+            self.bom_estimator_show_image,
+            bom_estimator_show_sizer,
+            wx.EXPAND,
+        )
+        _add_setting_row(settings_grid, None, library_sizer, wx.EXPAND)
+        _add_setting_row(settings_grid, None, library_data_path_sizer, wx.EXPAND)
 
         layout = wx.BoxSizer(wx.VERTICAL)
-        layout.Add(settings_grid, 1, wx.ALL | wx.EXPAND, 5)
+        layout.Add(settings_grid, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(hooks_box_sizer, 0, wx.ALL | wx.EXPAND, 5)
 
         self.SetSizer(layout)

--- a/settings.py
+++ b/settings.py
@@ -11,6 +11,11 @@ from .dblib import LIBRARY_CONFIGS
 from .events import UpdateSetting
 from .helpers import HighResWxSize, loadBitmapScaled
 
+# Display strings for the LCSC priority dropdown; the stored setting stays a boolean.
+LCSC_PRIORITY_SCHEMATIC = "Schematic"
+LCSC_PRIORITY_DATABASE = "Database"
+LCSC_PRIORITY_CHOICES = [LCSC_PRIORITY_SCHEMATIC, LCSC_PRIORITY_DATABASE]
+
 
 class SettingsDialog(wx.Dialog):
     """Dialog for plugin settings."""
@@ -51,16 +56,14 @@ class SettingsDialog(wx.Dialog):
         self.tented_vias_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
-            label="Do not tent vias",
+            label="Tent vias",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=0,
             name="gerber_tented_vias",
         )
 
-        self.tented_vias_setting.SetToolTip(
-            wx.ToolTip("Whether vias should be coverd by soldermask or not")
-        )
+        self.tented_vias_setting.SetToolTip(wx.ToolTip("Cover vias with soldermask"))
 
         self.tented_vias_image = wx.StaticBitmap(
             self,
@@ -113,7 +116,7 @@ class SettingsDialog(wx.Dialog):
         self.force_drc_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
-            label="Force DRC check before Gerber export - Saves board and fills zones!",
+            label="Force DRC check before Gerber export (saves board and fills zones)",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=0,
@@ -148,7 +151,7 @@ class SettingsDialog(wx.Dialog):
         self.plot_values_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
-            label="Plot values",
+            label="Plot values on silkscreen",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=0,
@@ -179,7 +182,7 @@ class SettingsDialog(wx.Dialog):
         self.plot_references_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
-            label="Plot references",
+            label="Plot references on silkscreen",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=0,
@@ -187,7 +190,7 @@ class SettingsDialog(wx.Dialog):
         )
 
         self.plot_references_setting.SetToolTip(
-            wx.ToolTip("Whether value should be plotted on gerber generation")
+            wx.ToolTip("Whether references should be plotted on gerber generation")
         )
 
         self.plot_references_image = wx.StaticBitmap(
@@ -234,19 +237,28 @@ class SettingsDialog(wx.Dialog):
 
         ##### LCSC priority #####
 
-        self.lcsc_priority_setting = wx.CheckBox(
+        lcsc_priority_label = wx.StaticText(
             self,
             id=wx.ID_ANY,
-            label="LCSC number priority",
+            label="Prefer LCSC numbers from:",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
-            style=0,
+        )
+
+        self.lcsc_priority_setting = wx.ComboBox(
+            self,
+            id=wx.ID_ANY,
+            value="",
+            choices=LCSC_PRIORITY_CHOICES,
+            pos=wx.DefaultPosition,
+            size=wx.DefaultSize,
+            style=wx.CB_READONLY,
             name="general_lcsc_priority",
         )
 
         self.lcsc_priority_setting.SetToolTip(
             wx.ToolTip(
-                "Whether LCSC number from schematic should overrule those in the database"
+                "When a part has an LCSC number in both the schematic and the plugin database, which one is used"
             )
         )
 
@@ -259,18 +271,24 @@ class SettingsDialog(wx.Dialog):
             0,
         )
 
-        self.lcsc_priority_setting.Bind(wx.EVT_CHECKBOX, self.update_settings)
+        self.lcsc_priority_setting.Bind(wx.EVT_COMBOBOX, self.update_settings)
 
         lcsc_priority_sizer = wx.BoxSizer(wx.HORIZONTAL)
         lcsc_priority_sizer.Add(self.lcsc_priority_image, 10, wx.ALL | wx.EXPAND, 5)
-        lcsc_priority_sizer.Add(self.lcsc_priority_setting, 100, wx.ALL | wx.EXPAND, 5)
+        lcsc_priority_sizer.Add(
+            lcsc_priority_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
+        )
+        lcsc_priority_sizer.Add(
+            self.lcsc_priority_setting, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
+        )
+        lcsc_priority_sizer.AddStretchSpacer(100)
 
         ##### Only parts with LCSC number in BOM/CPL #####
 
         self.lcsc_bom_cpl_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
-            label="Add parts without LCSC numbers to BOM/CPL",
+            label="Add parts without LCSC number to BOM/CPL",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=0,
@@ -278,7 +296,7 @@ class SettingsDialog(wx.Dialog):
         )
 
         self.lcsc_bom_cpl_setting.SetToolTip(
-            wx.ToolTip("Whether parts wihout LCSC number should be added to BOM/CPL")
+            wx.ToolTip("Whether parts without LCSC number should be added to BOM/CPL")
         )
 
         self.lcsc_bom_cpl_image = wx.StaticBitmap(
@@ -301,7 +319,7 @@ class SettingsDialog(wx.Dialog):
         self.order_number_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
-            label="Check if an order/serial number placeholder is placed",
+            label="Check for an order/serial number placeholder on export",
             pos=wx.DefaultPosition,
             size=wx.DefaultSize,
             style=0,
@@ -329,14 +347,6 @@ class SettingsDialog(wx.Dialog):
 
         ##### Highlight text matches ######
 
-        highlight_matches_label = wx.StaticText(
-            self,
-            id=wx.ID_ANY,
-            label="Match highlighting",
-            pos=wx.DefaultPosition,
-            size=wx.DefaultSize,
-        )
-
         self.highlight_matches_setting = wx.CheckBox(
             self,
             id=wx.ID_ANY,
@@ -357,10 +367,7 @@ class SettingsDialog(wx.Dialog):
 
         highlight_matches_sizer = wx.BoxSizer(wx.HORIZONTAL)
         highlight_matches_sizer.Add(
-            highlight_matches_label, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5
-        )
-        highlight_matches_sizer.Add(
-            self.highlight_matches_setting, 0, wx.ALL | wx.EXPAND, 5
+            self.highlight_matches_setting, 100, wx.ALL | wx.EXPAND, 5
         )
 
         ##### Library Selection #####
@@ -657,37 +664,19 @@ class SettingsDialog(wx.Dialog):
 
     def update_tented_vias(self, tented):
         """Update settings dialog according to the settings."""
-        if tented:
-            self.tented_vias_setting.SetValue(tented)
-            self.tented_vias_setting.SetLabel("Tented vias")
-            self.tented_vias_image.SetBitmap(
-                loadBitmapScaled("tented.png", self.parent.scale_factor, static=True)
-            )
-        else:
-            self.tented_vias_setting.SetValue(tented)
-            self.tented_vias_setting.SetLabel("Untented vias")
-            self.tented_vias_image.SetBitmap(
-                loadBitmapScaled("untented.png", self.parent.scale_factor, static=True)
-            )
+        self.tented_vias_setting.SetValue(tented)
+        icon = "tented.png" if tented else "untented.png"
+        self.tented_vias_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def update_fill_zones(self, fill):
         """Update settings dialog according to the settings."""
-        if fill:
-            self.fill_zones_setting.SetValue(fill)
-            self.fill_zones_setting.SetLabel("Fill zones")
-            self.fill_zones_image.SetBitmap(
-                loadBitmapScaled(
-                    "fill-zones.png", self.parent.scale_factor, static=True
-                )
-            )
-        else:
-            self.fill_zones_setting.SetValue(fill)
-            self.fill_zones_setting.SetLabel("Don't fill zones")
-            self.fill_zones_image.SetBitmap(
-                loadBitmapScaled(
-                    "unfill-zones.png", self.parent.scale_factor, static=True
-                )
-            )
+        self.fill_zones_setting.SetValue(fill)
+        icon = "fill-zones.png" if fill else "unfill-zones.png"
+        self.fill_zones_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def build_force_drc_bitmap(self, enabled):
         """Build the Force DRC icon, overlaying a red X when disabled."""
@@ -718,135 +707,65 @@ class SettingsDialog(wx.Dialog):
 
     def update_plot_values(self, plot_values):
         """Update settings dialog according to the settings."""
-        if plot_values:
-            self.plot_values_setting.SetValue(plot_values)
-            self.plot_values_setting.SetLabel("Plot values on silkscreen")
-            self.plot_values_image.SetBitmap(
-                loadBitmapScaled(
-                    "plot_values.png", self.parent.scale_factor, static=True
-                )
-            )
-        else:
-            self.plot_values_setting.SetValue(plot_values)
-            self.plot_values_setting.SetLabel("Don't plot values on silkscreen")
-            self.plot_values_image.SetBitmap(
-                loadBitmapScaled("no_values.png", self.parent.scale_factor, static=True)
-            )
+        self.plot_values_setting.SetValue(plot_values)
+        icon = "plot_values.png" if plot_values else "no_values.png"
+        self.plot_values_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def update_force_drc(self, force_drc):
         """Update settings dialog according to the settings."""
         self.force_drc_setting.SetValue(bool(force_drc))
         self.force_drc_image.SetBitmap(self.build_force_drc_bitmap(bool(force_drc)))
         if force_drc:
-            self.force_drc_setting.SetLabel(
-                "Force DRC check before Gerber export - Saves board and fills zones!"
-            )
             self.update_fill_zones(True)
             self.fill_zones_setting.Disable()
         else:
-            self.force_drc_setting.SetLabel(
-                "Do not force DRC check before Gerber export"
-            )
             self.fill_zones_setting.Enable()
 
     def update_plot_references(self, plot_references):
         """Update settings dialog according to the settings."""
-        if plot_references:
-            self.plot_references_setting.SetValue(plot_references)
-            self.plot_references_setting.SetLabel("Plot references on silkscreen")
-            self.plot_references_image.SetBitmap(
-                loadBitmapScaled("plot_refs.png", self.parent.scale_factor, static=True)
-            )
-        else:
-            self.plot_references_setting.SetValue(plot_references)
-            self.plot_references_setting.SetLabel("Don't plot references on silkscreen")
-            self.plot_references_image.SetBitmap(
-                loadBitmapScaled("no_refs.png", self.parent.scale_factor, static=True)
-            )
+        self.plot_references_setting.SetValue(plot_references)
+        icon = "plot_refs.png" if plot_references else "no_refs.png"
+        self.plot_references_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def update_subtract_mask_from_silk(self, enabled):
-        """Update subtract-mask-from-silk setting label/value."""
+        """Update subtract-mask-from-silk setting value."""
         self.subtract_mask_from_silk_setting.SetValue(bool(enabled))
-        if enabled:
-            self.subtract_mask_from_silk_setting.SetLabel(
-                "Subtract soldermask from silkscreen"
-            )
-        else:
-            self.subtract_mask_from_silk_setting.SetLabel(
-                "Do not subtract soldermask from silkscreen"
-            )
 
     def update_lcsc_priority(self, priority):
         """Update settings dialog according to the settings."""
         if priority:
-            self.lcsc_priority_setting.SetValue(priority)
-            self.lcsc_priority_setting.SetLabel(
-                "LCSC numbers from schematic have priority"
-            )
-            self.lcsc_priority_image.SetBitmap(
-                loadBitmapScaled("schematic.png", self.parent.scale_factor, static=True)
-            )
+            self.lcsc_priority_setting.SetStringSelection(LCSC_PRIORITY_SCHEMATIC)
+            icon = "schematic.png"
         else:
-            self.lcsc_priority_setting.SetValue(priority)
-            self.lcsc_priority_setting.SetLabel(
-                "LCSC numbers from database have priority"
-            )
-            self.lcsc_priority_image.SetBitmap(
-                loadBitmapScaled(
-                    "database-outline.png", self.parent.scale_factor, static=True
-                )
-            )
+            self.lcsc_priority_setting.SetStringSelection(LCSC_PRIORITY_DATABASE)
+            icon = "database-outline.png"
+        self.lcsc_priority_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def update_lcsc_bom_cpl(self, add):
         """Update settings dialog according to the settings."""
-        if add:
-            self.lcsc_bom_cpl_setting.SetValue(add)
-            self.lcsc_bom_cpl_setting.SetLabel(
-                "Add parts without LCSC number to BOM/POS"
-            )
-            self.lcsc_bom_cpl_image.SetBitmap(
-                loadBitmapScaled("bom.png", self.parent.scale_factor, static=True)
-            )
-        else:
-            self.lcsc_bom_cpl_setting.SetValue(add)
-            self.lcsc_bom_cpl_setting.SetLabel(
-                "Don't add parts without LCSC number to BOM/POS"
-            )
-            self.lcsc_bom_cpl_image.SetBitmap(
-                loadBitmapScaled("no_bom.png", self.parent.scale_factor, static=True)
-            )
+        self.lcsc_bom_cpl_setting.SetValue(add)
+        icon = "bom.png" if add else "no_bom.png"
+        self.lcsc_bom_cpl_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def update_order_number(self, check):
         """Update settings dialog according to the settings."""
-        self.logger.debug(check)
-        if check:
-            self.order_number_setting.SetValue(check)
-            self.order_number_setting.SetLabel(
-                "Check if an order/serial number placeholder is placed"
-            )
-            self.order_number_image.SetBitmap(
-                loadBitmapScaled(
-                    "order_number.png", self.parent.scale_factor, static=True
-                )
-            )
-        else:
-            self.order_number_setting.SetValue(check)
-            self.order_number_setting.SetLabel(
-                "Don't check if an order/serial number placeholder is placed"
-            )
-            self.order_number_image.SetBitmap(
-                loadBitmapScaled(
-                    "no_order_number.png", self.parent.scale_factor, static=True
-                )
-            )
+        self.order_number_setting.SetValue(check)
+        icon = "order_number.png" if check else "no_order_number.png"
+        self.order_number_image.SetBitmap(
+            loadBitmapScaled(icon, self.parent.scale_factor, static=True)
+        )
 
     def update_highlight_matches(self, enabled):
         """Update settings dialog according to the settings."""
         self.highlight_matches_setting.SetValue(bool(enabled))
-        if enabled:
-            self.highlight_matches_setting.SetLabel("Highlight search matches")
-        else:
-            self.highlight_matches_setting.SetLabel("Do not highlight search matches")
 
     def update_matches(self, enabled):
         """Alias shared highlighting setting updates to the checkbox UI helper."""
@@ -855,10 +774,6 @@ class SettingsDialog(wx.Dialog):
     def update_bom_estimator_show(self, show):
         """Update settings dialog according to the BOM estimator visibility setting."""
         self.bom_estimator_show_setting.SetValue(bool(show))
-        if show:
-            self.bom_estimator_show_setting.SetLabel("Show BOM cost estimator")
-        else:
-            self.bom_estimator_show_setting.SetLabel("Hide BOM cost estimator")
 
     def show_bom_estimator_help(self, *_):
         """Show shared BOM estimator help text via the help_text helper."""
@@ -966,6 +881,11 @@ class SettingsDialog(wx.Dialog):
                     self.logger.debug("Selected library key: %s", key)
                     value = key
                     break
+
+        # Special handling for LCSC priority: the dropdown text maps onto the
+        # boolean that has always been stored (True = schematic wins).
+        if section == "general" and name == "lcsc_priority":
+            value = value == LCSC_PRIORITY_SCHEMATIC
 
         # If forced DRC is enabled, fill zones must stay enabled.
         if (

--- a/settings.py
+++ b/settings.py
@@ -17,17 +17,8 @@ LCSC_PRIORITY_DATABASE = "Database"
 LCSC_PRIORITY_CHOICES = [LCSC_PRIORITY_SCHEMATIC, LCSC_PRIORITY_DATABASE]
 
 
-def _add_setting_row(grid, image, control, flags=wx.ALIGN_CENTER_VERTICAL):
-    """Add an icon | control pair to the settings grid so the controls line up.
-
-    Every row gets an icon cell, empty when the setting has no icon, so the
-    checkboxes and captions share one left edge regardless of icon size.
-    """
-    if image is None:
-        grid.Add((0, 0))
-    else:
-        grid.Add(image, 0, wx.ALL | wx.ALIGN_CENTER, 5)
-    grid.Add(control, 0, wx.ALL | flags, 5)
+# Side of the square icon cell in every settings row (largest icon is 48 px).
+ICON_CELL_SIZE = 48
 
 
 class SettingsDialog(wx.Dialog):
@@ -599,39 +590,46 @@ class SettingsDialog(wx.Dialog):
         # ---------------------- Main Layout Sizer ----------------------------
         # ---------------------------------------------------------------------
 
-        # Two settings columns, each an icon cell plus a control cell, so the
-        # checkboxes line up whatever the icon size (or absence of an icon).
+        # Two settings columns, each a fixed-size icon cell plus a control cell,
+        # so the controls line up and every row has the same height whatever
+        # the icon size (or absence of an icon).
         settings_grid = wx.FlexGridSizer(0, 4, 0, 0)
         settings_grid.AddGrowableCol(1, 1)
         settings_grid.AddGrowableCol(3, 1)
-        _add_setting_row(
+        self._add_setting_row(
             settings_grid, self.tented_vias_image, self.tented_vias_setting
         )
-        _add_setting_row(settings_grid, self.fill_zones_image, self.fill_zones_setting)
-        _add_setting_row(settings_grid, self.force_drc_image, self.force_drc_setting)
-        _add_setting_row(
+        self._add_setting_row(
+            settings_grid, self.fill_zones_image, self.fill_zones_setting
+        )
+        self._add_setting_row(
+            settings_grid, self.force_drc_image, self.force_drc_setting
+        )
+        self._add_setting_row(
             settings_grid, self.plot_values_image, self.plot_values_setting
         )
-        _add_setting_row(
+        self._add_setting_row(
             settings_grid, self.plot_references_image, self.plot_references_setting
         )
-        _add_setting_row(settings_grid, None, self.subtract_mask_from_silk_setting)
-        _add_setting_row(settings_grid, self.lcsc_priority_image, lcsc_priority_sizer)
-        _add_setting_row(
+        self._add_setting_row(settings_grid, None, self.subtract_mask_from_silk_setting)
+        self._add_setting_row(
+            settings_grid, self.lcsc_priority_image, lcsc_priority_sizer
+        )
+        self._add_setting_row(
             settings_grid, self.lcsc_bom_cpl_image, self.lcsc_bom_cpl_setting
         )
-        _add_setting_row(
+        self._add_setting_row(
             settings_grid, self.order_number_image, self.order_number_setting
         )
-        _add_setting_row(settings_grid, None, self.highlight_matches_setting)
-        _add_setting_row(
+        self._add_setting_row(settings_grid, None, self.highlight_matches_setting)
+        self._add_setting_row(
             settings_grid,
             self.bom_estimator_show_image,
             bom_estimator_show_sizer,
             wx.EXPAND,
         )
-        _add_setting_row(settings_grid, None, library_sizer, wx.EXPAND)
-        _add_setting_row(settings_grid, None, library_data_path_sizer, wx.EXPAND)
+        self._add_setting_row(settings_grid, None, library_sizer, wx.EXPAND)
+        self._add_setting_row(settings_grid, None, library_data_path_sizer, wx.EXPAND)
 
         layout = wx.BoxSizer(wx.VERTICAL)
         layout.Add(settings_grid, 0, wx.ALL | wx.EXPAND, 5)
@@ -642,6 +640,23 @@ class SettingsDialog(wx.Dialog):
         self.Centre(wx.BOTH)
 
         self.load_settings()
+
+    def _add_setting_row(self, grid, image, control, flags=wx.ALIGN_CENTER_VERTICAL):
+        """Add an icon | control pair to the settings grid.
+
+        The icon sits centred in a square cell of fixed size (empty when the
+        setting has no icon), so controls share one left edge and rows share
+        one pitch regardless of icon size.
+        """
+        side = int(round(ICON_CELL_SIZE * self.parent.scale_factor))
+        icon_cell = wx.BoxSizer(wx.HORIZONTAL)
+        icon_cell.SetMinSize(side, side)
+        if image is not None:
+            icon_cell.AddStretchSpacer()
+            icon_cell.Add(image, 0, wx.ALIGN_CENTER_VERTICAL)
+            icon_cell.AddStretchSpacer()
+        grid.Add(icon_cell, 0, wx.ALL, 5)
+        grid.Add(control, 0, wx.ALL | flags, 5)
 
     def update_tented_vias(self, tented):
         """Update settings dialog according to the settings."""

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,8 +1,8 @@
 """Regression tests for the settings dialog's static labels and LCSC dropdown.
 
 ``settings.py`` normally runs inside KiCad and imports wxPython at module load
-time.  These tests load it under a private synthetic package with a small fake
-``wx`` module whose controls record labels, values and selections, so the
+time.  The shared harness loads it under a private synthetic package with a
+fake ``wx`` whose controls record labels, values and selections, so the
 dialog's real construction and change-handling code runs without a GUI.
 
 Covers https://github.com/Bouni/kicad-jlcpcb-tools/issues/778: checkbox labels
@@ -10,53 +10,52 @@ must describe the behaviour when checked and never change with the state, and
 the LCSC priority setting is a two-way choice rather than an on/off switch.
 """
 
-from contextlib import contextmanager
-import importlib.util
-from itertools import count
-from pathlib import Path
-import sys
 import types
 
 import pytest
 
-_ROOT = Path(__file__).parent.parent
-_PACKAGE = "pr778_settings_dialog_tests"
-_MISSING = object()
+from .wx_harness import load, module, package_stubs, wx_stubs
 
-
-def _module(name, **symbols):
-    """Create a module containing the explicitly supplied symbols."""
-    module = types.ModuleType(name)
-    module.__dict__.update(symbols)
-    return module
-
-
-@contextmanager
-def _temporary_modules(replacements):
-    """Install import stubs temporarily and restore prior modules afterward."""
-    previous = {name: sys.modules.get(name, _MISSING) for name in replacements}
-    sys.modules.update(replacements)
-    try:
-        yield
-    finally:
-        for name, module in previous.items():
-            if module is _MISSING:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = module
+_PACKAGE = "settings_dialog_tests"
 
 
 class _FakeWidget:
-    """Permissive stand-in for wx objects whose state the tests never inspect."""
+    """Stand-in for the wx objects whose state these tests never inspect."""
 
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
 
     def __getattr__(self, name):
+        """Answer wx-style method calls with a no-op, and nothing else."""
         if name[:1].isupper():
             return lambda *_args, **_kwargs: None
         raise AttributeError(name)
+
+
+# Everything settings.py builds that these tests do not look at.  Naming them
+# keeps the fake wx strict: a name that is not here and not a control below
+# raises AttributeError rather than quietly becoming callable.
+_INERT = (
+    "AcceleratorEntry",
+    "AcceleratorTable",
+    "BoxSizer",
+    "Button",
+    "Colour",
+    "DefaultPosition",
+    "DefaultSize",
+    "DirPickerCtrl",
+    "FilePickerCtrl",
+    "FlexGridSizer",
+    "MemoryDC",
+    "NewId",
+    "NullBitmap",
+    "Pen",
+    "Size",
+    "SpinCtrl",
+    "StaticBoxSizer",
+    "ToolTip",
+)
 
 
 class _FakeBitmap:
@@ -165,73 +164,44 @@ class _Dialog(_FakeWidget):
     """wx.Dialog stand-in whose window methods are all no-ops."""
 
 
-def _make_wx():
-    """Build the fake wx module used to load settings.py."""
-    wx = _module(
-        "wx",
-        Dialog=_Dialog,
-        CheckBox=_CheckBox,
-        ComboBox=_ComboBox,
-        StaticText=_StaticText,
-        StaticBitmap=_StaticBitmap,
-        EVT_CHECKBOX="EVT_CHECKBOX",
-        EVT_COMBOBOX="EVT_COMBOBOX",
-        posted_events=[],
-    )
-    wx.PostEvent = lambda target, event: wx.posted_events.append((target, event))
-
-    constants = {}
-    bits = count(1)
-
-    def _missing(name):
-        # UPPER_CASE names are flags and ids; anything else is a widget class.
-        if name.isupper():
-            return constants.setdefault(name, 1 << next(bits))
-        return _FakeWidget
-
-    wx.__getattr__ = _missing
-    return wx
-
-
 def _load_settings_module():
     """Load settings.py with deterministic stubs for its GUI dependencies."""
-    package = _module(_PACKAGE)
-    package.__path__ = [str(_ROOT)]
-    bom_estimation_package = _module(f"{_PACKAGE}.bom_estimation")
-    bom_estimation_package.__path__ = []
     library_config = types.SimpleNamespace(display_name="Full Library - All Parts")
-
-    replacements = {
-        "wx": _make_wx(),
-        _PACKAGE: package,
-        f"{_PACKAGE}.bom_estimation": bom_estimation_package,
-        f"{_PACKAGE}.bom_estimation.help_text": _module(
-            f"{_PACKAGE}.bom_estimation.help_text",
-            show_bom_estimator_help=lambda *_args, **_kwargs: None,
-        ),
-        f"{_PACKAGE}.dblib": _module(
-            f"{_PACKAGE}.dblib", LIBRARY_CONFIGS={"current-parts": library_config}
-        ),
-        f"{_PACKAGE}.events": _module(
-            f"{_PACKAGE}.events",
-            UpdateSetting=types.SimpleNamespace,
-        ),
-        f"{_PACKAGE}.helpers": _module(
-            f"{_PACKAGE}.helpers",
-            HighResWxSize=lambda _window, size: size,
-            loadBitmapScaled=lambda filename, *_args, **_kwargs: _FakeBitmap(filename),
-        ),
-    }
-
-    module_name = f"{_PACKAGE}.settings"
-    spec = importlib.util.spec_from_file_location(module_name, _ROOT / "settings.py")
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    module.__package__ = _PACKAGE
-    replacements[module_name] = module
-    with _temporary_modules(replacements):
-        spec.loader.exec_module(module)
-    return module
+    stubs = package_stubs(_PACKAGE, ("bom_estimation",))
+    stubs.update(
+        wx_stubs(
+            submodules=(),
+            Dialog=_Dialog,
+            CheckBox=_CheckBox,
+            ComboBox=_ComboBox,
+            StaticText=_StaticText,
+            StaticBitmap=_StaticBitmap,
+            posted_events=[],
+            **dict.fromkeys(_INERT, _FakeWidget),
+        )
+    )
+    wx = stubs["wx"]
+    wx.PostEvent = lambda target, event: wx.posted_events.append((target, event))
+    stubs.update(
+        {
+            f"{_PACKAGE}.bom_estimation.help_text": module(
+                f"{_PACKAGE}.bom_estimation.help_text",
+                show_bom_estimator_help=lambda *_args, **_kwargs: None,
+            ),
+            f"{_PACKAGE}.dblib": module(
+                f"{_PACKAGE}.dblib", LIBRARY_CONFIGS={"current-parts": library_config}
+            ),
+            f"{_PACKAGE}.events": module(
+                f"{_PACKAGE}.events", UpdateSetting=types.SimpleNamespace
+            ),
+            f"{_PACKAGE}.helpers": module(
+                f"{_PACKAGE}.helpers",
+                HighResWxSize=lambda _window, size: size,
+                loadBitmapScaled=lambda filename, *_a, **_k: _FakeBitmap(filename),
+            ),
+        }
+    )
+    return load(_PACKAGE, "settings", stubs)
 
 
 settings = _load_settings_module()

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,0 +1,410 @@
+"""Regression tests for the settings dialog's static labels and LCSC dropdown.
+
+``settings.py`` normally runs inside KiCad and imports wxPython at module load
+time.  These tests load it under a private synthetic package with a small fake
+``wx`` module whose controls record labels, values and selections, so the
+dialog's real construction and change-handling code runs without a GUI.
+
+Covers https://github.com/Bouni/kicad-jlcpcb-tools/issues/778: checkbox labels
+must describe the behaviour when checked and never change with the state, and
+the LCSC priority setting is a two-way choice rather than an on/off switch.
+"""
+
+from contextlib import contextmanager
+import importlib.util
+from itertools import count
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_PACKAGE = "pr778_settings_dialog_tests"
+_MISSING = object()
+
+
+def _module(name, **symbols):
+    """Create a module containing the explicitly supplied symbols."""
+    module = types.ModuleType(name)
+    module.__dict__.update(symbols)
+    return module
+
+
+@contextmanager
+def _temporary_modules(replacements):
+    """Install import stubs temporarily and restore prior modules afterward."""
+    previous = {name: sys.modules.get(name, _MISSING) for name in replacements}
+    sys.modules.update(replacements)
+    try:
+        yield
+    finally:
+        for name, module in previous.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+class _FakeWidget:
+    """Permissive stand-in for wx objects whose state the tests never inspect."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __getattr__(self, name):
+        if name[:1].isupper():
+            return lambda *_args, **_kwargs: None
+        raise AttributeError(name)
+
+
+class _FakeBitmap:
+    """Bitmap stand-in that remembers which icon file it was loaded from."""
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def ConvertToImage(self):
+        return self
+
+    def ConvertToBitmap(self):
+        return _FakeBitmap(self.filename)
+
+    def GetSize(self):
+        return (24, 24)
+
+
+class _Control:
+    """Strict base for controls whose state the tests inspect."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.name = kwargs.get("name", "")
+        self.tooltip = None
+        self.handler = None
+
+    def GetName(self):
+        return self.name
+
+    def SetToolTip(self, tooltip):
+        self.tooltip = tooltip
+
+    def Bind(self, _event_type, handler):
+        self.handler = handler
+
+
+class _CheckBox(_Control):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.label = kwargs.get("label", "")
+        self.value = False
+        self.enabled = True
+
+    def SetLabel(self, label):
+        self.label = label
+
+    def GetLabel(self):
+        return self.label
+
+    def SetValue(self, value):
+        self.value = bool(value)
+
+    def GetValue(self):
+        return self.value
+
+    def Enable(self, enable=True):
+        self.enabled = bool(enable)
+
+    def Disable(self):
+        self.enabled = False
+
+    def IsEnabled(self):
+        return self.enabled
+
+
+class _ComboBox(_Control):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.choices = list(kwargs.get("choices", []))
+        self.value = kwargs.get("value", "")
+
+    def SetStringSelection(self, text):
+        if text not in self.choices:
+            return False
+        self.value = text
+        return True
+
+    def GetStringSelection(self):
+        return self.value
+
+    def GetValue(self):
+        return self.value
+
+
+class _StaticText(_Control):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.label = kwargs.get("label", "")
+
+    def GetLabel(self):
+        return self.label
+
+
+class _StaticBitmap(_Control):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bitmap = args[2] if len(args) > 2 else kwargs.get("bitmap")
+
+    def SetBitmap(self, bitmap):
+        self.bitmap = bitmap
+
+
+class _Dialog(_FakeWidget):
+    """wx.Dialog stand-in whose window methods are all no-ops."""
+
+
+def _make_wx():
+    """Build the fake wx module used to load settings.py."""
+    wx = _module(
+        "wx",
+        Dialog=_Dialog,
+        CheckBox=_CheckBox,
+        ComboBox=_ComboBox,
+        StaticText=_StaticText,
+        StaticBitmap=_StaticBitmap,
+        EVT_CHECKBOX="EVT_CHECKBOX",
+        EVT_COMBOBOX="EVT_COMBOBOX",
+        posted_events=[],
+    )
+    wx.PostEvent = lambda target, event: wx.posted_events.append((target, event))
+
+    constants = {}
+    bits = count(1)
+
+    def _missing(name):
+        # UPPER_CASE names are flags and ids; anything else is a widget class.
+        if name.isupper():
+            return constants.setdefault(name, 1 << next(bits))
+        return _FakeWidget
+
+    wx.__getattr__ = _missing
+    return wx
+
+
+def _load_settings_module():
+    """Load settings.py with deterministic stubs for its GUI dependencies."""
+    package = _module(_PACKAGE)
+    package.__path__ = [str(_ROOT)]
+    bom_estimation_package = _module(f"{_PACKAGE}.bom_estimation")
+    bom_estimation_package.__path__ = []
+    library_config = types.SimpleNamespace(display_name="Full Library - All Parts")
+
+    replacements = {
+        "wx": _make_wx(),
+        _PACKAGE: package,
+        f"{_PACKAGE}.bom_estimation": bom_estimation_package,
+        f"{_PACKAGE}.bom_estimation.help_text": _module(
+            f"{_PACKAGE}.bom_estimation.help_text",
+            show_bom_estimator_help=lambda *_args, **_kwargs: None,
+        ),
+        f"{_PACKAGE}.dblib": _module(
+            f"{_PACKAGE}.dblib", LIBRARY_CONFIGS={"current-parts": library_config}
+        ),
+        f"{_PACKAGE}.events": _module(
+            f"{_PACKAGE}.events",
+            UpdateSetting=types.SimpleNamespace,
+        ),
+        f"{_PACKAGE}.helpers": _module(
+            f"{_PACKAGE}.helpers",
+            HighResWxSize=lambda _window, size: size,
+            loadBitmapScaled=lambda filename, *_args, **_kwargs: _FakeBitmap(filename),
+        ),
+    }
+
+    module_name = f"{_PACKAGE}.settings"
+    spec = importlib.util.spec_from_file_location(module_name, _ROOT / "settings.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = _PACKAGE
+    replacements[module_name] = module
+    with _temporary_modules(replacements):
+        spec.loader.exec_module(module)
+    return module
+
+
+settings = _load_settings_module()
+SettingsDialog = settings.SettingsDialog
+_wx = settings.wx
+
+# Checkbox attribute on the dialog -> (settings section, settings key).
+_BOOLEAN_SETTINGS = {
+    "tented_vias_setting": ("gerber", "tented_vias"),
+    "fill_zones_setting": ("gerber", "fill_zones"),
+    "force_drc_setting": ("gerber", "force_drc"),
+    "plot_values_setting": ("gerber", "plot_values"),
+    "plot_references_setting": ("gerber", "plot_references"),
+    "subtract_mask_from_silk_setting": ("gerber", "subtract_mask_from_silk"),
+    "lcsc_bom_cpl_setting": ("gerber", "lcsc_bom_cpl"),
+    "order_number_setting": ("general", "order_number"),
+    "highlight_matches_setting": ("highlighting", "matches"),
+    "bom_estimator_show_setting": ("general", "bom_estimator_show"),
+}
+
+# Every label describes what happens when the box is checked.
+_EXPECTED_LABELS = {
+    "tented_vias_setting": "Tent vias",
+    "fill_zones_setting": "Fill zones",
+    "force_drc_setting": (
+        "Force DRC check before Gerber export (saves board and fills zones)"
+    ),
+    "plot_values_setting": "Plot values on silkscreen",
+    "plot_references_setting": "Plot references on silkscreen",
+    "subtract_mask_from_silk_setting": "Subtract soldermask from silkscreen",
+    "lcsc_bom_cpl_setting": "Add parts without LCSC number to BOM/CPL",
+    "order_number_setting": ("Check for an order/serial number placeholder on export"),
+    "highlight_matches_setting": "Highlight search matches",
+    "bom_estimator_show_setting": "Show BOM cost estimator",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_posted_events():
+    """Start every test with an empty record of posted UpdateSetting events."""
+    del _wx.posted_events[:]
+
+
+def _settings(flag):
+    """Return a settings dict with every boolean checkbox setting set to ``flag``."""
+    settings_dict = {
+        "gerber": {},
+        "general": {"lcsc_priority": True},
+        "highlighting": {},
+        "library": {"selected_library": "current-parts", "data_path": ""},
+        "hooks": {"pre_script": "", "post_script": "", "timeout_seconds": 30},
+    }
+    for section, key in _BOOLEAN_SETTINGS.values():
+        settings_dict[section][key] = flag
+    return settings_dict
+
+
+def _dialog(settings_dict):
+    """Construct the dialog against a fake main window holding ``settings_dict``."""
+    parent = types.SimpleNamespace(
+        window=object(),
+        scale_factor=1.0,
+        settings=settings_dict,
+        library=types.SimpleNamespace(datadir="/data"),
+    )
+    return SettingsDialog(parent)
+
+
+def _fire(control):
+    """Invoke the change handler bound to ``control``; return the posted events."""
+    before = len(_wx.posted_events)
+    control.handler(types.SimpleNamespace(GetEventObject=lambda: control))
+    return [event for _target, event in _wx.posted_events[before:]]
+
+
+@pytest.mark.parametrize("attribute", sorted(_EXPECTED_LABELS))
+def test_checkbox_label_is_static_and_describes_checked_behaviour(attribute):
+    """A label must read the same whether the setting is on or off."""
+    expected = _EXPECTED_LABELS[attribute]
+
+    labels = {
+        flag: getattr(_dialog(_settings(flag)), attribute).GetLabel()
+        for flag in (True, False)
+    }
+
+    assert labels == {True: expected, False: expected}
+
+
+def test_unchecking_a_box_keeps_its_label_and_posts_the_new_value():
+    """Toggling changes the value and the persisted setting, never the text."""
+    dialog = _dialog(_settings(True))
+    checkbox = dialog.tented_vias_setting
+
+    checkbox.SetValue(False)
+    events = _fire(checkbox)
+
+    assert (checkbox.GetLabel(), checkbox.GetValue()) == ("Tent vias", False)
+    assert [(e.section, e.setting, e.value) for e in events] == [
+        ("gerber", "tented_vias", False)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("flag", "icon"), [(True, "tented.png"), (False, "untented.png")]
+)
+def test_tented_vias_icon_follows_state(flag, icon):
+    """The icon keeps illustrating the effect of the current setting."""
+    dialog = _dialog(_settings(flag))
+
+    assert dialog.tented_vias_image.bitmap.filename == icon
+
+
+@pytest.mark.parametrize(
+    ("priority", "choice", "icon"),
+    [(True, "Schematic", "schematic.png"), (False, "Database", "database-outline.png")],
+)
+def test_lcsc_priority_dropdown_reflects_setting(priority, choice, icon):
+    """The stored boolean maps onto a Schematic/Database choice and icon."""
+    settings_dict = _settings(True)
+    settings_dict["general"]["lcsc_priority"] = priority
+
+    dialog = _dialog(settings_dict)
+    control = dialog.lcsc_priority_setting
+
+    assert isinstance(control, _wx.ComboBox)
+    assert (control.choices, control.GetStringSelection()) == (
+        ["Schematic", "Database"],
+        choice,
+    )
+    assert dialog.lcsc_priority_image.bitmap.filename == icon
+
+
+@pytest.mark.parametrize(
+    ("choice", "expected", "icon"),
+    [("Database", False, "database-outline.png"), ("Schematic", True, "schematic.png")],
+)
+def test_selecting_lcsc_priority_posts_a_boolean(choice, expected, icon):
+    """Choosing an entry persists the existing boolean setting, not the text."""
+    dialog = _dialog(_settings(True))
+    control = dialog.lcsc_priority_setting
+    assert isinstance(control, _wx.ComboBox)
+
+    control.SetStringSelection(choice)
+    events = _fire(control)
+
+    assert [(e.section, e.setting) for e in events] == [("general", "lcsc_priority")]
+    assert events[0].value is expected
+    assert dialog.lcsc_priority_image.bitmap.filename == icon
+
+
+def test_force_drc_forces_and_disables_fill_zones():
+    """Forcing DRC pins fill zones on; releasing it re-enables the checkbox."""
+    settings_dict = _settings(True)
+    settings_dict["gerber"]["fill_zones"] = False
+    dialog = _dialog(settings_dict)
+    fill_zones = dialog.fill_zones_setting
+
+    assert (fill_zones.GetValue(), fill_zones.IsEnabled()) == (True, False)
+
+    dialog.force_drc_setting.SetValue(False)
+    _fire(dialog.force_drc_setting)
+
+    assert fill_zones.IsEnabled()
+
+
+def test_enabling_force_drc_also_persists_fill_zones():
+    """Turning forced DRC on posts fill_zones=True before force_drc=True."""
+    dialog = _dialog(_settings(False))
+
+    dialog.force_drc_setting.SetValue(True)
+    events = _fire(dialog.force_drc_setting)
+
+    assert [(e.section, e.setting, e.value) for e in events] == [
+        ("gerber", "fill_zones", True),
+        ("gerber", "force_drc", True),
+    ]

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -263,7 +263,7 @@ _EXPECTED_LABELS = {
     "plot_references_setting": "Plot references on silkscreen",
     "subtract_mask_from_silk_setting": "Subtract soldermask from silkscreen",
     "lcsc_bom_cpl_setting": "Add parts without LCSC number to BOM/CPL",
-    "order_number_setting": ("Check for an order/serial number placeholder on export"),
+    "order_number_setting": "Check for an order/serial number placeholder on export",
     "highlight_matches_setting": "Highlight search matches",
     "bom_estimator_show_setting": "Show BOM cost estimator",
 }


### PR DESCRIPTION
Every checkbox in the settings dialog rewrote its own label when toggled
("Tented vias" / "Untented vias", "Force DRC check ..." / "Do not force DRC check ..."),
so an unchecked box read as a statement of the current behaviour and users could not
tell whether the text described the state or the effect of clicking it.

- Labels are now static and describe the behaviour when checked; the icons keep following the state.
- "LCSC number priority" is a two-way choice, not an on/off, so it becomes a read-only dropdown:
   "Prefer LCSC numbers from: Schematic / Database". The stored setting stays the existing
    general.lcsc_priority boolean, so existing settings.json files load unchanged.
- Fix tooltip typos, correct the plot-references tooltip, and drop the redundant "Match highlighting" caption.
- Add tests/test_settings_dialog.py, which loads the dialog against a fake wx module so it runs in CI without wxPython.
- Added a helper when adding the settings to the dialog for alignment - now the settings that don't have icons (or have icons of different sizes) all have consistent sizes or a placeholder blank space so the checkboxes line up.  This also fixes an annoying issue where the icon would move around the first time you toggled a setting.

Lots of unit tests added, along with the mock/fake so it can run under the CI tests.
The main settings file has quite a few changes, but mostly deletions in the update_whatever functions
since it no longer has to remember two text labels to swap around.


Fixes #778