### PR TITLE
Replace numeric assembly classifications with an enum

### DIFF
--- a/bom_estimation/assembly_mode.py
+++ b/bom_estimation/assembly_mode.py
@@ -4,7 +4,16 @@
 # pyupgrade: disable
 
 from dataclasses import dataclass, field
+from enum import IntEnum
 from typing import Optional
+
+
+class ComponentProductType(IntEnum):
+    """Observed JLCPCB assembly classifications with their numeric API values."""
+
+    ECONOMIC_AND_STANDARD = 0
+    ECONOMIC_ONLY = 1
+    STANDARD_ONLY = 2
 
 
 @dataclass(frozen=True)
@@ -73,8 +82,8 @@ class AssemblyModeDecision:
         return self.economic_only_refs if self.board_standard is True else frozenset()
 
 
-def classify_component_product_type(value: object) -> Optional[int]:
-    """Normalize the observed JLC assembly classification to 0, 1, or 2.
+def classify_component_product_type(value: object) -> Optional[ComponentProductType]:
+    """Normalize the observed JLC assembly classification to a named value.
 
     The numeric mapping is observed API behavior, not a published JLCPCB API
     contract: 0 is Economic and Standard, 1 is Economic Only, and 2 is
@@ -85,7 +94,6 @@ def classify_component_product_type(value: object) -> Optional[int]:
     if isinstance(value, float) and not value.is_integer():
         return None
     try:
-        normalized = int(value)
+        return ComponentProductType(int(value))
     except (TypeError, ValueError, OverflowError):
         return None
-    return normalized if normalized in {0, 1, 2} else None

--- a/bom_estimation/pricing.py
+++ b/bom_estimation/pricing.py
@@ -11,7 +11,7 @@ import contextlib
 from dataclasses import dataclass, field
 import json
 
-from .assembly_mode import classify_component_product_type
+from .assembly_mode import ComponentProductType, classify_component_product_type
 
 
 @dataclass
@@ -262,7 +262,10 @@ def _scan_assembly_state(
         tht = is_tht_part(part)
 
         if not exclude_from_pos:
-            if classify_component_product_type(part.get("component_product_type")) == 2:
+            if (
+                classify_component_product_type(part.get("component_product_type"))
+                == ComponentProductType.STANDARD_ONLY
+            ):
                 scan.standard_present = True
             scan.populated_part_present = True
             joints = max(0, _safe_int(part.get("pad_count"))) * board_count

--- a/bom_widget.py
+++ b/bom_widget.py
@@ -12,6 +12,7 @@ import wx  # pylint: disable=import-error
 
 from .bom_estimation.assembly_mode import (
     AssemblyModeDecision,
+    ComponentProductType,
     classify_component_product_type,
 )
 from .bom_estimation.pricing import calculate_bom_estimate, get_assembly_flags
@@ -224,9 +225,9 @@ class BomEstimatorController:
             product_type = classify_component_product_type(
                 part.get("component_product_type")
             )
-            if product_type == 2:
+            if product_type == ComponentProductType.STANDARD_ONLY:
                 standard_only_refs.add(reference)
-            elif product_type == 1:
+            elif product_type == ComponentProductType.ECONOMIC_ONLY:
                 economic_only_refs.add(reference)
             elif product_type is None:
                 classification_missing_refs.add(reference)

--- a/common/test_bom_estimator_policy.py
+++ b/common/test_bom_estimator_policy.py
@@ -4,6 +4,7 @@ import pytest
 
 from bom_estimation.assembly_mode import (  # pylint: disable=import-error
     AssemblyModeDecision,
+    ComponentProductType,
     classify_component_product_type,
 )
 
@@ -22,9 +23,11 @@ def _decision(**overrides):
 @pytest.mark.parametrize(
     ("raw_value", "expected"),
     [
-        (0, 0),
-        ("1", 1),
-        (2, 2),
+        (0, ComponentProductType.ECONOMIC_AND_STANDARD),
+        ("1", ComponentProductType.ECONOMIC_ONLY),
+        (2, ComponentProductType.STANDARD_ONLY),
+        (2.0, ComponentProductType.STANDARD_ONLY),
+        (ComponentProductType.STANDARD_ONLY, ComponentProductType.STANDARD_ONLY),
         (None, None),
         ("bad", None),
         (2.5, None),
@@ -34,7 +37,7 @@ def _decision(**overrides):
 )
 def test_component_product_type_accepts_only_the_observed_mapping(raw_value, expected):
     """Unknown values never become Standard merely because they are nonzero."""
-    assert classify_component_product_type(raw_value) == expected
+    assert classify_component_product_type(raw_value) is expected
 
 
 @pytest.mark.parametrize(

--- a/common/test_store_pad_filter.py
+++ b/common/test_store_pad_filter.py
@@ -48,6 +48,9 @@ footprint_has_tht = footprint_metadata_module.footprint_has_tht
 
 # Imported here for the round-trip test below; the import sits below the
 # package bootstrap so bom_estimation resolves correctly.
+from bom_estimation.assembly_mode import (  # noqa: E402  pylint: disable=wrong-import-position,import-error
+    ComponentProductType,
+)
 from bom_estimation.pricing import (  # noqa: E402  pylint: disable=wrong-import-position,import-error
     get_assembly_flags as parse_assembly_flags,
 )
@@ -228,7 +231,11 @@ def test_assembly_metadata_follows_lcsc_lifecycle(tmp_path):
     _update_part(store, "C2")
     assert _part_state(store) == ("C2", "10k", "", None)
 
-    assert store.set_assembly_metadata("R1", "SMT", 0, expected_lcsc="C2")
+    assert store.set_assembly_metadata(
+        "R1", "SMT", ComponentProductType.ECONOMIC_AND_STANDARD, expected_lcsc="C2"
+    )
+    product_type = store.get_part("R1")["component_product_type"]
+    assert product_type == 0 and type(product_type) is int
     store.set_lcsc("R1", "CNEW")
     assert _part_state(store) == ("CNEW", "10k", "", None)
 

--- a/enrichment/providers.py
+++ b/enrichment/providers.py
@@ -22,10 +22,16 @@ import time
 from typing import Protocol
 
 try:
-    from ..bom_estimation.assembly_mode import classify_component_product_type
+    from ..bom_estimation.assembly_mode import (
+        ComponentProductType,
+        classify_component_product_type,
+    )
     from ..lcsc_api import LCSC_API
 except ImportError:  # pragma: no cover - test import fallback
-    from bom_estimation.assembly_mode import classify_component_product_type
+    from bom_estimation.assembly_mode import (
+        ComponentProductType,
+        classify_component_product_type,
+    )
     from lcsc_api import LCSC_API
 
 
@@ -74,7 +80,7 @@ class LCSCAssemblyMetadataProvider:
             assembly_process = ""
             component_product_type = None
 
-        is_standard = component_product_type == 2
+        is_standard = component_product_type == ComponentProductType.STANDARD_ONLY
 
         return {
             "assembly_process": assembly_process,


### PR DESCRIPTION
## Summary

Follow up on the enum suggestion from Andy during review of #797.

- Add `ComponentProductType(IntEnum)` with named values for Economic and Standard, Economic Only, and Standard Only.
- Return enum members from the existing normalizer and use them in BOM, pricing, and enrichment comparisons.
- Preserve numeric API values, integer storage, and existing handling of unknown classifications. No UI, pricing-policy, or schema changes.

Production changes and tests are in separate commits. The diff is limited to six files: 44 additions and 16 deletions.

## Validation

- All 428 tracked tests passed.
- Ruff lint and formatting checks passed; commit hooks passed.
- Tests cover enum return values, supported inputs, unknown values, and SQLite integer-storage compatibility.
- Independent scope and compatibility review found no issues.