### PR TITLE
Bind clean_database reference parameters

### DIFF
--- a/store.py
+++ b/store.py
@@ -444,10 +444,14 @@ class Store:
 
     def clean_database(self):
         """Delete all parts from the database that are no longer present on the board."""
-        refs = [f"'{fp.GetReference()}'" for fp in get_valid_footprints(self.board)]
+        refs = [fp.GetReference() for fp in get_valid_footprints(self.board)]
         with contextlib.closing(sqlite3.connect(self.dbfile)) as con, con as cur:
+            # The f-string only injects ?-placeholders; the reference text
+            # itself is bound, so quotes in a designator stay literal.
+            placeholders = ",".join("?" for _ in refs)
             cur.execute(
-                f"DELETE FROM part_info WHERE reference NOT IN ({','.join(refs)})"
+                f"DELETE FROM part_info WHERE reference NOT IN ({placeholders})",
+                refs,
             )
             cur.commit()
 

--- a/tests/test_store_clean_database.py
+++ b/tests/test_store_clean_database.py
@@ -1,0 +1,114 @@
+"""Keep board reference text out of the clean_database DELETE statement."""
+
+import logging
+
+import pytest
+
+from .wx_harness import load, package_stubs, wx_stubs
+
+_PACKAGE = "_store_clean_database_tests"
+
+# get_valid_footprints only requires a reference to start with a word
+# character, so quotes reach clean_database untouched.
+QUOTED_REFERENCE = "U1'A"
+
+# sqlite3.execute refuses to chain statements, so the reachable damage is a
+# reference that smuggles an extra entry into the NOT IN keep-list.
+SMUGGLING_REFERENCE = "R1', 'C9"
+
+
+class _Footprint:
+    """Expose the single board accessor clean_database relies on."""
+
+    def __init__(self, reference):
+        self.reference = reference
+
+    def GetReference(self):
+        """Return the board reference designator."""
+        return self.reference
+
+
+class _Board:
+    """Return a fixed set of footprints for reference collection."""
+
+    def __init__(self, references):
+        self.footprints = [_Footprint(reference) for reference in references]
+
+    def GetFootprints(self):
+        """Return every footprint currently on the board."""
+        return self.footprints
+
+
+@pytest.fixture
+def make_store(tmp_path):
+    """Build a Store on real SQLite without the constructor's board sync."""
+    stubs = {**package_stubs(_PACKAGE), **wx_stubs()}
+    store_module = load(_PACKAGE, "store", stubs)
+
+    def _make(board_references, stored_references):
+        store = store_module.Store.__new__(store_module.Store)
+        store.logger = logging.getLogger(_PACKAGE)
+        store.dbfile = str(tmp_path / "project.db")
+        store.board = _Board(board_references)
+        # Constructor defaults that read_all interpolates into its ORDER BY.
+        store.order_by = "reference"
+        store.order_dir = "ASC"
+        store.create_db()
+        for reference in stored_references:
+            store.create_part(
+                {
+                    "reference": reference,
+                    "value": "10k",
+                    "footprint": "R_0603",
+                    "lcsc": "",
+                    "exclude_from_bom": 0,
+                    "exclude_from_pos": 0,
+                }
+            )
+        return store
+
+    return _make
+
+
+def _references(store):
+    """Return the references still recorded in the project database."""
+    return sorted(part["reference"] for part in store.read_all())
+
+
+def test_quoted_reference_survives_cleanup(make_store):
+    """Keep a part whose reference contains a quote and is still on the board."""
+    store = make_store(
+        ["R1", QUOTED_REFERENCE],
+        ["R1", QUOTED_REFERENCE, "C9"],
+    )
+
+    store.clean_database()
+
+    assert _references(store) == sorted(["R1", QUOTED_REFERENCE])
+
+
+def test_quoted_reference_is_removed_once_off_the_board(make_store):
+    """Drop a quoted reference that no longer exists on the board."""
+    store = make_store(["R1"], ["R1", QUOTED_REFERENCE])
+
+    store.clean_database()
+
+    assert _references(store) == ["R1"]
+
+
+def test_reference_text_cannot_extend_the_keep_list(make_store):
+    """Bind reference text so one designator cannot spare unrelated stale parts."""
+    store = make_store([SMUGGLING_REFERENCE], [SMUGGLING_REFERENCE, "C9"])
+
+    store.clean_database()
+
+    assert _references(store) == [SMUGGLING_REFERENCE]
+
+
+def test_empty_board_clears_every_stored_reference(make_store):
+    """Keep the empty keep-list working, which SQLite accepts as `NOT IN ()`."""
+    store = make_store([], ["R1", "C9"])
+
+    store.clean_database()
+
+    assert _references(store) == []


### PR DESCRIPTION
`clean_database` built its `DELETE` by f-string-interpolating board reference designators into single-quoted SQL literals. `get_valid_footprints` uses an unanchored `re.match(r"[\w\d-]+", ...)`, so a reference only has to *start* with a word character — a quote passes straight through.

**Scope note:** this originally also parameterized the three correction-table queries. Those are dropped — #816 parameterizes all three and adds finite-value validation for offsets, so it owns that code. Keeping both would have conflicted in `library.py` and on `tests/test_library_corrections.py`. This PR is now `store.py` only and does not touch `library.py`.

### The defect

An apostrophe in a designator breaks the statement. `clean_database` runs from `Store.__init__`, so it raises before the plugin window can open, with nothing in the UI to explain why. Reproduced on `main`:

```
sqlite3.OperationalError: near "A": syntax error
```

Short of a syntax error, a crafted designator silently widens the keep-list. `sqlite3.execute` refuses to chain statements, so this is wrong results rather than arbitrary SQL: a reference like `R1', 'C9` smuggles an extra entry into the `NOT IN` list, sparing an unrelated stale part while deleting the live one.

### The fix

Build only `?`-placeholders into the f-string and bind the references, matching the existing approach in `get_assembly_enrichment_targets`.

**Empty board unchanged.** `",".join` produces an empty list either way, so the statement is byte-identical to before, and SQLite accepts `NOT IN ()` as an extension. There is now a regression test pinning that, per review feedback.

**Variable limit.** Bound parameters trade `SQLITE_MAX_SQL_LENGTH` for `SQLITE_LIMIT_VARIABLE_NUMBER`, one per footprint. That is 32766 on SQLite ≥ 3.32; KiCad's bundled Python 3.9.13 ships SQLite 3.37.2, so it would take a 32,767-footprint board to reach. Not chunking, but recording the reasoning.

### Tests

Four tests on real SQLite, no mocking of the code under test. Two fail on `main` (quoted designator, keep-list widening); the quoted-removal and empty-board cases are guards that pass on both.

```
python -m pytest -q          486 passed
ruff check .                 clean on the changed files
```

`ruff format --check` is clean on both changed files. Rebased onto current `main`.

Not covered: no KiCad-in-the-loop run, so whether KiCad's own reference-field validation permits an apostrophe in a designator is untested — only that the plugin's filter lets one through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
