### PR TITLE
Derive enrichment-target classifications from ComponentProductType

### DIFF
--- a/common/test_store_pad_filter.py
+++ b/common/test_store_pad_filter.py
@@ -241,7 +241,11 @@ def test_assembly_metadata_follows_lcsc_lifecycle(tmp_path):
 
 
 def test_get_assembly_enrichment_targets_uses_or_logic(tmp_path):
-    """Rows missing any required enrichment field should be selected."""
+    """Rows missing any required enrichment field should be selected.
+
+    Every ComponentProductType member (0, 1, 2) counts as enriched; only NULL
+    or an unrecognized classification keeps a row in the target set.
+    """
     s = _store_obj()
     s.logger = logging.getLogger(__name__)
     s.dbfile = str(tmp_path / "project.db")
@@ -260,6 +264,7 @@ def test_get_assembly_enrichment_targets_uses_or_logic(tmp_path):
                 ("R5", "22k", "C5", "SMT", 3),
                 ("R6", "4k7", "C6", "SMT", "bad"),
                 ("R7", "1k", "C7", "SMT", 2),
+                ("R8", "330p", "C8", "SMT", 1),
             ],
         )
         cur.commit()

--- a/store.py
+++ b/store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sqlite3
 from typing import Union
 
+from .bom_estimation.assembly_mode import ComponentProductType
 from .footprint_helpers import (
     get_exclude_from_bom,
     get_exclude_from_pos,
@@ -292,16 +293,24 @@ class Store:
 
     def get_assembly_enrichment_targets(self, references=None) -> dict:
         """Get references grouped by LCSC that still need assembly process enrichment."""
+        # A row counts as enriched only once its classification is one the
+        # ComponentProductType enum knows about; NULL or an unrecognized value
+        # still needs a fetch. Deriving the list here keeps the query in step
+        # with the enum instead of repeating its numeric values.
+        known_product_types = [int(t) for t in ComponentProductType]
+        # The f-string only injects ?-placeholders; the classification values
+        # are bound through `params` below, never interpolated.
+        type_placeholders = ",".join("?" for _ in known_product_types)
         query = (
             "SELECT reference, lcsc FROM part_info "
             "WHERE lcsc IS NOT NULL AND lcsc != '' "
             "AND ("
             "assembly_process IS NULL OR assembly_process = '' "
             "OR component_product_type IS NULL "
-            "OR component_product_type NOT IN (0, 1, 2)"
+            f"OR component_product_type NOT IN ({type_placeholders})"
             ")"
         )
-        params = []
+        params = list(known_product_types)
         if references:
             # The f-string only injects ?-placeholders; the actual reference
             # values are bound through `params` below, never interpolated.


### PR DESCRIPTION
## Summary

Follow-up to the nitpick I left on #804. After that enum refactor, `Store.get_assembly_enrichment_targets()` was the last place still spelling out the numeric classifications:

```python
"OR component_product_type NOT IN (0, 1, 2)"
```

That is the spot most likely to drift — a newly observed classification would need an enum member *and* a hand-edit here, and nothing would fail loudly if you forgot the second one.

- Build the list from `ComponentProductType` instead of repeating its values.
- Bind the values as parameters rather than interpolating them, using the same `?`-placeholder pattern the reference filter directly below already uses. The classification placeholders precede the reference ones in the query text, so their params lead `params`.

Generated query and binds are unchanged in effect:

```
... OR component_product_type NOT IN (?,?,?)) AND reference IN (?,?) ORDER BY lcsc, reference
params: [0, 1, 2, 'R1', 'R2']
```

## Validation

- 455 tests pass; `ruff check` and `ruff format --check` clean on both touched files.
- `test_get_assembly_enrichment_targets_uses_or_logic` already pinned this behavior (classification `0` and `2` count as enriched, `3` and `"bad"` stay targets). It had no row for classification `1`, so I added one — every enum member is now covered.

No behavior change, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)