### PR TITLE
Bind classification to a local in _scan_assembly_state

### DIFF
--- a/bom_estimation/pricing.py
+++ b/bom_estimation/pricing.py
@@ -262,10 +262,10 @@ def _scan_assembly_state(
         tht = is_tht_part(part)
 
         if not exclude_from_pos:
-            if (
-                classify_component_product_type(part.get("component_product_type"))
-                == ComponentProductType.STANDARD_ONLY
-            ):
+            product_type = classify_component_product_type(
+                part.get("component_product_type")
+            )
+            if product_type == ComponentProductType.STANDARD_ONLY:
                 scan.standard_present = True
             scan.populated_part_present = True
             joints = max(0, _safe_int(part.get("pad_count"))) * board_count


### PR DESCRIPTION
## Summary

Follow-up readability nit from the review of #804. Naming the enum member turned the Standard Only check in `bom_estimation/pricing.py` into a four-line parenthesized condition:

```python
if (
    classify_component_product_type(part.get("component_product_type"))
    == ComponentProductType.STANDARD_ONLY
):
```

`bom_widget._get_board_standard_context()` already does the same comparison by binding the classification to a local first, which keeps the call and the comparison on separate lines and reads better:

```python
product_type = classify_component_product_type(
    part.get("component_product_type")
)
if product_type == ComponentProductType.STANDARD_ONLY:
```

This makes the two call sites look alike. Six lines touched in one function.

## Validation

- 455 tests pass; `ruff check` and `ruff format --check` clean on the touched file.

Pure readability; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)