### PR TITLE
test: extract a shared wx/pcbnew harness for GUI-module tests

### DIFF
--- a/tests/test_mainwindow_empty_zone_warning.py
+++ b/tests/test_mainwindow_empty_zone_warning.py
@@ -1,232 +1,31 @@
 """Tests for empty-zone warnings during fabrication-data generation."""
 
-import importlib.util
-import logging
-from pathlib import Path
-import sys
-import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
-_ROOT = Path(__file__).parent.parent
+from .wx_harness import load_mainwindow, wx_stubs
 
-
-class _WxModule(types.ModuleType):
-    """Minimal wx module whose unused attributes resolve to harmless constants."""
-
-    def __getattr__(self, name):
-        """Return a harmless constant for an unused wx attribute."""
-        value = 0
-        setattr(self, name, value)
-        return value
-
-
-class _Dialog:
-    """Stand-in base class used while importing the main window."""
-
-
-def _stub_module(monkeypatch, name, **attributes):
-    """Install a module stub with the requested attributes."""
-    module = types.ModuleType(name)
-    for attribute, value in attributes.items():
-        setattr(module, attribute, value)
-    monkeypatch.setitem(sys.modules, name, module)
-    return module
-
-
-def _load_mainwindow(monkeypatch):
-    """Load mainwindow.py under an isolated package with wx dependencies stubbed."""
-    wx = _WxModule("wx")
-    wx.__path__ = []
-    wx.Dialog = _Dialog
-    wx.NewIdRef = MagicMock(side_effect=object)
-    wx.ID_YES = 1
-    wx.ID_NO = 2
-    wx.ID_CANCEL = 3
-    wx.CANCEL = wx.ID_CANCEL
-    wx.OK = 4
-    wx.YES_NO = 8
-    wx.NO_DEFAULT = 16
-    wx.ICON_WARNING = 32
-    wx.ICON_ERROR = 64
-    wx.CENTER = 128
-    wx.BeginBusyCursor = MagicMock()
-    wx.EndBusyCursor = MagicMock()
-    wx.IsBusy = MagicMock(return_value=True)
-    wx.MessageBox = MagicMock()
-    wx.MessageDialog = MagicMock()
-    monkeypatch.setitem(sys.modules, "wx", wx)
-
-    dataview = _WxModule("wx.dataview")
-    adv = _WxModule("wx.adv")
-    wx.dataview = dataview
-    wx.adv = adv
-    monkeypatch.setitem(sys.modules, "wx.dataview", dataview)
-    monkeypatch.setitem(sys.modules, "wx.adv", adv)
-    monkeypatch.setitem(sys.modules, "pcbnew", MagicMock())
-
-    package_name = f"mainwindow_test_{uuid4().hex}"
-    package = types.ModuleType(package_name)
-    package.__path__ = [str(_ROOT)]
-    monkeypatch.setitem(sys.modules, package_name, package)
-
-    bom_estimation = _stub_module(monkeypatch, f"{package_name}.bom_estimation")
-    bom_estimation.__path__ = []
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.bom_estimation.assembly_mode",
-        classify_component_product_type=MagicMock(),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.bom_estimation.help_text",
-        show_bom_estimator_help=MagicMock(),
-    )
-    enrichment = _stub_module(monkeypatch, f"{package_name}.enrichment")
-    enrichment.__path__ = []
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.enrichment.providers",
-        LCSCAssemblyMetadataProvider=type("LCSCAssemblyMetadataProvider", (), {}),
-    )
-
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.bom_widget",
-        BomEstimatorController=type("BomEstimatorController", (), {}),
-        BomEstimatorWidget=type("BomEstimatorWidget", (), {}),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.corrections",
-        CorrectionManagerDialog=type("CorrectionManagerDialog", (), {}),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.datamodel",
-        PartListDataModel=type("PartListDataModel", (), {"columns": {}}),
-        STANDARD_ONLY_TOOLTIP="",
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.dataview_highlight",
-        HighlightedTextRenderer=type("HighlightedTextRenderer", (), {}),
-        decode_highlighted_value=MagicMock(),
-        simplify_footprint_name=MagicMock(),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.derive_params",
-        params_for_part=MagicMock(),
-    )
-
-    events = {
-        name: object()
-        for name in (
-            "EVT_ASSEMBLY_ENRICHMENT_COMPLETED_EVENT",
-            "EVT_ASSEMBLY_ENRICHMENT_PROGRESS_EVENT",
-            "EVT_ASSIGN_PARTS_EVENT",
-            "EVT_BOM_DATA_CHANGED_EVENT",
-            "EVT_DOWNLOAD_COMPLETED_EVENT",
-            "EVT_DOWNLOAD_PROGRESS_EVENT",
-            "EVT_DOWNLOAD_STARTED_EVENT",
-            "EVT_LOGBOX_APPEND_EVENT",
-            "EVT_MESSAGE_EVENT",
-            "EVT_POPULATE_FOOTPRINT_LIST_EVENT",
-            "EVT_UNZIP_COMBINING_PROGRESS_EVENT",
-            "EVT_UNZIP_COMBINING_STARTED_EVENT",
-            "EVT_UNZIP_EXTRACTING_COMPLETED_EVENT",
-            "EVT_UNZIP_EXTRACTING_PROGRESS_EVENT",
-            "EVT_UNZIP_EXTRACTING_STARTED_EVENT",
-            "EVT_UPDATE_SETTING",
-            "AssemblyEnrichmentCompletedEvent",
-            "AssemblyEnrichmentProgressEvent",
-            "BomDataChangedEvent",
-            "LogboxAppendEvent",
-        )
-    }
-    _stub_module(monkeypatch, f"{package_name}.events", **events)
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.fabrication",
-        Fabrication=type("Fabrication", (), {}),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.footprint_helpers",
-        get_is_dnp=MagicMock(),
-        set_lcsc_value=MagicMock(),
-        toggle_exclude_from_bom=MagicMock(),
-        toggle_exclude_from_pos=MagicMock(),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.generate_hooks",
-        format_hook_error=MagicMock(),
-        run_configured_hook=MagicMock(),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.helpers",
-        PLUGIN_PATH=str(_ROOT),
-        GetScaleFactor=MagicMock(),
-        HighResWxSize=MagicMock(),
-        getVersion=MagicMock(return_value="test"),
-        loadBitmapScaled=MagicMock(),
-    )
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.kicad_drc",
-        DRCViolationCounter=type("DRCViolationCounter", (), {}),
-    )
-
-    class _LibraryState:
-        INITIALIZED = object()
-
-    _stub_module(
-        monkeypatch,
-        f"{package_name}.library",
-        Library=type("Library", (), {}),
-        LibraryState=_LibraryState,
-    )
-    for module_name, class_name in (
-        ("partdetails", "PartDetailsDialog"),
-        ("partmapper", "PartMapperManagerDialog"),
-        ("partselector", "PartSelectorDialog"),
-        ("schematicexport", "SchematicExport"),
-        ("settings", "SettingsDialog"),
-        ("store", "Store"),
-        ("why_standard_dialog", "WhyStandardDialog"),
-    ):
-        _stub_module(
-            monkeypatch,
-            f"{package_name}.{module_name}",
-            **{class_name: type(class_name, (), {})},
-        )
-
-    module_name = f"{package_name}.mainwindow"
-    spec = importlib.util.spec_from_file_location(module_name, _ROOT / "mainwindow.py")
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, module_name, module)
-    spec.loader.exec_module(module)
-    return module, wx
+_PACKAGE = "mainwindow_empty_zone_tests"
 
 
 @pytest.fixture
-def mainwindow_module(monkeypatch):
+def mainwindow_module():
     """Provide an isolated mainwindow module and its wx stub."""
-    requests_logger = logging.getLogger("requests")
-    urllib3_logger = logging.getLogger("urllib3")
-    previous_levels = (requests_logger.level, urllib3_logger.level)
-    try:
-        yield _load_mainwindow(monkeypatch)
-    finally:
-        requests_logger.setLevel(previous_levels[0])
-        urllib3_logger.setLevel(previous_levels[1])
+    module = load_mainwindow(
+        _PACKAGE,
+        wx=wx_stubs(
+            Dialog=type("Dialog", (), {}),
+            NewIdRef=MagicMock(side_effect=object),
+            BeginBusyCursor=MagicMock(),
+            EndBusyCursor=MagicMock(),
+            IsBusy=MagicMock(return_value=True),
+            MessageBox=MagicMock(),
+            MessageDialog=MagicMock(),
+        ),
+    )
+    return module, module.wx
 
 
 def _make_window(empty_pours, fill_zones=None):

--- a/tests/test_mainwindow_stale_footprints.py
+++ b/tests/test_mainwindow_stale_footprints.py
@@ -1,223 +1,29 @@
 """Regression tests for main-window actions targeting deleted footprints.
 
 ``mainwindow.py`` normally runs inside KiCad and imports wxPython/pcbnew at
-module load time.  These tests load it under a private synthetic package and
-provide only the dependency surface needed by the handlers under test.  The
-handlers themselves are invoked directly against small capturing fakes, so the
-tests exercise production control flow without requiring a GUI event loop.
+module load time.  The shared harness loads it under a private synthetic
+package instead.  The handlers themselves are invoked directly against small
+capturing fakes, so the tests exercise production control flow without
+requiring a GUI event loop.
 """
 
-from contextlib import contextmanager
-import importlib.util
 from itertools import count
-import logging
-from pathlib import Path
-import sys
 import types
 from unittest.mock import MagicMock, call
 
 import pytest
 
-_ROOT = Path(__file__).parent.parent
-_PACKAGE = "pr782_stale_footprint_tests"
-_MISSING = object()
+from .wx_harness import load_mainwindow, wx_stubs
 
-
-def _module(name, **symbols):
-    """Create a module containing the explicitly supplied symbols."""
-    module = types.ModuleType(name)
-    module.__dict__.update(symbols)
-    return module
-
-
-@contextmanager
-def _temporary_modules(replacements):
-    """Install import stubs temporarily and restore prior modules afterward."""
-    previous = {name: sys.modules.get(name, _MISSING) for name in replacements}
-    sys.modules.update(replacements)
-    try:
-        yield
-    finally:
-        for name, module in previous.items():
-            if module is _MISSING:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = module
-
-
-def _load_mainwindow_module():
-    """Load mainwindow with deterministic stubs for its GUI dependencies."""
-    package = _module(_PACKAGE)
-    package.__path__ = [str(_ROOT)]
-
-    bom_estimation_package = _module(f"{_PACKAGE}.bom_estimation")
-    bom_estimation_package.__path__ = []
-    enrichment_package = _module(f"{_PACKAGE}.enrichment")
-    enrichment_package.__path__ = []
-
-    class _Dialog:
-        pass
-
-    ids = count(1)
-    wx = _module(
-        "wx",
-        Dialog=_Dialog,
-        NewIdRef=lambda: next(ids),
+_ids = count(1)
+mainwindow = load_mainwindow(
+    "mainwindow_stale_footprint_tests",
+    wx=wx_stubs(
+        Dialog=type("Dialog", (), {}),
+        NewIdRef=lambda: next(_ids),
         PostEvent=lambda *_args, **_kwargs: None,
-    )
-    wx.__path__ = []
-    wx_dataview = _module("wx.dataview")
-    wx_adv = _module("wx.adv")
-    wx.dataview = wx_dataview
-    wx.adv = wx_adv
-
-    def event_factory(**values):
-        return types.SimpleNamespace(**values)
-
-    event_names = (
-        "EVT_ASSEMBLY_ENRICHMENT_COMPLETED_EVENT",
-        "EVT_ASSEMBLY_ENRICHMENT_PROGRESS_EVENT",
-        "EVT_ASSIGN_PARTS_EVENT",
-        "EVT_BOM_DATA_CHANGED_EVENT",
-        "EVT_DOWNLOAD_COMPLETED_EVENT",
-        "EVT_DOWNLOAD_PROGRESS_EVENT",
-        "EVT_DOWNLOAD_STARTED_EVENT",
-        "EVT_LOGBOX_APPEND_EVENT",
-        "EVT_MESSAGE_EVENT",
-        "EVT_POPULATE_FOOTPRINT_LIST_EVENT",
-        "EVT_UNZIP_COMBINING_PROGRESS_EVENT",
-        "EVT_UNZIP_COMBINING_STARTED_EVENT",
-        "EVT_UNZIP_EXTRACTING_COMPLETED_EVENT",
-        "EVT_UNZIP_EXTRACTING_PROGRESS_EVENT",
-        "EVT_UNZIP_EXTRACTING_STARTED_EVENT",
-        "EVT_UPDATE_SETTING",
-    )
-    events = {name: object() for name in event_names}
-    events.update(
-        {
-            "AssemblyEnrichmentCompletedEvent": event_factory,
-            "AssemblyEnrichmentProgressEvent": event_factory,
-            "BomDataChangedEvent": event_factory,
-            "LogboxAppendEvent": event_factory,
-        }
-    )
-
-    library_state = types.SimpleNamespace(
-        INITIALIZED=object(),
-        UPDATE_NEEDED=object(),
-    )
-    replacements = {
-        "pcbnew": _module("pcbnew"),
-        "wx": wx,
-        "wx.dataview": wx_dataview,
-        "wx.adv": wx_adv,
-        _PACKAGE: package,
-        f"{_PACKAGE}.bom_estimation": bom_estimation_package,
-        f"{_PACKAGE}.bom_estimation.assembly_mode": _module(
-            f"{_PACKAGE}.bom_estimation.assembly_mode",
-            classify_component_product_type=lambda _value: None,
-        ),
-        f"{_PACKAGE}.bom_estimation.help_text": _module(
-            f"{_PACKAGE}.bom_estimation.help_text",
-            show_bom_estimator_help=lambda *_args, **_kwargs: None,
-        ),
-        f"{_PACKAGE}.bom_widget": _module(
-            f"{_PACKAGE}.bom_widget",
-            BomEstimatorController=object,
-            BomEstimatorWidget=object,
-        ),
-        f"{_PACKAGE}.corrections": _module(
-            f"{_PACKAGE}.corrections", CorrectionManagerDialog=object
-        ),
-        f"{_PACKAGE}.datamodel": _module(
-            f"{_PACKAGE}.datamodel",
-            PartListDataModel=object,
-            STANDARD_ONLY_TOOLTIP="",
-        ),
-        f"{_PACKAGE}.dataview_highlight": _module(
-            f"{_PACKAGE}.dataview_highlight",
-            HighlightedTextRenderer=object,
-            decode_highlighted_value=lambda value: (value, []),
-            simplify_footprint_name=lambda value: value,
-        ),
-        f"{_PACKAGE}.derive_params": _module(
-            f"{_PACKAGE}.derive_params",
-            params_for_part=lambda _details: "params",
-        ),
-        f"{_PACKAGE}.enrichment": enrichment_package,
-        f"{_PACKAGE}.enrichment.providers": _module(
-            f"{_PACKAGE}.enrichment.providers",
-            LCSCAssemblyMetadataProvider=object,
-        ),
-        f"{_PACKAGE}.events": _module(f"{_PACKAGE}.events", **events),
-        f"{_PACKAGE}.fabrication": _module(
-            f"{_PACKAGE}.fabrication", Fabrication=object
-        ),
-        f"{_PACKAGE}.footprint_helpers": _module(
-            f"{_PACKAGE}.footprint_helpers",
-            get_is_dnp=lambda _footprint: False,
-            set_lcsc_value=lambda *_args: None,
-            toggle_exclude_from_bom=lambda _footprint: None,
-            toggle_exclude_from_pos=lambda _footprint: None,
-        ),
-        f"{_PACKAGE}.generate_hooks": _module(
-            f"{_PACKAGE}.generate_hooks",
-            format_hook_error=lambda result: str(result),
-            run_configured_hook=lambda **_kwargs: None,
-        ),
-        f"{_PACKAGE}.helpers": _module(
-            f"{_PACKAGE}.helpers",
-            PLUGIN_PATH=str(_ROOT),
-            GetScaleFactor=lambda _window: 1,
-            HighResWxSize=lambda _window, size: size,
-            getVersion=lambda: "test",
-            loadBitmapScaled=lambda *_args: None,
-        ),
-        f"{_PACKAGE}.kicad_drc": _module(
-            f"{_PACKAGE}.kicad_drc", DRCViolationCounter=object
-        ),
-        f"{_PACKAGE}.library": _module(
-            f"{_PACKAGE}.library", Library=object, LibraryState=library_state
-        ),
-        f"{_PACKAGE}.partdetails": _module(
-            f"{_PACKAGE}.partdetails", PartDetailsDialog=object
-        ),
-        f"{_PACKAGE}.partmapper": _module(
-            f"{_PACKAGE}.partmapper", PartMapperManagerDialog=object
-        ),
-        f"{_PACKAGE}.partselector": _module(
-            f"{_PACKAGE}.partselector", PartSelectorDialog=object
-        ),
-        f"{_PACKAGE}.schematicexport": _module(
-            f"{_PACKAGE}.schematicexport", SchematicExport=object
-        ),
-        f"{_PACKAGE}.settings": _module(f"{_PACKAGE}.settings", SettingsDialog=object),
-        f"{_PACKAGE}.store": _module(f"{_PACKAGE}.store", Store=object),
-        f"{_PACKAGE}.why_standard_dialog": _module(
-            f"{_PACKAGE}.why_standard_dialog", WhyStandardDialog=object
-        ),
-    }
-
-    module_name = f"{_PACKAGE}.mainwindow"
-    spec = importlib.util.spec_from_file_location(module_name, _ROOT / "mainwindow.py")
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    module.__package__ = _PACKAGE
-    replacements[module_name] = module
-
-    logger_levels = {
-        name: logging.getLogger(name).level for name in ("requests", "urllib3")
-    }
-    try:
-        with _temporary_modules(replacements):
-            spec.loader.exec_module(module)
-    finally:
-        for name, level in logger_levels.items():
-            logging.getLogger(name).setLevel(level)
-    return module
-
-
-mainwindow = _load_mainwindow_module()
+    ),
+)
 JLCPCBTools = mainwindow.JLCPCBTools
 
 

--- a/tests/wx_harness.py
+++ b/tests/wx_harness.py
@@ -1,0 +1,213 @@
+"""Scaffolding for tests that import plugin modules outside KiCad.
+
+The plugin's GUI modules import wxPython and pcbnew at module load time and
+reach their siblings through relative imports, so a test can only import one by
+standing up a fake ``wx``, a fake ``pcbnew`` and a synthetic parent package
+first.  Every test that needs one of those modules needs the same scaffolding,
+so it lives here once instead of being rebuilt per test file.
+
+Stubs installed through :func:`temporary_modules` are removed again afterwards,
+which keeps one test file's fakes from becoming another's surprise.
+"""
+
+from contextlib import contextmanager
+import importlib.util
+from itertools import count
+import logging
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).parent.parent
+
+_MISSING = object()
+
+
+def module(name, **symbols):
+    """Create a module containing the explicitly supplied symbols."""
+    created = types.ModuleType(name)
+    created.__dict__.update(symbols)
+    return created
+
+
+@contextmanager
+def temporary_modules(replacements):
+    """Install import stubs temporarily and restore prior modules afterward."""
+    previous = {name: sys.modules.get(name, _MISSING) for name in replacements}
+    sys.modules.update(replacements)
+    try:
+        yield
+    finally:
+        for name, restored in previous.items():
+            if restored is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = restored
+
+
+class FakeWidget:
+    """Permissive stand-in for wx objects whose state the tests never inspect."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __getattr__(self, name):
+        """Answer wx-style method calls with a no-op, and nothing else."""
+        if name[:1].isupper():
+            return lambda *_args, **_kwargs: None
+        raise AttributeError(name)
+
+
+class FakeWxModule(types.ModuleType):
+    """A wx-shaped module that mints the attributes it is asked for.
+
+    ``UPPER_CASE`` names become distinct single-bit flags, so a test can assert
+    on style arithmetic (``style & wx.ICON_WARNING``) without two unrelated
+    flags colliding.  Any other name becomes a permissive widget class.
+    """
+
+    def __init__(self, name, **symbols):
+        super().__init__(name)
+        self.__dict__["_bits"] = count()
+        self.__dict__.update(symbols)
+
+    def __getattr__(self, name):
+        """Mint a flag or a widget class for an attribute nobody supplied."""
+        if name.startswith("__"):
+            raise AttributeError(name)
+        value = 1 << next(self._bits) if name.isupper() else FakeWidget
+        setattr(self, name, value)
+        return value
+
+
+def wx_stubs(*, submodules=("dataview", "adv"), **symbols):
+    """Return ``{name: module}`` for a fake ``wx`` and the requested submodules."""
+    wx = FakeWxModule("wx", **symbols)
+    wx.__path__ = []
+    stubs = {"wx": wx}
+    for submodule in submodules:
+        child = FakeWxModule(f"wx.{submodule}")
+        setattr(wx, submodule, child)
+        stubs[f"wx.{submodule}"] = child
+    return stubs
+
+
+def package_stubs(package, submodules=()):
+    """Return a synthetic parent package, plus any subpackages needed under it."""
+    root = module(package)
+    root.__path__ = [str(ROOT)]
+    stubs = {package: root}
+    for submodule in submodules:
+        child = module(f"{package}.{submodule}")
+        child.__path__ = []
+        stubs[f"{package}.{submodule}"] = child
+    return stubs
+
+
+def load(package, name, replacements):
+    """Load ``<name>.py`` from the repo root as ``package.name`` under the stubs."""
+    module_name = f"{package}.{name}"
+    spec = importlib.util.spec_from_file_location(module_name, ROOT / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    loaded.__package__ = package
+    with temporary_modules({**replacements, module_name: loaded}):
+        spec.loader.exec_module(loaded)
+    return loaded
+
+
+def mainwindow_stubs(package, *, wx=None, pcbnew=None, **overrides):
+    """Return every module ``mainwindow.py`` imports, stubbed.
+
+    Defaults behave like the real thing where a caller is likely to depend on a
+    return value, and are inert everywhere else.  Pass ``overrides`` keyed by
+    module suffix to replace one module's symbols, e.g.
+    ``mainwindow_stubs(pkg, helpers={"getVersion": lambda: "1.2.3"})``.
+    """
+    stubs = package_stubs(package, ("bom_estimation", "enrichment"))
+    stubs.update(wx_stubs() if wx is None else wx)
+    stubs["pcbnew"] = module("pcbnew") if pcbnew is None else pcbnew
+
+    # events.py falls back to a plain event factory when wx.lib is missing, and
+    # the fake wx has no submodules, so the real module loads here.  Using it
+    # keeps the event names from drifting out of step with a copy.
+    stubs[f"{package}.events"] = load(package, "events", stubs)
+
+    symbols = {
+        "bom_estimation.assembly_mode": {
+            "classify_component_product_type": lambda _value: None
+        },
+        "bom_estimation.help_text": {
+            "show_bom_estimator_help": lambda *_args, **_kwargs: None
+        },
+        "bom_widget": {"BomEstimatorController": object, "BomEstimatorWidget": object},
+        "corrections": {"CorrectionManagerDialog": object},
+        "datamodel": {
+            "PartListDataModel": type("PartListDataModel", (), {"columns": {}}),
+            "STANDARD_ONLY_TOOLTIP": "",
+        },
+        "dataview_highlight": {
+            "HighlightedTextRenderer": object,
+            "decode_highlighted_value": lambda value: (value, []),
+            "simplify_footprint_name": lambda value: value,
+        },
+        "derive_params": {"params_for_part": lambda _details: "params"},
+        "enrichment.providers": {"LCSCAssemblyMetadataProvider": object},
+        "fabrication": {"Fabrication": object},
+        "footprint_helpers": {
+            "get_is_dnp": lambda _footprint: False,
+            "set_lcsc_value": lambda *_args: None,
+            "toggle_exclude_from_bom": lambda _footprint: None,
+            "toggle_exclude_from_pos": lambda _footprint: None,
+        },
+        "generate_hooks": {
+            "format_hook_error": str,
+            "run_configured_hook": lambda **_kwargs: None,
+        },
+        "helpers": {
+            "PLUGIN_PATH": str(ROOT),
+            "GetScaleFactor": lambda _window: 1,
+            "HighResWxSize": lambda _window, size: size,
+            "getVersion": lambda: "test",
+            "loadBitmapScaled": lambda *_args: None,
+        },
+        "kicad_drc": {"DRCViolationCounter": object},
+        "library": {
+            "Library": object,
+            "LibraryState": types.SimpleNamespace(
+                INITIALIZED=object(), UPDATE_NEEDED=object()
+            ),
+        },
+        "partdetails": {"PartDetailsDialog": object},
+        "partmapper": {"PartMapperManagerDialog": object},
+        "partselector": {"PartSelectorDialog": object},
+        "schematicexport": {"SchematicExport": object},
+        "settings": {"SettingsDialog": object},
+        "store": {"Store": object},
+        "why_standard_dialog": {"WhyStandardDialog": object},
+    }
+    symbols.update(overrides)
+    stubs.update(
+        {f"{package}.{suffix}": module(f"{package}.{suffix}", **values)
+         for suffix, values in symbols.items()}
+    )
+    return stubs
+
+
+def load_mainwindow(package, *, wx=None, pcbnew=None, **overrides):
+    """Load ``mainwindow.py`` under ``package`` with every dependency stubbed.
+
+    The loaded module keeps its own reference to the fake wx, so a caller that
+    needs to configure or assert on it can reach it as ``module.wx``.
+    """
+    stubs = mainwindow_stubs(package, wx=wx, pcbnew=pcbnew, **overrides)
+
+    # mainwindow.py raises the requests/urllib3 log levels as an import side
+    # effect; leaving that in place would leak into unrelated tests.
+    levels = {name: logging.getLogger(name).level for name in ("requests", "urllib3")}
+    try:
+        return load(package, "mainwindow", stubs)
+    finally:
+        for name, level in levels.items():
+            logging.getLogger(name).setLevel(level)

--- a/tests/wx_harness.py
+++ b/tests/wx_harness.py
@@ -45,26 +45,17 @@ def temporary_modules(replacements):
                 sys.modules[name] = restored
 
 
-class FakeWidget:
-    """Permissive stand-in for wx objects whose state the tests never inspect."""
-
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-
-    def __getattr__(self, name):
-        """Answer wx-style method calls with a no-op, and nothing else."""
-        if name[:1].isupper():
-            return lambda *_args, **_kwargs: None
-        raise AttributeError(name)
-
-
 class FakeWxModule(types.ModuleType):
-    """A wx-shaped module that mints the attributes it is asked for.
+    """A wx-shaped module that mints the flag constants it is asked for.
 
-    ``UPPER_CASE`` names become distinct single-bit flags, so a test can assert
-    on style arithmetic (``style & wx.ICON_WARNING``) without two unrelated
-    flags colliding.  Any other name becomes a permissive widget class.
+    ``UPPER_CASE`` names become distinct single-bit values, so a test can
+    assert on style arithmetic (``style & wx.ICON_WARNING``) without two
+    unrelated flags colliding, and no test has to hand-number its constants.
+
+    Everything else -- classes, functions, submodules -- must be supplied
+    explicitly by the caller.  An attribute nobody supplied raises
+    ``AttributeError`` rather than resolving to something callable, so a
+    misspelled wx call fails the test instead of quietly succeeding.
     """
 
     def __init__(self, name, **symbols):
@@ -73,10 +64,10 @@ class FakeWxModule(types.ModuleType):
         self.__dict__.update(symbols)
 
     def __getattr__(self, name):
-        """Mint a flag or a widget class for an attribute nobody supplied."""
-        if name.startswith("__"):
+        """Mint a flag; reject any other attribute that was not supplied."""
+        if not name.isupper() or name.startswith("__"):
             raise AttributeError(name)
-        value = 1 << next(self._bits) if name.isupper() else FakeWidget
+        value = 1 << next(self._bits)
         setattr(self, name, value)
         return value
 
@@ -129,9 +120,11 @@ def mainwindow_stubs(package, *, wx=None, pcbnew=None, **overrides):
     stubs.update(wx_stubs() if wx is None else wx)
     stubs["pcbnew"] = module("pcbnew") if pcbnew is None else pcbnew
 
-    # events.py falls back to a plain event factory when wx.lib is missing, and
-    # the fake wx has no submodules, so the real module loads here.  Using it
-    # keeps the event names from drifting out of step with a copy.
+    # events.py falls back to a plain event factory when wx.lib is missing.
+    # The stub submodules are limited to the ones wired up above and the fake
+    # wx has an empty __path__, so wx.lib cannot be found and the fallback is
+    # taken here -- even where wxPython is installed.  Loading the real module
+    # keeps its event names from drifting out of step with a copy.
     stubs[f"{package}.events"] = load(package, "events", stubs)
 
     symbols = {


### PR DESCRIPTION
## Why

`mainwindow.py`, `settings.py`, `fabrication.py` and friends import wxPython and pcbnew at module load time, and reach their siblings through relative imports. A test can only import one of them after standing up a fake `wx`, a fake `pcbnew` and a synthetic parent package first — so every test that touches a GUI module has had to build that scaffolding itself.

There are four different idioms for it in the tree today. The two main-window tests are the clearest case: they stub an **identical** set of modules and event names, in two independent ~130-line implementations that differ only in cosmetics (`MagicMock` vs `lambda`, `monkeypatch` vs a context manager, and a different synthetic package name each).

That duplication has a running cost. Rebasing this PR onto #797 showed it directly: `feat(bom): add Standard-mode details` and its siblings had to add `bom_estimation.assembly_mode`, `datamodel.STANDARD_ONLY_TOOLTIP` and `why_standard_dialog.WhyStandardDialog` to **both** test files, in two different styles, to keep `mainwindow.py` importable. On this branch that same change is three lines in one place.

## What this does

Adds `tests/wx_harness.py` and moves both main-window tests onto it. **No test body changes** — only the bootstrap at the top of each file.

- `module()` / `temporary_modules()` — install stubs and take them back out again, so one test file's fakes cannot become another's surprise.
- `FakeWxModule` — a wx-shaped module that generates distinct flag values centrally, replacing the constants each test used to hand-number (`wx.ID_YES = 1 … wx.CENTER = 128`). Distinct bits mean two unrelated flags can't collide in a `style &` assertion. Anything that is not `UPPER_CASE` must be supplied explicitly by the caller and otherwise raises `AttributeError`, so a misspelled wx call fails the test rather than quietly resolving to something callable.
- `wx_stubs()` / `package_stubs()` / `load()` — the fake-wx, synthetic-package and `spec_from_file_location` dance, once.
- `mainwindow_stubs()` / `load_mainwindow()` — the main-window dependency surface in one place, with per-module `overrides` for tests that need a specific return value.

**`events.py` is loaded for real, not stubbed.** It already falls back to a plain event factory when `wx.lib` is missing, and `wx.lib` is not among the stub submodules while the fake `wx` has an empty `__path__` — so the fallback is taken deterministically, even where wxPython is installed. That removes 20 hand-copied event names: adding an event to `events.py` no longer means updating test files to match.

## Result

```
 tests/test_mainwindow_empty_zone_warning.py | 232 +++-----------------
 tests/test_mainwindow_stale_footprints.py   | 224 ++-----------------
 tests/wx_harness.py                         | 206 ++++++++++++++++++
 3 files changed, 236 insertions(+), 426 deletions(-)
```

`pytest` goes from 426 passing to 426 passing; `ruff check` is clean. Each migrated file also passes in isolation, in reverse collection order, and leaves `sys.modules` clean afterwards.

## Follow-ups (not in this PR)

- `test_fabrication_corrections.py`, `test_bom_designator_split.py` and `test_bom_estimator_controller.py` assign into `sys.modules` at import time and never restore it, leaking `wx`, `wx.dataview` and `pcbnew` for the rest of the session. `test_bom_estimator_controller.py` already carries a defensive *"Force-set F_Cu even if pcbnew was already stubbed by an earlier test"* workaround for it. They can move onto this harness next.
- `common/test_store_pad_filter.py` has its own third variant of the same bootstrap.

I have two open PRs (#800, #801) that both add wx mocking; I've checked both rebase cleanly onto this harness. #801 currently carries a verbatim copy of `_module()`/`_temporary_modules()` from `test_mainwindow_stale_footprints.py`, and #800 imports its harness directly out of that sibling test module — both go away once this lands. Happy to rebase them onto this if you'd like it in first, or to reorder if you'd rather take those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)