### PR TITLE
fix(corrections): rank matches by how much of the value they consume

### DIFF
--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -72,9 +72,13 @@ uncorrected placement. Unreadable storage or unresolved records are shown as
 
 The parts table and placement output use the same correction selection rules.
 Reference matches take priority over value matches, which take priority over
-footprint matches. For each of those fields, patterns matching the end of the
-text are tried before ordinary substring matches. Ties retain database order.
-For example, `SOT-23-3` wins over `SOT-23` for a footprint named `SOT-23-3`.
+footprint matches. Within a field, every pattern is searched against the text,
+and the pattern whose match consumes the most characters wins. Ties retain
+database order. For example, `SOT-23-3` wins over `SOT-23` for a footprint
+named `SOT-23-3`, and `^SOP-4_` wins over `^SOP-(?!18_)` for
+`SOP-4_3.8x4.1mm_P2.54mm` because a lookahead consumes nothing. Matching the
+end of the text carries no special priority: `SOT-23` wins over `23$` for
+`SOT-23-extra-23`.
 
 A matched correction of zero degrees and zero offset still takes precedence
 over lower-priority rules. The table labels the match source as `(ref)`, `(val)`,

--- a/correction_data.py
+++ b/correction_data.py
@@ -30,18 +30,14 @@ class Correction:
     rotation: int
     offset: tuple[float, float]
     _regex: re.Pattern[str] = field(init=False, repr=False, compare=False)
-    _suffix_regex: re.Pattern[str] = field(init=False, repr=False, compare=False)
 
     def __init__(self, pattern: object, rotation: object, offset: object) -> None:
         """Enforce the value contract at every construction or replacement."""
-        pattern, rotation, offset, regex, suffix_regex = _validated_values(
-            pattern, rotation, offset
-        )
+        pattern, rotation, offset, regex = _validated_values(pattern, rotation, offset)
         object.__setattr__(self, "pattern", pattern)
         object.__setattr__(self, "rotation", rotation)
         object.__setattr__(self, "offset", offset)
         object.__setattr__(self, "_regex", regex)
-        object.__setattr__(self, "_suffix_regex", suffix_regex)
 
     @classmethod
     def parse(
@@ -86,14 +82,18 @@ class CorrectionMatch:
 def find_correction(
     corrections: Sequence[Correction], value: str
 ) -> Optional[Correction]:  # noqa: UP045
-    """Prefer a suffix match, then the first unanchored match in input order."""
+    """Return the correction consuming the most of the value; ties keep order."""
+    best = None
+    best_length = -1
     for correction in corrections:
-        if correction._suffix_regex.search(value):
-            return correction
-    for correction in corrections:
-        if correction._regex.search(value):
-            return correction
-    return None
+        match = correction._regex.search(value)
+        if match is None:
+            continue
+        length = len(match.group(0))
+        if length > best_length:
+            best = correction
+            best_length = length
+    return best
 
 
 def match_correction(
@@ -180,10 +180,10 @@ def _offset(value: object) -> float:
 
 def _validated_values(
     pattern: object, rotation: object, offset: object
-) -> tuple[str, int, tuple[float, float], re.Pattern[str], re.Pattern[str]]:
+) -> tuple[str, int, tuple[float, float], re.Pattern[str]]:
     """Validate all fields once and return normalized constructor values.
 
-    Pattern text is preserved exactly. Both matching expressions are compiled
+    Pattern text is preserved exactly and its matching expression is compiled
     and retained. Rotations are signed whole degrees within SQLite's
     integer range; offsets must be finite floats. No invalid value is defaulted.
     """
@@ -200,13 +200,11 @@ def _validated_values(
         )
 
     regex = None
-    suffix_regex = None
     if not isinstance(pattern, str) or not pattern.strip():
         issue("pattern", pattern, "expected a nonempty regular expression")
     else:
         try:
             regex = re.compile(pattern)
-            suffix_regex = re.compile(f"(?:{pattern})$")
         except (re.error, OverflowError, RecursionError) as error:
             issue("pattern", pattern, f"invalid correction regular expression: {error}")
 
@@ -236,13 +234,11 @@ def _validated_values(
     assert isinstance(pattern, str)
     assert validated_rotation is not None
     assert regex is not None
-    assert suffix_regex is not None
     return (
         pattern,
         validated_rotation,
         (validated_offsets[0], validated_offsets[1]),
         regex,
-        suffix_regex,
     )
 
 

--- a/tests/test_correction_data.py
+++ b/tests/test_correction_data.py
@@ -208,16 +208,26 @@ def test_patterns_preserve_supported_regex_text(data, pattern):
         "",
         " \t\n",
         "[",
-        "(?i)SOT",
         "a{999999999999999999999}",
         "(" * 1000,
     ],
 )
-def test_invalid_patterns_include_anchored_matcher_failures(data, pattern):
-    """Reject invalid regexes, including raw-valid global flag expressions."""
+def test_invalid_patterns_are_rejected(data, pattern):
+    """Reject patterns that are not usable regular expressions."""
     with pytest.raises(data.CorrectionDataError) as raised:
         data.validate_correction(pattern, 0, (0, 0))
     assert raised.value.issues[0].field == "pattern"
+
+
+def test_a_global_flag_pattern_is_usable(data):
+    """A leading (?i) is a valid regex, and now survives to match with.
+
+    It only ever failed validation because the discarded anchored pass wrapped
+    the pattern in "(?:...)$", which moves the flag off the front of the
+    expression -- where Python requires it to be.
+    """
+    correction = data.Correction("(?i)SOT-23", 90, (0, 0))
+    assert data.find_correction((correction,), "Package:sot-23") is correction
 
 
 def test_validation_aggregates_all_fields(data):
@@ -475,7 +485,6 @@ def test_parser_requires_decoded_text(data, value):
         ("C1", float("inf"), (0, 0), "rotation"),
         ("C1", True, (0, 0), "rotation"),
         ("[", 0, (0, 0), "pattern"),
-        ("(?i)C1", 0, (0, 0), "pattern"),
         (" ", 0, (0, 0), "pattern"),
         (123, 0, (0, 0), "pattern"),
         ("C1", 0, (float("nan"), 0), "offset_x"),
@@ -549,7 +558,7 @@ def test_dataclass_replace_normalizes_valid_inputs(data: ModuleType) -> None:
     assert correction == data.Correction("C1", -90, (-1.25, 2.5))
 
 
-def test_dataclass_replace_pattern_updates_both_matching_passes(
+def test_dataclass_replace_pattern_updates_the_matching_expression(
     data: ModuleType,
 ) -> None:
     """A replacement uses its new pattern while the original remains usable."""
@@ -557,7 +566,7 @@ def test_dataclass_replace_pattern_updates_both_matching_passes(
     replacement = replace(original, pattern="NEW")
     fallback = data.Correction("prefix", -90, (0, 0))
 
-    assert data.find_correction((fallback, replacement), "prefix-NEW") is replacement
+    assert data.find_correction((fallback, replacement), "only-NEW") is replacement
     assert data.find_correction((replacement,), "prefix-NEW-suffix") is replacement
     assert data.find_correction((replacement,), "prefix-OLD") is None
     assert data.find_correction((replacement,), "prefix-OLD-suffix") is None

--- a/tests/test_correction_matching.py
+++ b/tests/test_correction_matching.py
@@ -31,10 +31,10 @@ def data(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
         (("SOT-23-3", "SOT-23"), "SOT-23-3", 0),
         (("SOT-23",), "Package:SOT-23", 0),
         (("SOT-23",), "Package:SOT-23-extra", 0),
-        (("23", "SOT-23"), "SOT-23", 0),
+        (("23", "SOT-23"), "SOT-23", 1),
         (("SOT-23", "23"), "SOT-23", 0),
         ((".+", "SOT-23"), "SOT-23", 0),
-        (("SOT", "SOT-23"), "SOT-23-extra", 0),
+        (("SOT", "SOT-23"), "SOT-23-extra", 1),
         (("SOT-23", "SOT"), "SOT-23-extra", 0),
         (("SOT|QFN", "SOT-23"), "SOT-23", 1),
         (("SOT|QFN",), "Package:QFN", 0),
@@ -43,16 +43,18 @@ def data(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
         (("SOT-23",), "sot-23", None),
         (("SOT-23",), "QFN-32", None),
         (("SOT-23", "23\\n"), "SOT-23\n", 0),
+        (("^SOP-(?!18_)", "^SOP-4_"), "SOP-4_3.8x4.1mm_P2.54mm", 1),
+        (("^SOP-(?!18_)", "^SOP-4_"), "SOP-18_7.5x11.6mm_P1.27mm", None),
         ((), "QFN-32", None),
     ],
 )
-def test_find_correction_preserves_cpl_match_precedence(
+def test_find_correction_ranks_by_how_much_of_the_value_is_consumed(
     data: ModuleType,
     patterns: tuple[str, ...],
     value: str,
     expected: Optional[int],  # noqa: UP045
 ) -> None:
-    """Suffix preference and stable ties must not become a new ranking policy."""
+    """More specific wins: the longest match, then input order for ties."""
     corrections = tuple(
         data.Correction(pattern, index * 90, (index, -index))
         for index, pattern in enumerate(patterns)
@@ -70,7 +72,7 @@ def test_find_correction_preserves_cpl_match_precedence(
         (("SOT-23", "SOT-23-3"), "R1", "VALUE", "SOT-23-3", 1, "fpt"),
         (("R", "R12", "VALUE"), "R12", "VALUE", "SOT-23-3", 1, "ref"),
         (("VAL", "VALUE"), "R12", "VALUE", "SOT-23-3", 1, "val"),
-        (("1", "R1", "VALUE"), "R1", "VALUE", "SOT-23-3", 0, "ref"),
+        (("1", "R1", "VALUE"), "R1", "VALUE", "SOT-23-3", 1, "ref"),
         (("R1", "VALUE", "SOT-23"), "R1", "VALUE", "SOT-23-3", 0, "ref"),
         (("SOT-23",), "R1", "VALUE", "Package:SOT-23-extra", 0, "fpt"),
     ],

--- a/tests/test_correction_matching.py
+++ b/tests/test_correction_matching.py
@@ -146,7 +146,7 @@ def test_large_correction_set_never_recompiles_during_matching(
     expected: Optional[int],  # noqa: UP045
     source: Optional[str],  # noqa: UP045
 ) -> None:
-    """Retained expressions survive cache eviction for suffix, fallback and misses."""
+    """Retained expressions survive cache eviction for footprint, value and missed matches."""
     corrections = tuple(
         data.Correction(f"REVIEW_{index:04d}", index, (0, 0)) for index in range(600)
     )


### PR DESCRIPTION
Follow-up to #748, which fixed one shape of correction conflict but not the shape the shipped table is actually made of.

Rebased onto #816, which moved matching out of `fabrication.py` into `correction_data.find_correction` and kept #748's two-pass rule, so the defect is still present — just in a new place. This is a re-fit rather than a rebase, and it now touches a test #816 added; see **The collision** below.

### The bug

#748 resolved conflicts by preferring any pattern that matched the *end* of the value, then falling back to substring matches, with ties broken by database order. That settles suffix-vs-substring conflicts, but every entry in the shipped corrections table is a `^`-prefixed prefix matcher, so prefix-vs-longer-prefix conflicts still fall through to alphabetical order.

The visible consequence: `^SOP-4_` (0°) never fires for a real footprint name. `^SOP-(?!18_)` (270°) carves out SOP-18 but not SOP-4, neither survives the anchored pass, and `(` sorts before `4`. Every SOP-4 optocoupler in the KiCad standard libraries comes out 270° instead of the 0° the table intends.

Still true on `main` at 1110a6b:

```
upstream/main (suffix-first, then input order):
  SOP-4_3.8x4.1mm_P2.54mm      -> 270deg via '^SOP-(?!18_)'
  SOP-4_4.4x2.6mm_P1.27mm      -> 270deg via '^SOP-(?!18_)'
  SOP-4_7.5x4.1mm_P2.54mm      -> 270deg via '^SOP-(?!18_)'
```

### The fix

Rank candidates by the length of the text they actually match, and keep the longest. Ties keep database order.

That is the faithful reading of "more specific wins": it settles prefix conflicts, and it is immune to zero-width syntax inflating a pattern's apparent specificity. Ranking by *pattern* length would not fix this bug — `^SOP-(?!18_)` is 12 characters against 7 for `^SOP-4_`, but the lookahead consumes nothing:

```
'^SOP-(?!18_)'   pattern_len=12  match='SOP-'    match_len=4
'^SOP-4_'        pattern_len= 7  match='SOP-4_'  match_len=6
```

Match-length ranking also subsumes the anchored pass, so the `(?:...)$` wrapping and the second compiled expression go away.

### The collision

#816 added `test_find_correction_preserves_cpl_match_precedence`, docstringed *"Suffix preference and stable ties must not become a new ranking policy."* This PR is that new ranking policy, so the test is renamed and three assertions change. Worth deciding deliberately rather than quietly:

| corrections | value | old winner | new winner |
|---|---|---|---|
| `('23', 'SOT-23')` | `SOT-23` | `23` | `SOT-23` |
| `('SOT', 'SOT-23')` | `SOT-23-extra` | `SOT` | `SOT-23` |
| `('1', 'R1')` on the reference | `R1` | `1` | `R1` |

In each case the new winner is the more specific pattern, which is the thing #748 was reaching for and the thing the shipped table needs. The reference/value/footprint priority #816 tests separately is untouched, and so is tie-breaking by database order.

One side effect worth naming: dropping the `(?:...)$` wrapping means a pattern whose only fault was that wrapping now validates. A leading `(?i)` is a valid regex, but Python rejects a global flag that is not at the front of the expression, so `(?i)SOT` had been failing validation for a reason that no longer exists. It is accepted and matches now, with a test.

### Verification

Full suite green: 1373 passed. Three assertions updated as tabled above, one test renamed for the policy it now guards, one test (`replace` rebuilding the matcher) re-paired onto a value that does not depend on ranking either way, and new cases covering the SOP-4 regression, the lookahead still applying to SOP-18, and the `(?i)` pattern.

Old rule vs new, from the original run against the shipped 59-entry corrections table across all 15436 footprint names in the KiCad standard libraries — the rule on both sides is unchanged by the re-fit, so the comparison carries over:

```
3 names where the old and new rule disagree:
  SOP-4_3.8x4.1mm_P2.54mm    old=(270, (0.0, 0.0))  new=(0, (0.0, 0.0))
  SOP-4_4.4x2.6mm_P1.27mm    old=(270, (0.0, 0.0))  new=(0, (0.0, 0.0))
  SOP-4_7.5x4.1mm_P2.54mm    old=(270, (0.0, 0.0))  new=(0, (0.0, 0.0))
```

Exactly the intended fix, no collateral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
