### PR TITLE
feat(lcsc): an Lcsc value type

### DIFF
--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -80,6 +80,31 @@ A matched correction of zero degrees and zero offset still takes precedence
 over lower-priority rules. The table labels the match source as `(ref)`, `(val)`,
 or `(fpt)`.
 
+## Corrections for one LCSC part
+
+The package JLC assembles belongs to the part number, not to the name KiCad
+gives the footprint, so two parts that share a footprint name can still need
+different rotations. No pattern over reference, value or footprint text can
+tell them apart. A correction keyed on the exact LCSC part number can.
+
+Tick `LCSC part, matched exactly` in the manager, or use `Add Correction by
+LCSC` on a part in the parts list, and enter a plain part number such as
+`C12345` rather than a pattern. The number is stored in canonical form (trimmed,
+upper case) and looked up the same way, so `c12345` finds the rule saved for
+`C12345`. A value that is not a bare part number is rejected, since an
+exact-match key that never matches is worse than a refused one.
+
+A part-number rule takes precedence over reference, value and footprint rules.
+A part-number rule of zero degrees and zero offset switches those rules off for
+that one part, which suits footprints that already arrive fab-oriented. The
+table labels the match source as `(lcsc)`. The part number used is the one
+assigned in the parts list, which is also what the BOM orders.
+
+Part-number rules are stored beside pattern rules in the same database, follow
+the same global or project scope, and are validated and repaired the same way;
+the manager lists both with their `Kind`. CSV import and export carry pattern
+rules only; an export says how many part-number rules it left out.
+
 ## Legacy data and database scope
 
 Existing patterns in the current correction database take precedence over

--- a/correction_data.py
+++ b/correction_data.py
@@ -1,13 +1,15 @@
 """Validate correction values and CSV files without GUI or database dependencies."""
 
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 import csv
 from dataclasses import dataclass, field, replace
 from decimal import Decimal, InvalidOperation
 from io import StringIO
 import math
 import re
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
+
+from .lcsc import normalize_lcsc
 
 _MIN_ROTATION = -(2**63)
 _MAX_ROTATION = 2**63 - 1
@@ -53,6 +55,11 @@ class Correction:
         except CorrectionDataError:
             return None
 
+    @property
+    def key(self) -> str:
+        """Return the text this rule is stored and listed under."""
+        return self.pattern
+
     def db_row(self) -> tuple[str, int, float, float]:
         """Return native SQLite values in the correction table column order."""
         return self.pattern, self.rotation, self.offset[0], self.offset[1]
@@ -75,31 +82,131 @@ class Correction:
         return f"{self.rotation}°, {self.offset[0]}/{self.offset[1]}"
 
 
+KIND_FOOTPRINT: Literal["footprint"] = "footprint"
+KIND_LCSC: Literal["lcsc"] = "lcsc"
+CorrectionKind = Literal["footprint", "lcsc"]
+
+_LCSC_PART = re.compile(r"C[0-9]+")
+
+
+def _lcsc_key(value: object) -> str:
+    """Return the canonical part number, rejecting anything that is not one."""
+    if isinstance(value, bool) or not isinstance(value, str):
+        raise TypeError("expected an LCSC part number")
+    key = normalize_lcsc(value)
+    if not _LCSC_PART.fullmatch(key):
+        raise ValueError("expected an LCSC part number")
+    return key
+
+
+@dataclass(frozen=True, init=False)
+class LcscCorrection:
+    """A validated correction for exactly one LCSC part number.
+
+    The package JLC assembles belongs to the part number, not to the name KiCad
+    gives the footprint, so two parts on one footprint name can need different
+    rotations. No pattern over reference, value or footprint text can tell them
+    apart; an exact per-part key can. The key is stored and compared in the
+    canonical form from ``normalize_lcsc``.
+    """
+
+    lcsc: str
+    rotation: int
+    offset: tuple[float, float]
+
+    def __init__(self, lcsc: object, rotation: object, offset: object) -> None:
+        """Enforce the value contract at every construction or replacement."""
+        lcsc, rotation, offset = _validated_lcsc_values(lcsc, rotation, offset)
+        object.__setattr__(self, "lcsc", lcsc)
+        object.__setattr__(self, "rotation", rotation)
+        object.__setattr__(self, "offset", offset)
+
+    @classmethod
+    def parse(
+        cls, lcsc: object, rotation: object, offset: object
+    ) -> Optional["LcscCorrection"]:  # noqa: UP045
+        """Return a normalized correction, or None for invalid input values."""
+        try:
+            return cls(lcsc, rotation, offset)
+        except CorrectionDataError:
+            return None
+
+    @property
+    def key(self) -> str:
+        """Return the text this rule is stored and listed under."""
+        return self.lcsc
+
+    def db_row(self) -> tuple[str, int, float, float]:
+        """Return native SQLite values in the lcsc_correction column order."""
+        return self.lcsc, self.rotation, self.offset[0], self.offset[1]
+
+    def editor_values(self) -> tuple[str, str, str, str]:
+        """Return lossless text for the part number, rotation and two offsets."""
+        return (
+            self.lcsc,
+            str(self.rotation),
+            str(self.offset[0]),
+            str(self.offset[1]),
+        )
+
+    def __str__(self) -> str:
+        """Format the correction consistently for display without rounding."""
+        return f"{self.rotation}°, {self.offset[0]}/{self.offset[1]}"
+
+
+AnyCorrection = Union[Correction, LcscCorrection]
+
+
+def correction_kind(correction: AnyCorrection) -> CorrectionKind:
+    """Name the table a validated correction belongs to."""
+    return KIND_LCSC if isinstance(correction, LcscCorrection) else KIND_FOOTPRINT
+
+
 @dataclass(frozen=True)
 class CorrectionMatch:
-    """A selected correction and the footprint field that matched it."""
+    """A selected correction and the part field that matched it."""
 
-    correction: Correction
-    source: Literal["ref", "val", "fpt"]
+    correction: AnyCorrection
+    source: Literal["lcsc", "ref", "val", "fpt"]
 
 
 def find_correction(
-    corrections: Sequence[Correction], value: str
+    corrections: Sequence[AnyCorrection], value: str
 ) -> Optional[Correction]:  # noqa: UP045
-    """Prefer a suffix match, then the first unanchored match in input order."""
+    """Prefer a suffix match, then the first unanchored match in input order.
+
+    Part-number rules carry no pattern and are skipped here; match_correction
+    resolves them by exact key before any pattern is tried.
+    """
     for correction in corrections:
-        if correction._suffix_regex.search(value):
+        if isinstance(correction, Correction) and correction._suffix_regex.search(
+            value
+        ):
             return correction
     for correction in corrections:
-        if correction._regex.search(value):
+        if isinstance(correction, Correction) and correction._regex.search(value):
             return correction
     return None
 
 
 def match_correction(
-    corrections: Sequence[Correction], reference: str, value: str, footprint: str
+    corrections: Sequence[AnyCorrection],
+    reference: str,
+    value: str,
+    footprint: str,
+    lcsc: object = "",
 ) -> Optional[CorrectionMatch]:  # noqa: UP045
-    """Resolve reference, then value, then footprint using one matching policy."""
+    """Resolve the exact part number, then reference, value and footprint.
+
+    A rule for the part itself outranks every pattern, including a rule of zero
+    degrees and zero offset, which switches a family correction off for that
+    one part.
+    """
+    key = normalize_lcsc(lcsc)
+    if key:
+        for correction in corrections:
+            if isinstance(correction, LcscCorrection) and correction.lcsc == key:
+                return CorrectionMatch(correction, "lcsc")
     targets: tuple[tuple[Literal["ref", "val", "fpt"], str], ...] = (
         ("ref", reference),
         ("val", value),
@@ -178,6 +285,32 @@ def _offset(value: object) -> float:
     return number
 
 
+def _validated_numbers(
+    rotation: object, offset: object, issue: Callable[[str, object, str], None]
+) -> tuple[Optional[int], list[float]]:  # noqa: UP045
+    """Validate the rotation and both offsets, reporting every problem found."""
+    validated_rotation = None
+    try:
+        validated_rotation = _rotation(rotation)
+    except (TypeError, ValueError, InvalidOperation, OverflowError):
+        issue(
+            "rotation",
+            rotation,
+            f"expected finite whole degrees between {_MIN_ROTATION} and {_MAX_ROTATION}",
+        )
+
+    validated_offsets = []
+    if not isinstance(offset, (tuple, list)) or len(offset) != 2:
+        issue("offset", offset, "expected exactly two offsets (X and Y)")
+    else:
+        for field, value in zip(("offset_x", "offset_y"), offset):
+            try:
+                validated_offsets.append(_offset(value))
+            except (TypeError, ValueError, OverflowError):
+                issue(field, value, "expected a finite numeric offset")
+    return validated_rotation, validated_offsets
+
+
 def _validated_values(
     pattern: object, rotation: object, offset: object
 ) -> tuple[str, int, tuple[float, float], re.Pattern[str], re.Pattern[str]]:
@@ -210,25 +343,7 @@ def _validated_values(
         except (re.error, OverflowError, RecursionError) as error:
             issue("pattern", pattern, f"invalid correction regular expression: {error}")
 
-    validated_rotation = None
-    try:
-        validated_rotation = _rotation(rotation)
-    except (TypeError, ValueError, InvalidOperation, OverflowError):
-        issue(
-            "rotation",
-            rotation,
-            f"expected finite whole degrees between {_MIN_ROTATION} and {_MAX_ROTATION}",
-        )
-
-    validated_offsets = []
-    if not isinstance(offset, (tuple, list)) or len(offset) != 2:
-        issue("offset", offset, "expected exactly two offsets (X and Y)")
-    else:
-        for field, value in zip(("offset_x", "offset_y"), offset):
-            try:
-                validated_offsets.append(_offset(value))
-            except (TypeError, ValueError, OverflowError):
-                issue(field, value, "expected a finite numeric offset")
+    validated_rotation, validated_offsets = _validated_numbers(rotation, offset, issue)
 
     if issues:
         raise CorrectionDataError(issues)
@@ -258,6 +373,53 @@ def validate_correction(
     """Construct a correction and attach source locations to field errors."""
     try:
         return Correction(pattern, rotation, offset)
+    except CorrectionDataError as error:
+        raise CorrectionDataError(
+            replace(issue, source=source, line=line, rowid=rowid)
+            for issue in error.issues
+        ) from error
+
+
+def _validated_lcsc_values(
+    lcsc: object, rotation: object, offset: object
+) -> tuple[str, int, tuple[float, float]]:
+    """Validate a part-number rule once and return normalized constructor values.
+
+    The part number is reduced to its canonical form and must be a bare
+    number such as C12345: an exact-match key that is really a pattern would
+    silently never fire. Rotation and offsets follow the pattern rules.
+    """
+    issues = []
+
+    def issue(field: str, value: object, message: str) -> None:
+        issues.append(CorrectionIssue(field, value, message))
+
+    key = None
+    try:
+        key = _lcsc_key(lcsc)
+    except (TypeError, ValueError):
+        issue("lcsc", lcsc, "expected an LCSC part number such as C12345")
+    validated_rotation, validated_offsets = _validated_numbers(rotation, offset, issue)
+
+    if issues:
+        raise CorrectionDataError(issues)
+    assert key is not None
+    assert validated_rotation is not None
+    return key, validated_rotation, (validated_offsets[0], validated_offsets[1])
+
+
+def validate_lcsc_correction(
+    lcsc: object,
+    rotation: object,
+    offset: object,
+    *,
+    source: str = "",
+    line: Optional[int] = None,  # noqa: UP045
+    rowid: Optional[int] = None,  # noqa: UP045
+) -> LcscCorrection:
+    """Construct a part-number correction and attach source locations to errors."""
+    try:
+        return LcscCorrection(lcsc, rotation, offset)
     except CorrectionDataError as error:
         raise CorrectionDataError(
             replace(issue, source=source, line=line, rowid=rowid)

--- a/correction_data.py
+++ b/correction_data.py
@@ -9,7 +9,7 @@ import math
 import re
 from typing import Literal, Optional, Union
 
-from .lcsc import normalize_lcsc
+from .lcsc import is_lcsc_part, normalize_lcsc
 
 _MIN_ROTATION = -(2**63)
 _MAX_ROTATION = 2**63 - 1
@@ -86,17 +86,14 @@ KIND_FOOTPRINT: Literal["footprint"] = "footprint"
 KIND_LCSC: Literal["lcsc"] = "lcsc"
 CorrectionKind = Literal["footprint", "lcsc"]
 
-_LCSC_PART = re.compile(r"C[0-9]+")
-
 
 def _lcsc_key(value: object) -> str:
     """Return the canonical part number, rejecting anything that is not one."""
     if isinstance(value, bool) or not isinstance(value, str):
         raise TypeError("expected an LCSC part number")
-    key = normalize_lcsc(value)
-    if not _LCSC_PART.fullmatch(key):
+    if not is_lcsc_part(value):
         raise ValueError("expected an LCSC part number")
-    return key
+    return normalize_lcsc(value)
 
 
 @dataclass(frozen=True, init=False)

--- a/corrections.py
+++ b/corrections.py
@@ -12,22 +12,30 @@ import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
 
 from .correction_data import (
+    KIND_FOOTPRINT,
+    KIND_LCSC,
+    AnyCorrection,
     Correction,
     CorrectionDataError,
+    correction_kind,
     parse_corrections_csv,
     validate_correction,
+    validate_lcsc_correction,
 )
 from .events import PopulateFootprintListEvent
 from .helpers import PLUGIN_PATH, HighResWxSize, loadBitmapScaled
+from .lcsc import normalize_lcsc
 
 if TYPE_CHECKING:
     from .library import StoredCorrection
+
+_KIND_LABELS = {KIND_FOOTPRINT: "Footprint", KIND_LCSC: "LCSC"}
 
 
 class CorrectionManagerDialog(wx.Dialog):
     """Dialog for managing part corrections."""
 
-    def __init__(self, parent: Any, footprint: str) -> None:
+    def __init__(self, parent: Any, footprint: str, lcsc_part: str = "") -> None:
         wx.Dialog.__init__(
             self,
             parent,
@@ -70,15 +78,28 @@ class CorrectionManagerDialog(wx.Dialog):
         self.regex = wx.TextCtrl(
             self,
             wx.ID_ANY,
-            footprint,
+            lcsc_part or footprint,
             wx.DefaultPosition,
             HighResWxSize(parent.window, wx.Size(200, 24)),
+        )
+        self.lcsc_mode = wx.CheckBox(self, wx.ID_ANY, "LCSC part, matched exactly")
+        self.lcsc_mode.SetValue(bool(lcsc_part))
+        self.lcsc_mode.SetToolTip(
+            "Correct one LCSC part number instead of every footprint matching "
+            "a pattern. Use this when two parts share a footprint name but JLC "
+            "assembles them in different orientations."
         )
 
         sizer_regex = wx.BoxSizer(wx.VERTICAL)
         sizer_regex.Add(regex_label, 0, wx.ALL, 5)
         sizer_regex.Add(
             self.regex,
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM,
+            5,
+        )
+        sizer_regex.Add(
+            self.lcsc_mode,
             0,
             wx.LEFT | wx.RIGHT | wx.BOTTOM,
             5,
@@ -205,6 +226,12 @@ class CorrectionManagerDialog(wx.Dialog):
             "Status",
             mode=wx.dataview.DATAVIEW_CELL_INERT,
             width=int(parent.scale_factor * 280),
+            align=wx.ALIGN_LEFT,
+        )
+        self.corrections_list.AppendTextColumn(
+            "Kind",
+            mode=wx.dataview.DATAVIEW_CELL_INERT,
+            width=int(parent.scale_factor * 100),
             align=wx.ALIGN_LEFT,
         )
         self.correction_status = wx.StaticText(self, wx.ID_ANY, "")
@@ -416,19 +443,58 @@ class CorrectionManagerDialog(wx.Dialog):
             self._record_editor_values(record),
         ):
             control.SetValue(value)
+        self.lcsc_mode.SetValue(record.kind == KIND_LCSC)
+
+    def _current_kind(self) -> str:
+        """Name the table the add/edit form is describing a rule for."""
+        return KIND_LCSC if self.lcsc_mode.GetValue() else KIND_FOOTPRINT
+
+    def _validated_input(
+        self, kind: str, target: str, rowid: int | None
+    ) -> AnyCorrection:
+        """Validate the editor text as a rule of the given kind."""
+        validate = (
+            validate_lcsc_correction if kind == KIND_LCSC else validate_correction
+        )
+        return validate(
+            self.regex.GetValue(),
+            self.rotation.GetValue(),
+            (self.offset_x.GetValue(), self.offset_y.GetValue()),
+            source=target,
+            rowid=rowid,
+        )
+
+    @staticmethod
+    def _same_key(row: StoredCorrection, correction: AnyCorrection) -> bool:
+        """Compare a stored row's key the way its own kind compares keys."""
+        if row.kind != correction_kind(correction) or not isinstance(row.pattern, str):
+            return False
+        if row.kind == KIND_LCSC:
+            return normalize_lcsc(row.pattern) == correction.key
+        return row.pattern == correction.key
 
     def populate_corrections_list(
-        self, *, selected_rowid: int | None = None, preserve_inputs: bool = False
+        self,
+        *,
+        selected: tuple[str, int] | None = None,
+        preserve_inputs: bool = False,
     ) -> None:
-        """Refresh rows without granting stale unsaved edits a newer record identity."""
+        """Refresh rows without granting stale unsaved edits a newer record identity.
+
+        ``selected`` names a row as (kind, rowid): rowids repeat across the
+        two rule tables, so a rowid alone cannot identify one.
+        """
         snapshot = self.parent.library.read_correction_data()
         preserve_inputs = preserve_inputs or (
-            selected_rowid is None
+            selected is None
             and self.selected_record is not None
-            and self._input_values() != self._record_editor_values(self.selected_record)
+            and (
+                self._input_values() != self._record_editor_values(self.selected_record)
+                or self._current_kind() != self.selected_record.kind
+            )
         )
-        if selected_rowid is None and self.selected_record is not None:
-            selected_rowid = self.selected_record.rowid
+        if selected is None and self.selected_record is not None:
+            selected = (self.selected_record.kind, self.selected_record.rowid)
         self._populating = True
         try:
             self.corrections_list.DeleteAllItems()
@@ -440,9 +506,10 @@ class CorrectionManagerDialog(wx.Dialog):
                         "; ".join(
                             f"{issue.field}: {issue.message}" for issue in record.issues
                         ),
+                        _KIND_LABELS[record.kind],
                     ]
                 )
-                if record.rowid == selected_rowid and (
+                if (record.kind, record.rowid) == selected and (
                     self.selected_record is None
                     or self.selection_db_path == snapshot.db_path
                 ):
@@ -499,11 +566,11 @@ class CorrectionManagerDialog(wx.Dialog):
         ) == os.path.realpath(self.parent.library.correctionsdb_file)
 
     def _confirm_replacement(
-        self, correction: Correction, conflicts: Sequence[StoredCorrection]
+        self, correction: AnyCorrection, conflicts: Sequence[StoredCorrection]
     ) -> bool:
-        """Ask before atomically replacing other records with the same pattern."""
+        """Ask before atomically replacing other records with the same key."""
         existing = "\n".join(
-            f"Row {row.rowid}: "
+            f"Row {row.rowid} ({_KIND_LABELS[row.kind]}): "
             + (
                 str(row.correction)
                 if row.correction is not None
@@ -513,18 +580,23 @@ class CorrectionManagerDialog(wx.Dialog):
         )
         dialog = wx.MessageDialog(
             self,
-            f"A rule for '{correction.pattern}' already exists!",
-            "Regex exists!",
+            f"A rule for '{correction.key}' already exists!",
+            "Part number exists!"
+            if correction_kind(correction) == KIND_LCSC
+            else "Regex exists!",
             wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
         )
         dialog.ExtendedMessage = (
             f"{existing}\n\nReplace these {len(conflicts)} existing entries with "
             f"{correction}?"
         )
-        if self.selected_record is not None:
+        selected = self.selected_record
+        # A selection of the other kind is not being edited: the save is an
+        # insert and that row stays as it is, so do not promise otherwise.
+        if selected is not None and selected.kind == correction_kind(correction):
             dialog.ExtendedMessage += (
-                f"\nThe selected row {self.selected_record.rowid} will become "
-                f"'{correction.pattern}'."
+                f"\nThe selected row {selected.rowid} ({_KIND_LABELS[selected.kind]}) "
+                f"will become '{correction.key}'."
             )
         try:
             return dialog.ShowModal() == wx.ID_YES
@@ -542,27 +614,27 @@ class CorrectionManagerDialog(wx.Dialog):
             return False
         library = self.parent.library
         target = str(library.correctionsdb_file)
-        rowid = self.selected_record.rowid if self.selected_record else None
+        kind = self._current_kind()
+        selected = self.selected_record
+        if selected is not None and selected.kind != kind:
+            # Switching kind describes a new rule. It is not an edit of the
+            # selected one, so that row stays exactly as it is.
+            selected = None
+        rowid = selected.rowid if selected else None
         try:
-            correction = validate_correction(
-                self.regex.GetValue(),
-                self.rotation.GetValue(),
-                (self.offset_x.GetValue(), self.offset_y.GetValue()),
-                source=target,
-                rowid=rowid,
-            )
+            correction = self._validated_input(kind, target, rowid)
             snapshot = library.read_correction_data(target)
             conflicts = [
                 row
                 for row in snapshot.rows
-                if row.pattern == correction.pattern and row.rowid != rowid
+                if row.rowid != rowid and self._same_key(row, correction)
             ]
             if (
-                self.selected_record is None
+                selected is None
                 and len(conflicts) == 1
                 and conflicts[0].correction == correction
             ):
-                self.populate_corrections_list(selected_rowid=conflicts[0].rowid)
+                self.populate_corrections_list(selected=(kind, conflicts[0].rowid))
                 return True
             if conflicts and not self._confirm_replacement(correction, conflicts):
                 return False
@@ -571,7 +643,7 @@ class CorrectionManagerDialog(wx.Dialog):
                 rowid=rowid,
                 replace=bool(conflicts),
                 db_path=target,
-                expected_record=self.selected_record,
+                expected_record=selected,
                 expected_conflicts=conflicts,
             )
         except CorrectionDataError as error:
@@ -579,7 +651,7 @@ class CorrectionManagerDialog(wx.Dialog):
             self.populate_corrections_list(preserve_inputs=True)
             return False
 
-        self.populate_corrections_list(selected_rowid=rowid)
+        self.populate_corrections_list(selected=(kind, rowid))
         wx.PostEvent(self.parent, PopulateFootprintListEvent())
         return True
 
@@ -790,9 +862,24 @@ class CorrectionManagerDialog(wx.Dialog):
             with open(path, "w", newline="", encoding="utf-8") as destination:
                 writer = csv.writer(destination, quotechar='"', quoting=csv.QUOTE_ALL)
                 writer.writerow(["Pattern", "Rotation", "Offset X", "Offset Y"])
+                # The format is seeded from JLCKicadTools upstream and has no
+                # part-number field, so the file carries pattern rules only.
                 for correction in corrections:
-                    writer.writerow(correction.csv_row())
+                    if isinstance(correction, Correction):
+                        writer.writerow(correction.csv_row())
         except (OSError, UnicodeError, CorrectionDataError) as error:
             self._show_error("Correction Export Error", f"{path}: {error}")
             return False
+        left_out = sum(
+            1 for correction in corrections if not isinstance(correction, Correction)
+        )
+        if left_out:
+            # Say so, or a backup-and-reimport would lose them without a word.
+            wx.MessageBox(
+                f"{left_out} LCSC part-number rule(s) were not exported: the CSV "
+                "format carries pattern rules only. They stay in the database.",
+                "Correction Export",
+                wx.OK | wx.ICON_INFORMATION,
+                self,
+            )
         return True

--- a/datamodel.py
+++ b/datamodel.py
@@ -320,6 +320,14 @@ class PartListDataModel(dv.PyDataViewModel):
         self.standard_only_refs.discard(ref)
         self.ItemChanged(self.ObjectToItem(item))
 
+    def set_correction(self, ref, correction):
+        """Show the correction rule now selected for the given reference."""
+        if (index := self.find_index(ref)) is None:
+            return
+        item = self.data[index]
+        item[self.columns["ROT_COL"]] = correction
+        self.ItemChanged(self.ObjectToItem(item))
+
     def set_bom_price(self, ref, price_label):
         """Set BOM price text for a given part reference."""
         if (index := self.find_index(ref)) is None:

--- a/fabrication.py
+++ b/fabrication.py
@@ -33,7 +33,12 @@ from pcbnew import (  # pylint: disable=import-error
     wxPoint,
 )
 
-from .correction_data import Correction, CorrectionMatch, match_correction
+from .correction_data import (
+    Correction,
+    CorrectionMatch,
+    LcscCorrection,
+    match_correction,
+)
 from .footprint_helpers import get_is_dnp
 
 # Compatibility hack for V6 / V7 / V7.99
@@ -158,19 +163,28 @@ class Fabrication:
                 empty_pours.append(f"{zone.GetNetname() or 'no net'} on {name}")
         return empty_pours
 
-    def _correction_for_footprint(self, footprint: Any) -> Optional[CorrectionMatch]:  # noqa: UP045
-        """Select the same reference, value, or package rule as the parts table."""
+    def _correction_for_footprint(
+        self, footprint: Any, lcsc: str = ""
+    ) -> Optional[CorrectionMatch]:  # noqa: UP045
+        """Select the same part, reference, value or package rule as the parts table.
+
+        The part number is the store's, which is what the BOM orders and the
+        parts list shows. The footprint's own LCSC field is not consulted: it
+        only seeds the store when the board is read, and a field the store has
+        since moved past would rotate one part while the BOM ordered another.
+        """
         return match_correction(
             self.corrections,
             str(footprint.GetReference()),
             str(footprint.GetValue()),
             str(footprint.GetFPID().GetLibItemName()),
+            lcsc,
         )
 
-    def fix_rotation(self, footprint: Any) -> float:
+    def fix_rotation(self, footprint: Any, lcsc: str = "") -> float:
         """Fix the rotation of footprints in order to be correct for JLCPCB."""
         return self._rotation_for_match(
-            footprint, self._correction_for_footprint(footprint)
+            footprint, self._correction_for_footprint(footprint, lcsc)
         )
 
     def _rotation_for_match(
@@ -233,10 +247,10 @@ class Fabrication:
             return _checked_position(position.x + offset_x, position.y + offset_y)
         return position
 
-    def fix_position(self, footprint: Any, position: Any) -> Any:
+    def fix_position(self, footprint: Any, position: Any, lcsc: str = "") -> Any:
         """Apply the offset from the same selected rule used for rotation."""
         return self._position_for_match(
-            footprint, position, self._correction_for_footprint(footprint)
+            footprint, position, self._correction_for_footprint(footprint, lcsc)
         )
 
     def _position_for_match(
@@ -450,9 +464,12 @@ class Fabrication:
                     "to repair or retry loading before generating fabrication files."
                 )
         if not isinstance(corrections, tuple) or any(
-            not isinstance(correction, Correction) for correction in corrections
+            not isinstance(correction, (Correction, LcscCorrection))
+            for correction in corrections
         ):
-            raise TypeError("Expected an immutable tuple of Correction values")
+            raise TypeError(
+                "Expected an immutable tuple of Correction or LcscCorrection values"
+            )
         self.corrections = corrections
         aux_origin = self.board.GetDesignSettings().GetAuxOrigin()
         add_without_lcsc = self.parent.settings.get("gerber", {}).get(
@@ -472,7 +489,7 @@ class Fabrication:
                 continue
             if not add_without_lcsc and not part["lcsc"]:
                 continue
-            match = self._correction_for_footprint(fp)
+            match = self._correction_for_footprint(fp, part["lcsc"])
             try:
                 center = self.get_position(fp)
                 # Subtract in Python, before native coordinate arithmetic can wrap.
@@ -498,9 +515,7 @@ class Fabrication:
                 )
             except (OverflowError, ValueError) as error:
                 source = (
-                    f"correction {match.correction.pattern!r}"
-                    if match
-                    else "no correction"
+                    f"correction {match.correction.key!r}" if match else "no correction"
                 )
                 raise ValueError(
                     f"Cannot generate CPL for {fp.GetReference()} ({source}): {error}"

--- a/footprint_helpers.py
+++ b/footprint_helpers.py
@@ -3,8 +3,35 @@
 import re
 from typing import Any, Optional
 
+from .lcsc import is_lcsc_part, normalize_lcsc
+
 EXCLUDE_FROM_POS = 2
 EXCLUDE_FROM_BOM = 3
+
+
+def _iter_assignment_fields(fp: Any):
+    """Yield (name, text) for every field, whichever KiCad API the board has."""
+    try:
+        return ((field.GetName(), field.GetText()) for field in fp.GetFields())
+    except AttributeError:
+        return iter(fp.GetProperties().items())
+
+
+def _is_assignment_alias(name: str) -> bool:
+    """Report whether a field name is one of the LCSC assignment aliases."""
+    return bool(re.match(r"lcsc|jlc", name, re.IGNORECASE))
+
+
+def _claims_the_part(name: str, text: str) -> bool:
+    """Report whether an alias field is claiming to hold the part number.
+
+    The canonical ``LCSC`` field claims it whatever it holds, because that is
+    the one the plugin writes when nothing else is there. Any other alias
+    claims it once its text names a part -- tested through the same normalised
+    predicate the reader uses, so a field typed as `` c12345 `` is recognised
+    as the claim it is rather than left behind as a stale duplicate.
+    """
+    return _is_assignment_alias(name) and (name.lower() == "lcsc" or is_lcsc_part(text))
 
 
 def find_lcsc_assignment_text(fp: Any) -> Optional[tuple[str, str]]:
@@ -13,28 +40,22 @@ def find_lcsc_assignment_text(fp: Any) -> Optional[tuple[str, str]]:
     Any text occupies the field, including whitespace or an identifier the
     legacy reader does not recognize. Inspect every alias before filling.
     """
-    try:
-        fields = ((field.GetName(), field.GetText()) for field in fp.GetFields())
-    except AttributeError:
-        fields = iter(fp.GetProperties().items())
-    for name, text in fields:
-        if re.match(r"lcsc|jlc", name, re.IGNORECASE) and text != "":
+    for name, text in _iter_assignment_fields(fp):
+        if _is_assignment_alias(name) and text != "":
             return name, text
     return None
 
 
 def get_lcsc_value(fp):
-    """Get the first lcsc number (C123456 for example) from the properties of the footprint."""
-    try:
-        for field in fp.GetFields():
-            if re.match(r"lcsc|jlc", field.GetName(), re.IGNORECASE) and re.match(
-                r"^C\d+$", field.GetText()
-            ):
-                return field.GetText()
-    except AttributeError:
-        for key, value in fp.GetProperties().items():
-            if re.match(r"lcsc|jlc", key, re.IGNORECASE) and re.match(r"^C\d+$", value):
-                return value
+    """Get the first lcsc number (C123456 for example) from the properties of the footprint.
+
+    The text is normalised before it is tested, so a field holding ``C12345 ``
+    or ``c12345`` names the part it looks like instead of reading as blank
+    (issue #773), and the canonical form is what the caller gets back.
+    """
+    for name, text in _iter_assignment_fields(fp):
+        if _is_assignment_alias(name) and is_lcsc_part(text):
+            return normalize_lcsc(text)
     return ""
 
 
@@ -42,14 +63,11 @@ def set_lcsc_value(fp: Any, lcsc: str) -> None:
     """Keep existing assignment aliases consistent, or create a hidden LCSC field."""
     if not fp:
         return
+    lcsc = normalize_lcsc(lcsc)
     names = [
         field.GetName()
         for field in fp.GetFields()
-        if re.match(r"lcsc|jlc", field.GetName(), re.IGNORECASE)
-        and (
-            field.GetName().lower() == "lcsc"
-            or re.fullmatch(r"C[0-9]+", field.GetText().strip(), re.IGNORECASE)
-        )
+        if _claims_the_part(field.GetName(), field.GetText())
     ]
     if names:
         for name in names:

--- a/lcsc.py
+++ b/lcsc.py
@@ -2,6 +2,13 @@
 
 import re
 
+# No anchors, so the same pattern answers both questions below: matched in
+# full for "is this a part number", searched for in "is there one in this
+# text". The digits are spelled out as [0-9] rather than \d because \d also
+# admits digits from other scripts, which LCSC does not issue and which the
+# part-preference validator this module absorbs has always rejected.
+_PART_NUMBER = re.compile(r"C[0-9]+")
+
 
 def normalize_lcsc(value):
     """Return an LCSC part number in canonical form for keying and comparison.
@@ -26,5 +33,32 @@ def is_lcsc_part(value):
     Testing raw text against a bare C-plus-digits pattern rejects exactly the
     values issue #773 is about, so the test belongs beside the normaliser and
     every caller gets the same answer.
+
+    It is strict on purpose: the value has to be a part number and nothing
+    else. Text that merely contains one is :func:`extract_lcsc`'s business.
     """
-    return bool(re.fullmatch(r"C\d+", normalize_lcsc(value)))
+    return bool(_PART_NUMBER.fullmatch(normalize_lcsc(value)))
+
+
+def extract_lcsc(text):
+    """Return the first LCSC part number appearing anywhere in text.
+
+    This reads what a person pasted, so it is lenient where
+    :func:`is_lcsc_part` is strict: a number copied out of a web page or a
+    parts table arrives surrounded by whatever came with it, and the number is
+    still the point. A schematic field claiming to be a part number gets no
+    such benefit of the doubt, which is why the two are separate functions
+    rather than one with a flag.
+
+    It takes the first C-plus-digits run it finds, so text that leads with a
+    capacitor designator (a parts-table row beginning with C1, say) yields
+    the designator rather than the part. No real LCSC number has fewer than
+    four digits, but shorter values are accepted everywhere else in the
+    plugin and by the tests over this path, so no floor is applied here.
+
+    The result is canonical, so what is pasted and what is stored agree.
+    """
+    if not text:
+        return ""
+    match = _PART_NUMBER.search(str(text).upper())
+    return match.group(0) if match else ""

--- a/lcsc.py
+++ b/lcsc.py
@@ -1,0 +1,16 @@
+"""Canonical handling of LCSC part numbers."""
+
+
+def normalize_lcsc(value):
+    """Return an LCSC part number in canonical form for keying and comparison.
+
+    Part numbers reach the plugin from a footprint field, a pasted clipboard
+    string, the parts database and saved part preferences. The current entry
+    points canonicalise what they accept, but a project database written by an
+    earlier release can still hold a number as it was typed then, and nothing
+    rewrites stored rows. Corrections are keyed exactly, so every key and every
+    lookup passes through here or a rule silently never fires.
+    """
+    if not value:
+        return ""
+    return str(value).strip().upper()

--- a/lcsc.py
+++ b/lcsc.py
@@ -1,5 +1,7 @@
 """Canonical handling of LCSC part numbers."""
 
+import re
+
 
 def normalize_lcsc(value):
     """Return an LCSC part number in canonical form for keying and comparison.
@@ -14,3 +16,15 @@ def normalize_lcsc(value):
     if not value:
         return ""
     return str(value).strip().upper()
+
+
+def is_lcsc_part(value):
+    """Report whether a value names an LCSC part number.
+
+    The value is normalised first, so a number typed into a schematic field
+    with a stray space or in lower case still reads as the part it names.
+    Testing raw text against a bare C-plus-digits pattern rejects exactly the
+    values issue #773 is about, so the test belongs beside the normaliser and
+    every caller gets the same answer.
+    """
+    return bool(re.fullmatch(r"C\d+", normalize_lcsc(value)))

--- a/lcsc.py
+++ b/lcsc.py
@@ -1,6 +1,19 @@
-"""Canonical handling of LCSC part numbers."""
+"""Canonical handling of LCSC part numbers.
 
+:class:`Lcsc` is the preferred form: a value that has been through it is a real
+part number in canonical form, which a ``str`` never tells you. The plain
+string helpers are the same answers rendered as strings, for the boundaries
+that must hand one to sqlite, wx or a CSV writer.
+
+Absence is ``None``, never an empty :class:`Lcsc`, and there is no
+``.valid()`` -- a part in hand is always valid. The empty string means "no
+part" only at the edges, and :func:`format_lcsc` is where that conversion
+happens.
+"""
+
+from dataclasses import dataclass
 import re
+from typing import Optional
 
 # No anchors, so the same pattern answers both questions below: matched in
 # full for "is this a part number", searched for in "is there one in this
@@ -36,6 +49,9 @@ def is_lcsc_part(value):
 
     It is strict on purpose: the value has to be a part number and nothing
     else. Text that merely contains one is :func:`extract_lcsc`'s business.
+
+    This is the string-level form: :meth:`Lcsc.parse` asks the same question
+    and answers with the part itself.
     """
     return bool(_PART_NUMBER.fullmatch(normalize_lcsc(value)))
 
@@ -57,8 +73,85 @@ def extract_lcsc(text):
     plugin and by the tests over this path, so no floor is applied here.
 
     The result is canonical, so what is pasted and what is stored agree.
+
+    This is the one search of the pattern in text; :meth:`Lcsc.find_in` is
+    this function with the result handed back as a part.
     """
     if not text:
         return ""
     match = _PART_NUMBER.search(str(text).upper())
     return match.group(0) if match else ""
+
+
+@dataclass(frozen=True)
+class Lcsc:
+    """A JLCPCB/LCSC part number, known to be well formed and canonical.
+
+    Construct one through :meth:`parse` or :meth:`find_in`, which answer
+    ``None`` when the value does not name a part. The constructor rejects
+    anything that is not a part number, so an ``Lcsc`` in hand needs no
+    further checking. It is frozen, so it can be a dict key, and it renders as
+    the bare number, so it can be formatted straight into a query, a CSV cell
+    or a log line.
+
+    Well formed means exactly what :func:`is_lcsc_part` means -- there is one
+    definition of the shape, and the type is built on it rather than beside
+    it, so a value the predicate accepts always builds a part and one it
+    rejects never does.
+
+    Not ordered: part numbers identify rather than measure. Sort with an
+    explicit key if a display ever needs one.
+
+        >>> part = Lcsc.parse(" c12345 ")
+        >>> str(part)
+        'C12345'
+        >>> f"ordering {part}"
+        'ordering C12345'
+    """
+
+    value: str
+
+    def __post_init__(self):
+        """Reject anything that is not a canonical part number."""
+        canonical = normalize_lcsc(self.value)
+        if not is_lcsc_part(canonical):
+            raise ValueError(f"not an LCSC part number: {self.value!r}")
+        # frozen dataclasses refuse plain assignment, even from __post_init__
+        object.__setattr__(self, "value", canonical)
+
+    @classmethod
+    def parse(cls, value) -> Optional["Lcsc"]:
+        """Return the part this value names, or None if it names none.
+
+        Use this wherever a value is *claimed* to be a part number -- a
+        schematic field, a database column -- and the claim has to be checked.
+        """
+        try:
+            return cls(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def find_in(cls, text) -> Optional["Lcsc"]:
+        """Return the first part number appearing anywhere in text.
+
+        Use this for text a person pasted, where the number arrives with
+        whatever surrounded it. It is lenient about the surroundings only: a
+        value that is not a part number does not become one by being pasted
+        into the right box.
+        """
+        found = extract_lcsc(text)
+        return cls(found) if found else None
+
+    def __str__(self) -> str:
+        """Render as the bare canonical part number."""
+        return self.value
+
+
+def format_lcsc(part) -> str:
+    """Render a part, or the absence of one, for something that wants a string.
+
+    The boundary between ``None`` inside the plugin and the empty string that
+    sqlite columns, CSV cells and wx list cells use for the same thing.
+    """
+    return str(part) if part is not None else ""

--- a/library.py
+++ b/library.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 from pathlib import Path, PurePath
-import re
 import sqlite3
 from threading import Lock, Thread
 import time
@@ -39,7 +38,7 @@ from .events import (
     MessageEvent,
 )
 from .helpers import PLUGIN_PATH, dict_factory, natural_sort_collation
-from .lcsc import normalize_lcsc
+from .lcsc import is_lcsc_part, normalize_lcsc
 from .partselector_columns import DB_FIELDS, SORTABLE_COLUMN_INDEX_TO_DB
 from .search_escape import escape_fts_phrase, escape_like_term
 from .unzip_parts import unzip_parts
@@ -96,12 +95,12 @@ _INITIAL_DOWNLOAD_TARGETS: set[str] = set()
 
 
 def _normalize_part_preference_lcsc(value: object) -> Optional[str]:  # noqa: UP045
-    """Accept a complete C-number without requiring current catalog membership."""
-    if isinstance(value, str) and re.fullmatch(
-        r"C[0-9]+", value.strip(), re.IGNORECASE
-    ):
-        return value.strip().upper()
-    return None
+    """Accept a complete C-number without requiring current catalog membership.
+
+    The shape of a part number is lcsc.py's business, not this module's, so
+    the test and the canonical form both come from there.
+    """
+    return normalize_lcsc(value) if is_lcsc_part(value) else None
 
 
 def _sqlite_file_uri(path: PurePath) -> str:

--- a/library.py
+++ b/library.py
@@ -1377,8 +1377,17 @@ class Library:
                 "MFR.Part" as part_no, "Description" as description, "Package" as package,
                 "First Category" as category, "Price" as price
                 FROM parts WHERE parts MATCH :number"""
-            cur.execute(query, {"number": number})
-            return next((n for n in cur.fetchall() if n["lcsc"] == number), {})
+            wanted = normalize_lcsc(number)
+            if not wanted:
+                # 'parts MATCH " "' is a syntax error to FTS5, so asking about
+                # a part that isn't there has to mean "not found", not a crash.
+                return {}
+            cur.execute(query, {"number": wanted})
+            # The FTS5 match is not exact, so the row still has to be confirmed;
+            # compare canonically or a differently spelled number finds nothing.
+            return next(
+                (n for n in cur.fetchall() if normalize_lcsc(n["lcsc"]) == wanted), {}
+            )
 
     def update(self):
         """Update the sqlite parts database from the JLCPCB CSV."""

--- a/library.py
+++ b/library.py
@@ -38,7 +38,7 @@ from .events import (
     MessageEvent,
 )
 from .helpers import PLUGIN_PATH, dict_factory, natural_sort_collation
-from .lcsc import is_lcsc_part, normalize_lcsc
+from .lcsc import Lcsc, format_lcsc, normalize_lcsc
 from .partselector_columns import DB_FIELDS, SORTABLE_COLUMN_INDEX_TO_DB
 from .search_escape import escape_fts_phrase, escape_like_term
 from .unzip_parts import unzip_parts
@@ -97,10 +97,10 @@ _INITIAL_DOWNLOAD_TARGETS: set[str] = set()
 def _normalize_part_preference_lcsc(value: object) -> Optional[str]:  # noqa: UP045
     """Accept a complete C-number without requiring current catalog membership.
 
-    The shape of a part number is lcsc.py's business, not this module's, so
-    the test and the canonical form both come from there.
+    The shape of a part number is lcsc.py's business, not this module's:
+    the value either parses as a part or it is not a preference.
     """
-    return normalize_lcsc(value) if is_lcsc_part(value) else None
+    return format_lcsc(Lcsc.parse(value)) or None
 
 
 def _sqlite_file_uri(path: PurePath) -> str:
@@ -1367,8 +1367,13 @@ class Library:
             cur.execute(f"CREATE TABLE IF NOT EXISTS parts ({cols})")
             cur.commit()
 
-    def get_part_details(self, number: str) -> dict:
-        """Get the part details for a LCSC number using optimized FTS5 querying."""
+    def get_part_details(self, number) -> dict:
+        """Get the part details for a LCSC number using optimized FTS5 querying.
+
+        Accepts an :class:`Lcsc` or anything that might name one. A value that
+        does not name a part is not an error -- most callers hold whatever the
+        board gave them -- so it returns no details rather than raising.
+        """
         with contextlib.closing(sqlite3.connect(self.partsdb_file)) as con:
             con.row_factory = dict_factory
             cur = con.cursor()
@@ -1376,16 +1381,17 @@ class Library:
                 "MFR.Part" as part_no, "Description" as description, "Package" as package,
                 "First Category" as category, "Price" as price
                 FROM parts WHERE parts MATCH :number"""
-            wanted = normalize_lcsc(number)
-            if not wanted:
-                # 'parts MATCH " "' is a syntax error to FTS5, so asking about
-                # a part that isn't there has to mean "not found", not a crash.
+            part = Lcsc.parse(number)
+            if part is None:
+                # Nothing that could name a part, so nothing to look up.
+                # 'parts MATCH " "' is a syntax error to FTS5 besides.
                 return {}
-            cur.execute(query, {"number": wanted})
-            # The FTS5 match is not exact, so the row still has to be confirmed;
-            # compare canonically or a differently spelled number finds nothing.
+            cur.execute(query, {"number": str(part)})
+            # The FTS5 match is not exact, so the row still has to be confirmed.
+            # Comparing parsed values makes the two sides canonical by
+            # construction rather than by remembering to normalise both.
             return next(
-                (n for n in cur.fetchall() if normalize_lcsc(n["lcsc"]) == wanted), {}
+                (n for n in cur.fetchall() if Lcsc.parse(n["lcsc"]) == part), {}
             )
 
     def update(self):

--- a/library.py
+++ b/library.py
@@ -19,11 +19,17 @@ import requests  # pylint: disable=import-error
 import wx  # pylint: disable=import-error
 
 from .correction_data import (
+    KIND_FOOTPRINT,
+    KIND_LCSC,
+    AnyCorrection,
     Correction,
     CorrectionDataError,
     CorrectionIssue,
+    LcscCorrection,
+    correction_kind,
     parse_corrections_csv,
     validate_correction,
+    validate_lcsc_correction,
 )
 from .dblib import DEFAULT_LIBRARY, LIBRARY_CONFIGS
 from .events import (
@@ -33,11 +39,57 @@ from .events import (
     MessageEvent,
 )
 from .helpers import PLUGIN_PATH, dict_factory, natural_sort_collation
+from .lcsc import normalize_lcsc
 from .partselector_columns import DB_FIELDS, SORTABLE_COLUMN_INDEX_TO_DB
 from .search_escape import escape_fts_phrase, escape_like_term
 from .unzip_parts import unzip_parts
 
 DatabasePath = Union[str, os.PathLike[str]]
+
+
+@dataclass(frozen=True)
+class _RuleTable:
+    """The statements that address one kind of correction by physical row."""
+
+    name: str
+    key: str
+    columns: str
+    probe: str
+    select_all: str
+    select_row: str
+    insert: str
+    update: str
+    delete: str
+
+
+# Pattern rules and part-number rules live in sibling tables of one database,
+# so both are validated, repaired and copied between scopes the same way.
+# rowids are only unique within a table, which is why every stored row also
+# carries its kind.
+_RULE_TABLES = {
+    KIND_FOOTPRINT: _RuleTable(
+        "correction",
+        "regex",
+        "PRAGMA table_xinfo(correction)",
+        "SELECT rowid FROM correction LIMIT 0",
+        "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction ORDER BY regex ASC, rowid ASC",
+        "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction WHERE rowid=?",
+        "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
+        "UPDATE correction SET regex=?, rotation=?, offset_x=?, offset_y=? WHERE rowid=?",
+        "DELETE FROM correction WHERE rowid=?",
+    ),
+    KIND_LCSC: _RuleTable(
+        "lcsc_correction",
+        "lcsc",
+        "PRAGMA table_xinfo(lcsc_correction)",
+        "SELECT rowid FROM lcsc_correction LIMIT 0",
+        "SELECT rowid, lcsc, rotation, offset_x, offset_y FROM lcsc_correction ORDER BY lcsc ASC, rowid ASC",
+        "SELECT rowid, lcsc, rotation, offset_x, offset_y FROM lcsc_correction WHERE rowid=?",
+        "INSERT INTO lcsc_correction (lcsc, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
+        "UPDATE lcsc_correction SET lcsc=?, rotation=?, offset_x=?, offset_y=? WHERE rowid=?",
+        "DELETE FROM lcsc_correction WHERE rowid=?",
+    ),
+}
 _INITIAL_DEFAULTS_KEY = "remote:initial-defaults:v1"
 _INITIAL_DOWNLOAD_LOCK = Lock()
 _INITIAL_DOWNLOAD_TARGETS: set[str] = set()
@@ -78,14 +130,19 @@ class LibraryState(Enum):
 
 @dataclass(frozen=True)
 class StoredCorrection:
-    """Preserve a stored row and its validation errors for precise repair."""
+    """Preserve a stored row and its validation errors for precise repair.
+
+    ``pattern`` holds the stored key text of either kind: a regular expression
+    for a footprint rule, the part number as stored for an LCSC rule.
+    """
 
     rowid: int
     pattern: object
     rotation: object
     offset: tuple[object, object]
     issues: tuple[CorrectionIssue, ...]
-    correction: Optional[Correction] = None  # noqa: UP045
+    correction: Optional[AnyCorrection] = None  # noqa: UP045
+    kind: str = KIND_FOOTPRINT
 
     @property
     def identity(self) -> tuple[tuple[type, object], ...]:
@@ -315,6 +372,10 @@ class Library:
                 raise CorrectionDataError(destination.issues)
             with self._correction_transaction(self.localcorrectionsdb_file) as con:
                 con.execute("DROP TABLE correction")
+                # uses_global_correction_database() decides by looking for
+                # 'correction', so a surviving part-number table would strand
+                # local overrides in a database that nothing reads.
+                con.execute("DROP TABLE IF EXISTS lcsc_correction")
                 # Keep automatic CSV provenance when leaving local scope, so
                 # an unarchived source cannot replay into the global database.
             self.correctionsdb_file = self.globalcorrectionsdb_file
@@ -329,10 +390,16 @@ class Library:
                 self.localcorrectionsdb_file, create=True
             ) as con:
                 con.execute("DELETE FROM correction")
-                con.executemany(
-                    "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
-                    [correction.db_row() for correction in source],
-                )
+                con.execute("DELETE FROM lcsc_correction")
+                for kind, table in _RULE_TABLES.items():
+                    con.executemany(
+                        table.insert,
+                        [
+                            correction.db_row()
+                            for correction in source
+                            if correction_kind(correction) == kind
+                        ],
+                    )
                 con.executemany(
                     "INSERT OR IGNORE INTO correction_migrations VALUES (?, ?)",
                     source_snapshot.csv_migrations,
@@ -483,6 +550,7 @@ class Library:
         con.execute(
             "CREATE TABLE IF NOT EXISTS correction ('regex', 'rotation', 'offset_x', 'offset_y')"
         )
+        Library._lcsc_correction_schema(con)
         con.execute(
             "CREATE TABLE IF NOT EXISTS correction_migrations "
             "(migration_key TEXT PRIMARY KEY, source TEXT NOT NULL)"
@@ -507,32 +575,66 @@ class Library:
             return "REAL"
         return "NUMERIC"
 
+    @staticmethod
+    def _lcsc_correction_schema(con: sqlite3.Connection) -> None:
+        """Create the part-number table; databases from earlier releases lack it."""
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS lcsc_correction "
+            "('lcsc', 'rotation', 'offset_x', 'offset_y')"
+        )
+
+    @staticmethod
+    def _has_table(con: sqlite3.Connection, name: str) -> bool:
+        """Report whether an ordinary table of that name exists."""
+        return (
+            con.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+            ).fetchone()
+            is not None
+        )
+
     @classmethod
     def _validate_correction_schema(cls, con: sqlite3.Connection) -> None:
         """Require named correction fields and unambiguous physical row identities."""
-        table = con.execute(
-            "SELECT type FROM sqlite_master WHERE name='correction'"
+        cls._validate_rule_table(con, _RULE_TABLES[KIND_FOOTPRINT], required=True)
+        # The part-number table is additive: a database from an earlier release
+        # is valid without it and gains it on its next write transaction.
+        cls._validate_rule_table(con, _RULE_TABLES[KIND_LCSC], required=False)
+
+    @classmethod
+    def _validate_rule_table(
+        cls, con: sqlite3.Connection, table: _RuleTable, *, required: bool
+    ) -> None:
+        """Check one rule table's columns, affinities and row identities."""
+        found = con.execute(
+            "SELECT type FROM sqlite_master WHERE name=?", (table.name,)
         ).fetchone()
-        if table is None or table[0] != "table":
-            raise sqlite3.DatabaseError("correction storage must be an ordinary table")
-        columns = con.execute("PRAGMA table_xinfo(correction)").fetchall()
-        expected = {"regex", "rotation", "offset_x", "offset_y"}
+        if found is None and not required:
+            return
+        if found is None or found[0] != "table":
+            raise sqlite3.DatabaseError(
+                f"{table.name} storage must be an ordinary table"
+            )
+        columns = con.execute(table.columns).fetchall()
+        expected = {table.key, "rotation", "offset_x", "offset_y"}
         if (
             len(columns) != len(expected)
             or {column[1].casefold() for column in columns} != expected
             or any(column[6] for column in columns)
         ):
             raise sqlite3.DatabaseError(
-                "correction table must contain exactly regex, rotation, offset_x, "
-                "and offset_y; unsupported schemas cannot be repaired automatically"
+                f"{table.name} table must contain exactly {table.key}, rotation, "
+                "offset_x, and offset_y; unsupported schemas cannot be repaired "
+                "automatically"
             )
         affinities = {
             column[1].casefold(): cls._sqlite_affinity(column[2]) for column in columns
         }
-        if affinities["regex"] not in {"TEXT", "BLOB"}:
+        if affinities[table.key] not in {"TEXT", "BLOB"}:
             raise sqlite3.DatabaseError(
-                "unsupported correction schema: regex must have TEXT or BLOB affinity "
-                "to preserve pattern text; use a supported correction database schema"
+                f"unsupported correction schema: {table.key} must have TEXT or BLOB "
+                "affinity to preserve the stored key text; use a supported "
+                "correction database schema"
             )
         if affinities["rotation"] == "REAL":
             raise sqlite3.DatabaseError(
@@ -547,10 +649,10 @@ class Library:
         # The exact-column check rules out aliases that shadow SQLite's rowid.
         # This query also rejects WITHOUT ROWID tables before exposing repair IDs.
         try:
-            con.execute("SELECT rowid FROM correction LIMIT 0")
+            con.execute(table.probe)
         except sqlite3.Error as error:
             raise sqlite3.DatabaseError(
-                "correction table requires SQLite row identities for safe repair"
+                f"{table.name} table requires SQLite row identities for safe repair"
             ) from error
 
     @staticmethod
@@ -591,6 +693,8 @@ class Library:
                 if create:
                     self._correction_schema(con)
                 self._validate_correction_schema(con)
+                # Every write transaction brings an older database up to date.
+                self._lcsc_correction_schema(con)
                 yield con
         except (sqlite3.Error, OSError) as error:
             raise self._storage_error(target, error) from error
@@ -808,20 +912,22 @@ class Library:
         db_path: Optional[DatabasePath] = None,  # noqa: UP045
         *,
         expected_record: Optional[StoredCorrection] = None,  # noqa: UP045
+        kind: str = KIND_FOOTPRINT,
     ) -> None:
-        """Delete the selected original row, rejecting a concurrent edit or reused ID."""
+        """Delete the selected original row, rejecting a concurrent edit or reused ID.
+
+        The record's own kind names the table; ``kind`` applies without one.
+        """
         target = db_path if db_path is not None else self.correctionsdb_file
+        table = _RULE_TABLES[expected_record.kind if expected_record else kind]
         with self._correction_transaction(target) as con:
             if expected_record is not None:
                 self._check_expected_corrections(
-                    con.execute(
-                        "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction WHERE rowid=?",
-                        (rowid,),
-                    ).fetchall(),
+                    con.execute(table.select_row, (rowid,)).fetchall(),
                     (expected_record,),
                     target,
                 )
-            con.execute("DELETE FROM correction WHERE rowid = ?", (rowid,))
+            con.execute(table.delete, (rowid,))
 
     def update_correction_data(
         self, regex: object, rotation: object, offset: object
@@ -845,6 +951,18 @@ class Library:
         """Validate and insert a correction, refusing accidental duplicate patterns."""
         return self.save_correction_data(regex, rotation, offset, db_path=db_path)
 
+    def insert_lcsc_correction_data(
+        self,
+        lcsc: object,
+        rotation: object,
+        offset: object,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> int:
+        """Validate and insert a part-number correction, refusing a duplicate key."""
+        return self.save_correction_data(
+            lcsc, rotation, offset, db_path=db_path, kind=KIND_LCSC
+        )
+
     def save_correction_data(
         self,
         pattern: object,
@@ -856,61 +974,103 @@ class Library:
         db_path: Optional[DatabasePath] = None,  # noqa: UP045
         expected_record: Optional[StoredCorrection] = None,  # noqa: UP045
         expected_conflicts: Optional[Sequence[StoredCorrection]] = None,  # noqa: UP045
+        kind: str = KIND_FOOTPRINT,
     ) -> int:
-        """Save or repair one row, with optional collision replacement in the same transaction."""
+        """Save or repair one row, with optional collision replacement in the same transaction.
+
+        A validated Correction or LcscCorrection names its own table; raw
+        values are validated as the given kind first.
+        """
         target = db_path if db_path is not None else self.correctionsdb_file
-        correction = (
-            pattern
-            if isinstance(pattern, Correction)
-            else validate_correction(
+        if isinstance(pattern, (Correction, LcscCorrection)):
+            correction = pattern
+        elif kind == KIND_LCSC:
+            correction = validate_lcsc_correction(
                 pattern, rotation, offset, source=str(target), rowid=rowid
             )
-        )
+        else:
+            correction = validate_correction(
+                pattern, rotation, offset, source=str(target), rowid=rowid
+            )
+        table = _RULE_TABLES[correction_kind(correction)]
+        if expected_record is not None and expected_record.kind != correction_kind(
+            correction
+        ):
+            raise self._storage_error(
+                target,
+                ValueError("the selected row is a different kind of rule"),
+                "row",
+            )
         with self._correction_transaction(target) as con:
             if rowid is not None or expected_record is not None:
                 self._check_expected_corrections(
-                    con.execute(
-                        "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction WHERE rowid=?",
-                        (rowid,),
-                    ).fetchall(),
+                    con.execute(table.select_row, (rowid,)).fetchall(),
                     (expected_record,) if expected_record is not None else None,
                     target,
                 )
-            conflicts = con.execute(
-                "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction "
-                "WHERE regex=? AND (? IS NULL OR rowid != ?) ORDER BY rowid",
-                (correction.pattern, rowid, rowid),
-            ).fetchall()
+            conflicts = self._conflicting_rows(con, correction, rowid)
             if expected_conflicts is not None:
                 self._check_expected_corrections(conflicts, expected_conflicts, target)
             if conflicts and not replace:
                 raise CorrectionDataError(
-                    (
-                        CorrectionIssue(
-                            "pattern",
-                            correction.pattern,
-                            "another correction already uses this pattern",
-                            str(target),
-                            pattern=correction.pattern,
-                            rowid=rowid,
-                        ),
-                    )
+                    (self._duplicate_key_issue(correction, target, rowid),)
                 )
             if conflicts:
-                con.executemany(
-                    "DELETE FROM correction WHERE rowid=?",
-                    [(row[0],) for row in conflicts],
-                )
+                con.executemany(table.delete, [(row[0],) for row in conflicts])
             if rowid is None:
-                return con.execute(
-                    "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
-                    correction.db_row(),
-                ).lastrowid
-            con.execute(
-                "UPDATE correction SET regex=?, rotation=?, offset_x=?, offset_y=? WHERE rowid=?",
-                (*correction.db_row(), rowid),
-            )
+                return con.execute(table.insert, correction.db_row()).lastrowid
+            con.execute(table.update, (*correction.db_row(), rowid))
         return rowid
+
+    @staticmethod
+    def _conflicting_rows(
+        con: sqlite3.Connection,
+        correction: AnyCorrection,
+        rowid: Optional[int],  # noqa: UP045
+    ) -> list[tuple[object, ...]]:
+        """Find the other rows of the same kind stored under the same key."""
+        if isinstance(correction, LcscCorrection):
+            # Part numbers compare in canonical form, so a row that reached the
+            # table in another spelling still counts as the same rule.
+            return [
+                row
+                for row in con.execute(
+                    "SELECT rowid, lcsc, rotation, offset_x, offset_y "
+                    "FROM lcsc_correction ORDER BY rowid"
+                ).fetchall()
+                if row[0] != rowid
+                and isinstance(row[1], str)
+                and normalize_lcsc(row[1]) == correction.lcsc
+            ]
+        return con.execute(
+            "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction "
+            "WHERE regex=? AND (? IS NULL OR rowid != ?) ORDER BY rowid",
+            (correction.pattern, rowid, rowid),
+        ).fetchall()
+
+    @staticmethod
+    def _duplicate_key_issue(
+        correction: AnyCorrection,
+        target: DatabasePath,
+        rowid: Optional[int],  # noqa: UP045
+    ) -> CorrectionIssue:
+        """Describe a refused save whose key another stored row already uses."""
+        if isinstance(correction, LcscCorrection):
+            return CorrectionIssue(
+                "lcsc",
+                correction.lcsc,
+                "another correction already uses this part number",
+                str(target),
+                rowid=rowid,
+            )
+        return CorrectionIssue(
+            "pattern",
+            correction.pattern,
+            "another correction already uses this pattern",
+            str(target),
+            pattern=correction.pattern,
+            rowid=rowid,
+        )
 
     def read_correction_data(
         self,
@@ -927,16 +1087,16 @@ class Library:
         issues = []
         corrections = {}
         csv_migrations = ()
-        raw_rows = []
+        raw_rows = {kind: [] for kind in _RULE_TABLES}
         unavailable = False
         warnings = []
         try:
             with contextlib.closing(self._read_database(target)) as con:
                 con.execute("BEGIN")
                 self._validate_correction_schema(con)
-                raw_rows = con.execute(
-                    "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction ORDER BY regex ASC, rowid ASC"
-                ).fetchall()
+                for kind, table in _RULE_TABLES.items():
+                    if kind == KIND_FOOTPRINT or self._has_table(con, table.name):
+                        raw_rows[kind] = con.execute(table.select_all).fetchall()
                 completed, states = self._correction_metadata(con)
                 csv_migrations = tuple(
                     (key, source)
@@ -961,32 +1121,13 @@ class Library:
         issues.extend(session_issues)
         warnings.extend(session_warnings)
         unavailable = unavailable or bool(session_issues)
-        for rowid, pattern, rotation, offset_x, offset_y in raw_rows:
-            correction = None
-            row_issues = ()
-            try:
-                correction = validate_correction(
-                    pattern,
-                    rotation,
-                    (offset_x, offset_y),
-                    source=target,
-                    rowid=rowid,
-                )
-            except CorrectionDataError as error:
-                row_issues = error.issues
-                issues.extend(row_issues)
-            rows.append(
-                StoredCorrection(
-                    rowid,
-                    pattern,
-                    rotation,
-                    (offset_x, offset_y),
-                    row_issues,
-                    correction,
-                )
+        for kind, kind_rows in raw_rows.items():
+            stored, kind_issues, kind_corrections = self._stored_rows(
+                kind, kind_rows, target
             )
-            if correction is not None:
-                corrections.setdefault(pattern, correction)
+            rows.extend(stored)
+            issues.extend(kind_issues)
+            corrections.update(kind_corrections)
         rows, conflicts = self._mark_conflicting_corrections(rows, target)
         issues.extend(conflicts)
         state = (
@@ -1008,14 +1149,60 @@ class Library:
         )
 
     @staticmethod
+    def _stored_rows(
+        kind: str, raw_rows: Sequence[tuple[object, ...]], target: str
+    ) -> tuple[
+        list[StoredCorrection],
+        list[CorrectionIssue],
+        dict[tuple[str, str], AnyCorrection],
+    ]:
+        """Validate one table's rows, keeping every original for precise repair."""
+        validate = (
+            validate_lcsc_correction if kind == KIND_LCSC else validate_correction
+        )
+        rows = []
+        issues = []
+        corrections = {}
+        for rowid, key, rotation, offset_x, offset_y in raw_rows:
+            correction = None
+            row_issues = ()
+            try:
+                correction = validate(
+                    key, rotation, (offset_x, offset_y), source=target, rowid=rowid
+                )
+            except CorrectionDataError as error:
+                row_issues = error.issues
+                issues.extend(row_issues)
+            rows.append(
+                StoredCorrection(
+                    rowid,
+                    key,
+                    rotation,
+                    (offset_x, offset_y),
+                    row_issues,
+                    correction,
+                    kind,
+                )
+            )
+            if correction is not None:
+                corrections.setdefault((kind, correction.key), correction)
+        return rows, issues, corrections
+
+    @staticmethod
+    def _conflict_group(row: StoredCorrection) -> tuple[str, str]:
+        """Key a stored row the way its kind compares keys."""
+        key = str(row.pattern)
+        return row.kind, normalize_lcsc(key) if row.kind == KIND_LCSC else key
+
+    @staticmethod
     def _mark_conflicting_corrections(
         rows: Sequence[StoredCorrection], target: str
     ) -> tuple[list[StoredCorrection], list[CorrectionIssue]]:
-        """Identify every member of a conflicting pattern group for explicit repair."""
+        """Identify every member of a conflicting key group for explicit repair."""
         groups = {}
         for row in rows:
             if isinstance(row.pattern, str):
-                groups.setdefault(row.pattern, []).append(row)
+                groups.setdefault(Library._conflict_group(row), []).append(row)
         conflicting = {
             pattern
             for pattern, group in groups.items()
@@ -1028,15 +1215,27 @@ class Library:
         issues = []
         result = []
         for row in rows:
-            if row.pattern in conflicting:
-                issue = CorrectionIssue(
-                    "pattern",
-                    row.pattern,
-                    "conflicting stored corrections use this pattern; repair or delete the duplicate rows",
-                    target,
-                    pattern=row.pattern,
-                    rowid=row.rowid,
-                )
+            if (
+                isinstance(row.pattern, str)
+                and Library._conflict_group(row) in conflicting
+            ):
+                if row.kind == KIND_LCSC:
+                    issue = CorrectionIssue(
+                        "lcsc",
+                        row.pattern,
+                        "conflicting stored corrections use this part number; repair or delete the duplicate rows",
+                        target,
+                        rowid=row.rowid,
+                    )
+                else:
+                    issue = CorrectionIssue(
+                        "pattern",
+                        row.pattern,
+                        "conflicting stored corrections use this pattern; repair or delete the duplicate rows",
+                        target,
+                        pattern=row.pattern,
+                        rowid=row.rowid,
+                    )
                 issues.append(issue)
                 row = replace(row, issues=(*row.issues, issue))
             result.append(row)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -121,6 +121,7 @@ ID_CONTEXT_MENU_PASTE_LCSC = wx.NewIdRef()
 ID_CONTEXT_MENU_ADD_ROT_BY_REFERENCE = wx.NewIdRef()
 ID_CONTEXT_MENU_ADD_ROT_BY_PACKAGE = wx.NewIdRef()
 ID_CONTEXT_MENU_ADD_ROT_BY_NAME = wx.NewIdRef()
+ID_CONTEXT_MENU_ADD_ROT_BY_LCSC = wx.NewIdRef()
 ID_CONTEXT_MENU_APPLY_PART_PREFERENCES = wx.NewIdRef()
 ID_CONTEXT_MENU_SAVE_PART_PREFERENCES = wx.NewIdRef()
 
@@ -1065,6 +1066,7 @@ class JLCPCBTools(wx.Dialog):
         assigned = list(footprints)
         if notify:
             self.start_assembly_enrichment(assigned)
+            self.refresh_corrections(assigned)
             wx.PostEvent(self, BomDataChangedEvent(source="assign_parts"))
         return assigned
 
@@ -1373,10 +1375,38 @@ class JLCPCBTools(wx.Dialog):
             str(part["reference"]),
             str(part["value"]),
             str(part["footprint"]),
+            part["lcsc"],
         )
         if match is None:
             return "0°, 0.0/0.0"
         return f"{match.correction} ({match.source})"
+
+    def refresh_corrections(self, references: Iterable[str]) -> None:
+        """Recompute the Correction cells of parts whose LCSC number changed.
+
+        The rule selected for a part depends on its part number as well as
+        its reference, value and footprint, so the cell has to follow the
+        store whenever the number is assigned, pasted, applied from a part
+        preference or removed. Only the affected rows change; the list is
+        not repopulated.
+        """
+        if self.store is None:
+            return
+        references = list(references)
+        if not references:
+            return
+        snapshot = self.library.read_correction_data()
+        self.update_correction_status(snapshot)
+        for reference in references:
+            part = self.store.get_part(reference)
+            if not part:
+                continue
+            self.partlist_data_model.set_correction(
+                reference,
+                str(self.get_correction(part, snapshot.corrections))
+                if snapshot.corrections is not None
+                else "Unresolved",
+            )
 
     def update_correction_status(self, snapshot: CorrectionSnapshot) -> None:
         """Show aggregate readiness; detailed repair diagnostics stay in the manager."""
@@ -1644,6 +1674,7 @@ class JLCPCBTools(wx.Dialog):
         for item, _ref, fp in selected:
             set_lcsc_value(fp, "")
             self.partlist_data_model.remove_lcsc_number(item)
+        self.refresh_corrections([ref for _item, ref, _fp in selected])
         wx.PostEvent(self, BomDataChangedEvent(source="remove_lcsc_number"))
 
     def select_alike_parts(self, *_):
@@ -2222,6 +2253,7 @@ class JLCPCBTools(wx.Dialog):
 
     def add_correction(self, e: wx.CommandEvent) -> None:
         """Add part correction for the current part."""
+        without_lcsc = []
         for item in self.footprint_list.GetSelections():
             if e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_REFERENCE:
                 if reference := self.partlist_data_model.get_reference(item):
@@ -2236,6 +2268,17 @@ class JLCPCBTools(wx.Dialog):
             elif e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_NAME:
                 if value := self.partlist_data_model.get_value(item):
                     CorrectionManagerDialog(self, re.escape(value)).ShowModal()
+            elif e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_LCSC:
+                if lcsc := self.partlist_data_model.get_lcsc(item):
+                    CorrectionManagerDialog(self, "", lcsc_part=lcsc).ShowModal()
+                else:
+                    without_lcsc.append(self.partlist_data_model.get_reference(item))
+        if without_lcsc:
+            wx.MessageBox(
+                "No LCSC number is assigned to " + ", ".join(without_lcsc) + ".",
+                "No LCSC number",
+                style=wx.ICON_WARNING,
+            )
         self.populate_footprint_list()
 
     def export_to_schematic(self, *_):
@@ -2327,6 +2370,12 @@ class JLCPCBTools(wx.Dialog):
         )
         right_click_menu.Append(correction_by_name)
         right_click_menu.Bind(wx.EVT_MENU, self.add_correction, correction_by_name)
+
+        correction_by_lcsc = wx.MenuItem(
+            right_click_menu, ID_CONTEXT_MENU_ADD_ROT_BY_LCSC, "Add Correction by LCSC"
+        )
+        right_click_menu.Append(correction_by_lcsc)
+        right_click_menu.Bind(wx.EVT_MENU, self.add_correction, correction_by_lcsc)
 
         apply_part_preferences = wx.MenuItem(
             right_click_menu,

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -1013,32 +1013,54 @@ class JLCPCBTools(wx.Dialog):
         remember_part_preferences: bool = False,
         notify: bool = True,
     ) -> list[str]:
-        """Commit project changes before updating board fields or displayed rows."""
+        """Commit project changes before updating board fields or displayed rows.
+
+        Assignments arrive as strings from a part selector, the clipboard and
+        saved preferences, so they are parsed once here, at the boundary. What
+        the store, the board field and the model see below is the canonical
+        number of a part that is known to be one.
+        """
         if self.store is None:
             return []
         board = self.pcbnew.GetBoard()
+        parts = {}
+        for reference, number in assignments.items():
+            # Skipped like a reference the board no longer has: one bad entry
+            # is not a reason to abandon the rest of the action.
+            if (part := Lcsc.parse(number)) is None:
+                self.logger.warning(
+                    "Skipped %s: %r does not name an LCSC part.", reference, number
+                )
+            else:
+                parts[reference] = part
         footprints = {
             reference: footprint
-            for reference in assignments
+            for reference in parts
             if (footprint := board.FindFootprintByReference(reference)) is not None
         }
         if not footprints:
             return []
+        # The caller's details are keyed by whatever string it holds, so they
+        # are parsed too rather than compared against a canonical key.
+        supplied = {
+            part: row
+            for number, row in (details or {}).items()
+            if (part := Lcsc.parse(number)) is not None
+        }
         catalog = {}
         try:
-            for lcsc in dict.fromkeys(assignments[ref] for ref in footprints):
-                part = (details or {}).get(lcsc)
-                if part is None:
-                    part = self.library.get_part_details(lcsc)
-                stock = part.get("stock")
+            for part in dict.fromkeys(parts[ref] for ref in footprints):
+                row = supplied.get(part)
+                if row is None:
+                    row = self.library.get_part_details(part)
+                stock = row.get("stock")
                 try:
                     stored_stock = int(stock) if stock is not None else None
                 except (TypeError, ValueError):
                     stored_stock = None
-                catalog[lcsc] = (part, stored_stock, params_for_part(part))
+                catalog[part] = (row, stored_stock, params_for_part(row))
             self.store.set_lcsc_assignments(
-                (ref, assignments[ref], catalog[assignments[ref]][1])
-                for ref in footprints
+                (ref, str(parts[ref]), catalog[parts[ref]][1]) for ref in footprints
             )
         except sqlite3.Error as error:
             self.logger.warning("Unable to apply LCSC assignments: %s", error)
@@ -1046,14 +1068,15 @@ class JLCPCBTools(wx.Dialog):
 
         preferences = []
         for reference, footprint in footprints.items():
-            lcsc = assignments[reference]
-            part, _stored_stock, params = catalog[lcsc]
+            part = parts[reference]
+            lcsc = str(part)
+            row, _stored_stock, params = catalog[part]
             set_lcsc_value(footprint, lcsc)
-            stock = part.get("stock")
+            stock = row.get("stock")
             self.partlist_data_model.set_lcsc(
                 reference,
                 lcsc,
-                part.get("type", ""),
+                row.get("type", ""),
                 stock if stock is not None else "",
                 params,
             )

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -78,7 +78,7 @@ from .helpers import (
     loadBitmapScaled,
 )
 from .kicad_drc import DRCViolationCounter
-from .lcsc import normalize_lcsc
+from .lcsc import extract_lcsc, normalize_lcsc
 from .library import CorrectionState, Library, LibraryState
 from .partdetails import PartDetailsDialog
 from .part_preferences import PartPreferencesDialog
@@ -2245,7 +2245,7 @@ class JLCPCBTools(wx.Dialog):
             success = wx.TheClipboard.GetData(text_data)
             wx.TheClipboard.Close()
         if success:
-            if (lcsc := self.sanitize_lcsc(text_data.GetText())) != "":
+            if (lcsc := extract_lcsc(text_data.GetText())) != "":
                 references = [
                     self.partlist_data_model.get_reference(item)
                     for item in self.footprint_list.GetSelections()
@@ -2328,13 +2328,6 @@ class JLCPCBTools(wx.Dialog):
             self.logger.info(
                 "Applied part preferences to %d assignment(s).", len(updated_references)
             )
-
-    def sanitize_lcsc(self, lcsc_PN: str) -> str:
-        """Sanitize a given LCSC number using a regex."""
-        m = re.search("C\\d+", lcsc_PN, re.IGNORECASE)
-        if m:
-            return m.group(0).upper()
-        return ""
 
     def OnRightDown(self, *_: object) -> None:
         """Right click context menu for action on parts table."""

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -78,7 +78,7 @@ from .helpers import (
     loadBitmapScaled,
 )
 from .kicad_drc import DRCViolationCounter
-from .lcsc import extract_lcsc, normalize_lcsc
+from .lcsc import Lcsc, extract_lcsc, format_lcsc
 from .library import CorrectionState, Library, LibraryState
 from .partdetails import PartDetailsDialog
 from .part_preferences import PartPreferencesDialog
@@ -1468,9 +1468,10 @@ class JLCPCBTools(wx.Dialog):
                 continue
             is_dnp = get_is_dnp(fp)
             # Get part stock and type from library, skip if part number was already looked up before
-            # Keyed canonically: the store can hold two spellings of one number.
-            lcsc = normalize_lcsc(part["lcsc"])
-            if lcsc and lcsc not in details:
+            # Keyed on the parsed part, so two spellings of one number cannot
+            # become two cache entries and two round trips.
+            lcsc = Lcsc.parse(part["lcsc"])
+            if lcsc is not None and lcsc not in details:
                 details[lcsc] = self.library.get_part_details(lcsc)
             # don't show the part if hide BOM is set
             if self.hide_bom_parts and part["exclude_from_bom"]:
@@ -1483,7 +1484,10 @@ class JLCPCBTools(wx.Dialog):
                     part["reference"],
                     part["value"],
                     part["footprint"],
-                    part["lcsc"],
+                    # The canonical form, so the column agrees with the details
+                    # beside it rather than showing whatever spelling the store
+                    # happens to hold.
+                    format_lcsc(lcsc),
                     details.get(lcsc, {}).get("type", ""),  # type
                     details.get(lcsc, {}).get("stock", ""),  # stock
                     part["exclude_from_bom"],

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -78,6 +78,7 @@ from .helpers import (
     loadBitmapScaled,
 )
 from .kicad_drc import DRCViolationCounter
+from .lcsc import normalize_lcsc
 from .library import CorrectionState, Library, LibraryState
 from .partdetails import PartDetailsDialog
 from .part_preferences import PartPreferencesDialog
@@ -1467,8 +1468,10 @@ class JLCPCBTools(wx.Dialog):
                 continue
             is_dnp = get_is_dnp(fp)
             # Get part stock and type from library, skip if part number was already looked up before
-            if part["lcsc"] and part["lcsc"] not in details:
-                details[part["lcsc"]] = self.library.get_part_details(part["lcsc"])
+            # Keyed canonically: the store can hold two spellings of one number.
+            lcsc = normalize_lcsc(part["lcsc"])
+            if lcsc and lcsc not in details:
+                details[lcsc] = self.library.get_part_details(lcsc)
             # don't show the part if hide BOM is set
             if self.hide_bom_parts and part["exclude_from_bom"]:
                 continue
@@ -1481,8 +1484,8 @@ class JLCPCBTools(wx.Dialog):
                     part["value"],
                     part["footprint"],
                     part["lcsc"],
-                    details.get(part["lcsc"], {}).get("type", ""),  # type
-                    details.get(part["lcsc"], {}).get("stock", ""),  # stock
+                    details.get(lcsc, {}).get("type", ""),  # type
+                    details.get(lcsc, {}).get("stock", ""),  # stock
                     part["exclude_from_bom"],
                     part["exclude_from_pos"],
                     int(is_dnp),
@@ -1492,7 +1495,7 @@ class JLCPCBTools(wx.Dialog):
                         else "Unresolved"
                     ),
                     str(fp.GetLayer()),
-                    params_for_part(details.get(part["lcsc"], {})),
+                    params_for_part(details.get(lcsc, {})),
                     self._get_enrichment_status_label(part),  # enrichment
                     "",  # bom price label
                 ]

--- a/tests/test_correction_data.py
+++ b/tests/test_correction_data.py
@@ -1,29 +1,30 @@
 """Exercise the correction data contract without importing KiCad or wx."""
 
+from collections.abc import Iterator
 import csv
 from dataclasses import FrozenInstanceError, replace
-import importlib.util
 from io import StringIO
 import math
-from pathlib import Path
 import sqlite3
 import sys
 from types import ModuleType
 
 import pytest
 
-_ROOT = Path(__file__).resolve().parents[1]
+from tests.wx_harness import load_siblings
 
 
 @pytest.fixture
-def data(monkeypatch):
-    """Load the production validator with a scoped module registration."""
-    name = "correction_data_validation_tests"
-    spec = importlib.util.spec_from_file_location(name, _ROOT / "correction_data.py")
-    module = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, name, module)
-    spec.loader.exec_module(module)
-    return module
+def data() -> Iterator[ModuleType]:
+    """Load the production validator under a scoped package, without GUI imports.
+
+    The module reaches ``lcsc`` through a relative import, so it needs a
+    parent package; nothing else from the plugin is loaded.
+    """
+    with load_siblings(
+        "correction_data_validation_tests", ("correction_data",), {}
+    ) as loaded:
+        yield loaded["correction_data"]
 
 
 @pytest.mark.parametrize(
@@ -653,3 +654,56 @@ def test_serialization_roundtrips_exact_values(
     assert math.copysign(1, csv_correction.offset[0]) == math.copysign(1, offset[0])
     editor = correction.editor_values()
     assert data.Correction.parse(editor[0], editor[1], editor[2:]) == correction
+
+
+@pytest.mark.parametrize(
+    ("lcsc", "expected"),
+    [("C12345", "C12345"), ("c12345", "C12345"), (" C12345\n", "C12345")],
+)
+def test_lcsc_correction_keeps_the_canonical_part_number(
+    data: ModuleType, lcsc: str, expected: str
+) -> None:
+    """Every spelling a part number arrives in reaches one exact-match key."""
+    correction = data.LcscCorrection(lcsc, "90.0", ("0.5", 1))
+    assert correction.lcsc == correction.key == expected
+    assert (correction.rotation, correction.offset) == (90, (0.5, 1.0))
+    assert correction.db_row() == (expected, 90, 0.5, 1.0)
+    assert correction.editor_values() == (expected, "90", "0.5", "1.0")
+    assert str(correction) == "90°, 0.5/1.0"
+    assert correction == data.LcscCorrection(expected, 90, (0.5, 1))
+    with pytest.raises(FrozenInstanceError):
+        correction.lcsc = "C1"
+
+
+@pytest.mark.parametrize(
+    "lcsc", ["^C12345$", "C12345|C999", "SOT-23", "", " ", "C", "12345", None, 12345]
+)
+def test_lcsc_correction_rejects_anything_but_a_part_number(
+    data: ModuleType, lcsc: object
+) -> None:
+    """An exact key that is really a pattern would silently never match."""
+    with pytest.raises(data.CorrectionDataError) as error:
+        data.LcscCorrection(lcsc, 90, (0, 0))
+    (issue,) = error.value.issues
+    assert (issue.field, issue.value) == ("lcsc", lcsc)
+    assert "C12345" in issue.message
+    assert data.LcscCorrection.parse(lcsc, 90, (0, 0)) is None
+
+
+def test_lcsc_correction_reports_every_field_at_once(data: ModuleType) -> None:
+    """Rotation and offsets are validated by the same rules as pattern corrections."""
+    with pytest.raises(data.CorrectionDataError) as error:
+        data.validate_lcsc_correction("bad", "47u", ("x", 0), source="db", rowid=7)
+    assert [issue.field for issue in error.value.issues] == [
+        "lcsc",
+        "rotation",
+        "offset_x",
+    ]
+    assert all((issue.source, issue.rowid) == ("db", 7) for issue in error.value.issues)
+
+
+def test_correction_kind_names_the_table(data: ModuleType) -> None:
+    """Consumers route a validated value by its kind, never by inspecting text."""
+    assert data.correction_kind(data.Correction("C12345", 0, (0, 0))) == "footprint"
+    assert data.correction_kind(data.LcscCorrection("C12345", 0, (0, 0))) == "lcsc"
+    assert data.Correction("C12345", 0, (0, 0)).key == "C12345"

--- a/tests/test_correction_matching.py
+++ b/tests/test_correction_matching.py
@@ -1,27 +1,23 @@
 """Keep display and fabrication selection on the established CPL policy."""
 
+from collections.abc import Iterator
 from dataclasses import FrozenInstanceError
-import importlib.util
-from pathlib import Path
 import re
-import sys
 from types import ModuleType
 from typing import Optional
 
 import pytest
 
-_ROOT = Path(__file__).resolve().parents[1]
+from tests.wx_harness import load_siblings
 
 
 @pytest.fixture
-def data(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
-    """Load the pure production matcher without GUI or database imports."""
-    name = "correction_data_matching_tests"
-    spec = importlib.util.spec_from_file_location(name, _ROOT / "correction_data.py")
-    module = importlib.util.module_from_spec(spec)
-    monkeypatch.setitem(sys.modules, name, module)
-    spec.loader.exec_module(module)
-    return module
+def data() -> Iterator[ModuleType]:
+    """Load the pure production matcher under a scoped package, without GUI imports."""
+    with load_siblings(
+        "correction_data_matching_tests", ("correction_data",), {}
+    ) as loaded:
+        yield loaded["correction_data"]
 
 
 @pytest.mark.parametrize(
@@ -169,3 +165,50 @@ def test_large_correction_set_never_recompiles_during_matching(
                 assert match.correction is corrections[expected]
                 assert match.source == source
     assert len(compile_requests) == 0
+
+
+@pytest.mark.parametrize("spelling", ["C12345", "c12345", " C12345 "])
+def test_part_number_rule_outranks_every_pattern(
+    data: ModuleType, spelling: str
+) -> None:
+    """The exact part wins over reference, value and footprint rules alike."""
+    part = data.LcscCorrection("C12345", 45, (1, 1))
+    patterns = (
+        data.Correction("U1", 90, (0, 0)),
+        data.Correction("Device", 180, (0, 0)),
+        data.Correction("SOT-23-3", 270, (0, 0)),
+    )
+    match = data.match_correction(
+        (*patterns, part), "U1", "Device", "SOT-23-3", spelling
+    )
+    assert match.correction is part
+    assert match.source == "lcsc"
+
+
+def test_zero_part_rule_still_switches_the_family_rule_off(data: ModuleType) -> None:
+    """A part set to 0 degrees, 0/0 is an explicit rule, not a missing one."""
+    part = data.LcscCorrection("C12345", 0, (0, 0))
+    family = data.Correction("SOT-23-3", 180, (1, 2))
+    match = data.match_correction((family, part), "U1", "Device", "SOT-23-3", "C12345")
+    assert match.correction is part
+    assert match.source == "lcsc"
+
+
+@pytest.mark.parametrize("lcsc", ["", None, "C99999", "C1234", "C123456"])
+def test_other_parts_and_unassigned_parts_fall_through_to_patterns(
+    data: ModuleType, lcsc: object
+) -> None:
+    """Only the exact part number is overridden; siblings keep the family rule."""
+    part = data.LcscCorrection("C12345", 0, (0, 0))
+    family = data.Correction("SOT-23-3", 180, (1, 2))
+    match = data.match_correction((part, family), "U1", "Device", "SOT-23-3", lcsc)
+    assert match.correction is family
+    assert match.source == "fpt"
+    assert data.match_correction((part,), "U1", "Device", "SOT-23-3", lcsc) is None
+
+
+def test_part_rules_never_take_part_in_pattern_matching(data: ModuleType) -> None:
+    """A part number is not a pattern, even when it would read as one."""
+    part = data.LcscCorrection("C1", 90, (0, 0))
+    assert data.find_correction((part,), "C1") is None
+    assert data.match_correction((part,), "C1", "C1", "C1") is None

--- a/tests/test_corrections_import_export.py
+++ b/tests/test_corrections_import_export.py
@@ -1084,7 +1084,7 @@ def test_manager_constructor_imports_only_after_controls_exist(
     parent = SimpleNamespace(library=library, scale_factor=1, window=object())
     dialog = modules.corrections.CorrectionManagerDialog(parent, "R1")
     assert len(dialog.corrections_list.rows) == 1
-    assert dialog.corrections_list.rows == [["R1", "90", "0.0", "0.0", ""]]
+    assert dialog.corrections_list.rows == [["R1", "90", "0.0", "0.0", "", "Footprint"]]
     assert (
         modules.wx.dataview.DataViewListCtrl.call_args.kwargs["style"]
         == modules.wx.dataview.DV_SINGLE
@@ -1095,6 +1095,7 @@ def test_manager_constructor_imports_only_after_controls_exist(
         "Offset X",
         "Offset Y",
         "Status",
+        "Kind",
     ]
     assert dialog.global_corrections.GetValue() is True
     select(dialog, 0)

--- a/tests/test_corrections_manager.py
+++ b/tests/test_corrections_manager.py
@@ -1,0 +1,359 @@
+"""Exercise part-number rules through the real Corrections Manager constructor."""
+
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.correction_test_support import make_library, raw_rows, seed_raw
+from tests.test_corrections_import_export import (
+    field_values,
+    install_manager_controls,
+    manager,
+    select,
+    set_inputs,
+)
+from tests.test_library_lcsc_corrections import execute, lcsc_rows
+from tests.wx_harness import load_correction_modules
+
+
+@pytest.fixture
+def modules() -> Iterator[SimpleNamespace]:
+    """Keep production siblings under one package for the full test lifecycle."""
+    with load_correction_modules() as loaded:
+        yield loaded
+
+
+@pytest.fixture
+def setup(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[SimpleNamespace, Any, Any]:
+    """Provide real production imports, real SQLite, and captured controls."""
+    library = make_library(modules.library, tmp_path)
+    return modules, library, manager(modules, library, monkeypatch)
+
+
+def kinds(dialog: Any) -> list[str]:
+    """Read the Kind column as displayed."""
+    return [row[-1] for row in dialog.corrections_list.rows]
+
+
+@pytest.mark.parametrize(
+    ("footprint", "lcsc_part", "text", "ticked"),
+    [("^SOT-23", "", "^SOT-23", False), ("", "c12345", "c12345", True)],
+)
+def test_constructor_prefills_the_form_for_the_requested_kind(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    footprint: str,
+    lcsc_part: str,
+    text: str,
+    ticked: bool,
+) -> None:
+    """The parts list opens the manager either on a pattern or on a part number."""
+    library = make_library(modules.library, tmp_path)
+    install_manager_controls(modules, library, monkeypatch)
+    parent = SimpleNamespace(library=library, scale_factor=1, window=object())
+    dialog = modules.corrections.CorrectionManagerDialog(
+        parent, footprint, lcsc_part=lcsc_part
+    )
+    assert dialog.regex.GetValue() == text
+    assert dialog.lcsc_mode.GetValue() is ticked
+    assert dialog.corrections_list.columns[-1] == "Kind"
+
+
+def test_save_routes_each_kind_to_its_own_table(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """The checkbox decides which table a rule goes to, and the list says which."""
+    modules, library, dialog = setup
+    set_inputs(dialog, pattern="^SOT-23", rotation="180")
+    assert dialog.save_correction() is True
+    assert [row[1] for row in raw_rows(library)] == ["^SOT-23"]
+    assert lcsc_rows(library) == []
+
+    dialog.lcsc_mode.SetValue(True)
+    set_inputs(dialog, pattern="c12345", rotation="90")
+    assert dialog.save_correction() is True
+
+    assert lcsc_rows(library) == [(1, "C12345", 90, 0.0, 0.0)]
+    assert [row[1] for row in raw_rows(library)] == ["^SOT-23"]
+    assert kinds(dialog) == ["Footprint", "LCSC"]
+    assert dialog.selected_record.kind == "lcsc"
+    assert field_values(dialog) == ("C12345", "90", "0.0", "0.0")
+    assert modules.wx.PostEvent.call_count == 2
+
+
+@pytest.mark.parametrize("key", ["^C12345$", "C12345|C999", "SOT-23", "C", ""])
+def test_invalid_part_number_is_refused_and_inputs_kept(
+    setup: tuple[SimpleNamespace, Any, Any], key: str
+) -> None:
+    """A part rule that is not a bare part number would silently never fire."""
+    modules, library, dialog = setup
+    dialog.lcsc_mode.SetValue(True)
+    set_inputs(dialog, pattern=key, rotation="90")
+    inputs = field_values(dialog)
+
+    assert dialog.save_correction() is False
+
+    assert lcsc_rows(library) == []
+    assert raw_rows(library) == []
+    assert field_values(dialog) == inputs
+    assert dialog.lcsc_mode.GetValue() is True
+    assert "C12345" in str(modules.wx.MessageBox.call_args)
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_switching_kind_leaves_the_selected_rule_alone(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Editing the key moves a rule; changing its kind describes a new one.
+
+    One checkbox click must not silently delete an unrelated pattern rule.
+    """
+    modules, library, dialog = setup
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    dialog.lcsc_mode.SetValue(True)
+    dialog.regex.SetValue("C12345")
+
+    assert dialog.save_correction() is True
+
+    assert raw_rows(library) == [(1, "^SOT-23", 180, 0.0, 0.0)]
+    assert lcsc_rows(library) == [(1, "C12345", 180, 0.0, 0.0)]
+    assert (dialog.selected_record.kind, dialog.selected_record.rowid) == ("lcsc", 1)
+    modules.wx.PostEvent.assert_called_once()
+
+
+def test_checkbox_only_change_survives_a_list_refresh(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """A changed kind is an unsaved edit and survives a list refresh like changed text.
+
+    Ticking the LCSC checkbox with no text edit must not be silently reverted
+    when some unrelated event triggers ``populate_corrections_list``.
+    """
+    _modules, library, dialog = setup
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    entered = field_values(dialog)
+    dialog.lcsc_mode.SetValue(True)
+
+    dialog.populate_corrections_list()
+
+    assert dialog.lcsc_mode.GetValue() is True
+    assert field_values(dialog) == entered
+
+
+def test_editing_the_key_within_one_kind_still_moves_the_rule(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Renaming a part rule repairs that row rather than adding a second one."""
+    _modules, library, dialog = setup
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    assert dialog.lcsc_mode.GetValue() is True
+    dialog.regex.SetValue("C99999")
+    dialog.rotation.SetValue("180")
+
+    assert dialog.save_correction() is True
+
+    assert lcsc_rows(library) == [(1, "C99999", 180, 0.0, 0.0)]
+
+
+def test_a_matching_key_of_the_other_kind_is_not_a_conflict(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """A pattern rule spelled C12345 and a part rule for C12345 are independent."""
+    modules, library, dialog = setup
+    library.insert_correction_data("C12345", 180, (0, 0))
+    dialog.populate_corrections_list()
+    dialog.lcsc_mode.SetValue(True)
+    set_inputs(dialog, pattern="C12345", rotation="90")
+
+    assert dialog.save_correction() is True
+
+    modules.wx.MessageDialog.assert_not_called()
+    assert raw_rows(library) == [(1, "C12345", 180, 0.0, 0.0)]
+    assert lcsc_rows(library) == [(1, "C12345", 90, 0.0, 0.0)]
+    assert kinds(dialog) == ["Footprint", "LCSC"]
+
+
+def test_identical_existing_part_rule_selects_without_writing(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Entering a rule that already exists, however spelled, just selects it."""
+    modules, library, dialog = setup
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    dialog.populate_corrections_list()
+    dialog.lcsc_mode.SetValue(True)
+    set_inputs(dialog, pattern=" c12345 ", rotation="90")
+
+    assert dialog.save_correction() is True
+
+    assert lcsc_rows(library) == [(1, "C12345", 90, 0.0, 0.0)]
+    assert (dialog.selected_record.kind, dialog.selected_record.rowid) == ("lcsc", 1)
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_replacing_a_part_rule_by_another_spelling_needs_confirmation(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Different values for one part number are a replacement the user confirms."""
+    modules, library, dialog = setup
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    dialog.populate_corrections_list()
+    dialog.lcsc_mode.SetValue(True)
+    set_inputs(dialog, pattern="c12345", rotation="180")
+
+    assert dialog.save_correction() is False
+    assert lcsc_rows(library) == [(1, "C12345", 90, 0.0, 0.0)]
+    assert modules.wx.MessageDialog.call_args.args[2] == "Part number exists!"
+
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    assert dialog.save_correction() is True
+    # The replaced row is deleted first, so SQLite hands out its rowid again.
+    assert lcsc_rows(library) == [(1, "C12345", 180, 0.0, 0.0)]
+
+
+def test_delete_targets_the_selected_kind(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Row 1 of one table is not row 1 of the other."""
+    _modules, library, dialog = setup
+    library.insert_correction_data("R1", 90, (0, 0))
+    library.insert_lcsc_correction_data("C1", 180, (0, 0))
+    dialog.populate_corrections_list()
+    assert kinds(dialog) == ["Footprint", "LCSC"]
+
+    select(dialog, 1)
+    assert dialog.lcsc_mode.GetValue() is True
+    assert dialog.delete_correction() is True
+    assert lcsc_rows(library) == []
+    assert raw_rows(library) == [(1, "R1", 90, 0.0, 0.0)]
+
+    select(dialog, 0)
+    assert dialog.lcsc_mode.GetValue() is False
+    assert dialog.delete_correction() is True
+    assert raw_rows(library) == []
+
+
+def test_invalid_part_rule_is_listed_for_repair(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed part rule is shown with its kind and repaired in place."""
+    library = make_library(modules.library, tmp_path)
+    execute(
+        library.correctionsdb_file,
+        "INSERT INTO lcsc_correction VALUES ('C1', '47u', 0, 0)",
+    )
+    dialog = manager(modules, library, monkeypatch)
+    (row,) = dialog.corrections_list.rows
+    assert row[0] == "C1"
+    assert "rotation" in row[4]
+    assert row[5] == "LCSC"
+    assert "need repair" in dialog.correction_status.value
+
+    select(dialog, 0)
+    dialog.rotation.SetValue("90")
+    assert dialog.save_correction() is True
+    assert lcsc_rows(library) == [(1, "C1", 90, 0.0, 0.0)]
+    assert "need repair" not in dialog.correction_status.value
+
+
+def test_export_writes_pattern_rules_only(
+    setup: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """The CSV format has no part-number field, so part rules stay out of it."""
+    _modules, library, dialog = setup
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    path = tmp_path / "export.csv"
+
+    assert dialog._export_corrections(path) is True
+
+    assert path.read_text().splitlines() == [
+        '"Pattern","Rotation","Offset X","Offset Y"',
+        '"^SOT-23","180","0.0","0.0"',
+    ]
+
+
+def test_seeded_rows_of_both_kinds_survive_a_scope_switch(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Switching to a project database through the manager carries both kinds."""
+    modules, library, dialog = setup
+    seed_raw(library, [("^SOT-23", 180, 0, 0)])
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+
+    assert dialog.on_global_corrections_changed() is True
+
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert kinds(dialog) == ["Footprint", "LCSC"]
+    assert lcsc_rows(library) == [(1, "C12345", 90, 0.0, 0.0)]
+
+
+def test_replacement_prompt_names_kinds_and_does_not_promise_a_kind_switch(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """With a pattern row selected, a part rule save is an insert, and says so."""
+    modules, library, dialog = setup
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    dialog.lcsc_mode.SetValue(True)
+    set_inputs(dialog, pattern="C12345", rotation="45")
+
+    assert dialog.save_correction() is False
+
+    prompt = modules.wx.MessageDialog.return_value.ExtendedMessage
+    assert "Row 1 (LCSC): 90°, 0.0/0.0" in prompt
+    assert "will become" not in prompt
+    assert modules.wx.MessageDialog.call_args.args[2] == "Part number exists!"
+    assert raw_rows(library) == [(1, "^SOT-23", 180, 0.0, 0.0)]
+    assert lcsc_rows(library) == [(1, "C12345", 90, 0.0, 0.0)]
+
+
+def test_replacement_prompt_names_the_edited_row_of_the_same_kind(
+    setup: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Renaming a part rule onto another's key says which row is being edited."""
+    modules, library, dialog = setup
+    library.insert_lcsc_correction_data("C1", 90, (0, 0))
+    library.insert_lcsc_correction_data("C2", 180, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 1)
+    dialog.regex.SetValue("C1")
+
+    assert dialog.save_correction() is False
+
+    prompt = modules.wx.MessageDialog.return_value.ExtendedMessage
+    assert "Row 1 (LCSC): 90°, 0.0/0.0" in prompt
+    assert "The selected row 2 (LCSC) will become 'C1'." in prompt
+
+
+def test_export_reports_the_part_rules_it_leaves_out(
+    setup: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """A backup that silently lost part rules would surprise on re-import."""
+    modules, library, dialog = setup
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    assert dialog._export_corrections(tmp_path / "patterns.csv") is True
+    modules.wx.MessageBox.assert_not_called()
+
+    library.insert_lcsc_correction_data("C1", 90, (0, 0))
+    library.insert_lcsc_correction_data("C2", 90, (0, 0))
+    assert dialog._export_corrections(tmp_path / "mixed.csv") is True
+
+    modules.wx.MessageBox.assert_called_once()
+    message = modules.wx.MessageBox.call_args.args[0]
+    assert message.startswith("2 LCSC part-number rule")
+    assert "pattern rules only" in message

--- a/tests/test_fabrication_corrections.py
+++ b/tests/test_fabrication_corrections.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -182,3 +183,176 @@ def test_parts_table_reports_the_correction_used_by_cpl(
     assert float(row["Rotation"]) == rotation % 360
     assert float(row["Mid X"]) == pytest.approx(9 + offset[0])
     assert float(row["Mid Y"]) == pytest.approx(-18 - offset[1])
+
+
+@pytest.mark.parametrize(
+    ("records", "part_rules", "lcsc", "rotation", "offset", "source"),
+    [
+        pytest.param(
+            [("SOT-23-3", 180, (1, 1))],
+            [("C12345", 90, (0.5, -0.5))],
+            "C12345",
+            90,
+            (0.5, -0.5),
+            "lcsc",
+            id="part-rule-beats-its-footprint-family",
+        ),
+        pytest.param(
+            [("SOT-23-3", 180, (1, 1))],
+            [("C12345", 0, (0, 0))],
+            "C12345",
+            0,
+            (0, 0),
+            "lcsc",
+            id="zero-part-rule-switches-the-family-off",
+        ),
+        pytest.param(
+            [("SOT-23-3", 180, (1, 1))],
+            [("C12345", 0, (0, 0))],
+            "C99999",
+            180,
+            (1, 1),
+            "fpt",
+            id="sibling-on-the-same-footprint-keeps-the-family",
+        ),
+        pytest.param(
+            [("SOT-23-3", 180, (1, 1))],
+            [("C12345", 0, (0, 0))],
+            "",
+            180,
+            (1, 1),
+            "fpt",
+            id="unassigned-part-falls-through",
+        ),
+        pytest.param(
+            [("U1", 45, (0, 0)), ("Device", 135, (0, 0))],
+            [("C12345", 90, (0, 0))],
+            "C12345",
+            90,
+            (0, 0),
+            "lcsc",
+            id="part-rule-beats-reference-and-value",
+        ),
+        pytest.param(
+            [],
+            [("C12345", 90, (0, 0))],
+            "c12345",
+            90,
+            (0, 0),
+            "lcsc",
+            id="lower-case-store-value-still-matches",
+        ),
+        pytest.param(
+            [],
+            [("C12345", 90, (0, 0))],
+            "C1234",
+            0,
+            (0, 0),
+            None,
+            id="exact-not-prefix",
+        ),
+    ],
+)
+def test_part_rules_share_the_display_and_cpl_policy(
+    runtime: SimpleNamespace,
+    tmp_path: Path,
+    records: list[tuple[str, int, tuple[float, float]]],
+    part_rules: list[tuple[str, int, tuple[float, float]]],
+    lcsc: str,
+    rotation: int,
+    offset: tuple[float, float],
+    source: Any,
+) -> None:
+    """A rule for the exact part is what the table shows and the CPL applies.
+
+    Two parts on one footprint name are the case no pattern can express: the
+    overridden part gets its own rotation while its sibling keeps the family's.
+    """
+    runtime.library.apply_corrections(records)
+    for key, degrees, part_offset in part_rules:
+        runtime.library.insert_lcsc_correction_data(key, degrees, part_offset)
+    fabrication = make_fabrication(runtime.modules, runtime.library, tmp_path)
+    fp = make_footprint("U1", 0, 0, Point(10, 20))
+    fp.GetFPID = lambda: SimpleNamespace(GetLibItemName=lambda: "SOT-23-3")
+    fabrication.board.Footprints.return_value = [fp]
+    part = {
+        "reference": "U1",
+        "value": "Device",
+        "footprint": "SOT-23-3",
+        "exclude_from_bom": 0,
+        "exclude_from_pos": 0,
+        "lcsc": lcsc,
+    }
+    fabrication.parent.store.get_part = lambda _reference: part
+    window = _population_window(runtime)
+    # The parts list looks up stock and type for an assigned number; there is
+    # no parts database here, and that lookup is not what is under test.
+    window.library.get_part_details = lambda _lcsc: {}
+    window.store.read_all.return_value = [part]
+    window.pcbnew = SimpleNamespace(
+        GetBoard=lambda: SimpleNamespace(FindFootprintByReference=lambda _reference: fp)
+    )
+
+    window.populate_footprint_list()
+    fabrication.generate_cpl()
+
+    expected = (
+        f"{rotation}°, {float(offset[0])}/{float(offset[1])} ({source})"
+        if source is not None
+        else "0°, 0.0/0.0"
+    )
+    assert _displayed_corrections(window) == [expected]
+    (row,) = read_cpl(fabrication)
+    assert float(row["Rotation"]) == rotation % 360
+    assert float(row["Mid X"]) == pytest.approx(9 + offset[0])
+    assert float(row["Mid Y"]) == pytest.approx(-18 - offset[1])
+
+
+def test_cpl_resolves_the_stored_part_number_not_the_footprint_field(
+    runtime: SimpleNamespace, tmp_path: Path
+) -> None:
+    """The BOM orders the store's number, so the CPL must rotate for that one.
+
+    "Paste LCSC" and "Find LCSC from Mappings" write the store without touching
+    the footprint field, so a stale field would rotate one part while the BOM
+    ordered another -- the silent wrong rotation part rules exist to prevent.
+    """
+    runtime.library.insert_lcsc_correction_data("C111", 180, (0, 0))
+    runtime.library.insert_lcsc_correction_data("C222", 90, (0, 0))
+    fabrication = make_fabrication(runtime.modules, runtime.library, tmp_path)
+    fp = make_footprint("U1", 0, 0, Point(10, 20))
+    fp.GetFields = MagicMock(
+        return_value=[SimpleNamespace(GetName=lambda: "LCSC", GetText=lambda: "C111")]
+    )
+    fp.GetProperties = MagicMock(return_value={"LCSC": "C111"})
+    fabrication.board.Footprints.return_value = [fp]
+    part = {
+        "reference": "U1",
+        "value": "Device",
+        "footprint": "Package:Device",
+        "exclude_from_pos": 0,
+        "lcsc": "C222",
+    }
+    fabrication.parent.store.get_part = lambda _reference: part
+
+    fabrication.generate_cpl()
+
+    (row,) = read_cpl(fabrication)
+    assert float(row["Rotation"]) == 90
+    fp.GetFields.assert_not_called()
+    fp.GetProperties.assert_not_called()
+
+
+def test_public_wrappers_take_the_part_number(
+    runtime: SimpleNamespace, tmp_path: Path
+) -> None:
+    """fix_rotation and fix_position resolve the part only when given its number."""
+    runtime.library.insert_lcsc_correction_data("C12345", 90, (1, 0))
+    fabrication = make_fabrication(runtime.modules, runtime.library, tmp_path)
+    fabrication.corrections = runtime.library.get_all_correction_data()
+    fp = make_footprint("U1", 0, 0, Point(10, 20))
+
+    assert fabrication.fix_rotation(fp, "C12345") == 90
+    assert fabrication.fix_rotation(fp) == 0
+    assert fabrication.fix_position(fp, Point(10, 20), "C12345") == Point(11, 20)
+    assert fabrication.fix_position(fp, Point(10, 20)) == Point(10, 20)

--- a/tests/test_footprint_lcsc_field.py
+++ b/tests/test_footprint_lcsc_field.py
@@ -1,0 +1,231 @@
+"""Tests for reading and writing the LCSC field on a footprint (issue #773)."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+# footprint_helpers imports .lcsc relatively, so give it a package to resolve
+# against. Neither module touches wx or pcbnew, so both load for real.
+_pkg = sys.modules.get("kicadplugin")
+if _pkg is None:
+    _pkg = types.ModuleType("kicadplugin")
+    _pkg.__path__ = [str(_ROOT)]
+    sys.modules["kicadplugin"] = _pkg
+
+_spec = importlib.util.spec_from_file_location(
+    "kicadplugin.footprint_helpers", _ROOT / "footprint_helpers.py"
+)
+assert _spec is not None and _spec.loader is not None
+_fh = importlib.util.module_from_spec(_spec)
+_fh.__package__ = "kicadplugin"
+sys.modules["kicadplugin.footprint_helpers"] = _fh
+_spec.loader.exec_module(_fh)
+
+get_lcsc_value = _fh.get_lcsc_value
+set_lcsc_value = _fh.set_lcsc_value
+
+
+class FakeField:
+    """A KiCad footprint field."""
+
+    def __init__(self, name, text):
+        self.name = name
+        self.text = text
+        self.visible = True
+
+    def GetName(self):
+        """Return the field name."""
+        return self.name
+
+    def GetText(self):
+        """Return the field value."""
+        return self.text
+
+    def SetVisible(self, visible):
+        """Record the field's visibility."""
+        self.visible = visible
+
+
+class FakeFootprint:
+    """A KiCad 7.99+ footprint, which exposes fields rather than properties."""
+
+    def __init__(self, *fields):
+        self.fields = list(fields)
+
+    def GetFields(self):
+        """Return every field on the footprint."""
+        return self.fields
+
+    def SetField(self, name, value):
+        """Set a field by name, adding it if it does not exist yet."""
+        for field in self.fields:
+            if field.GetName() == name:
+                field.text = value
+                return
+        self.fields.append(FakeField(name, value))
+
+
+class LegacyFootprint:
+    """A KiCad <= 7 footprint, which exposes a properties dict."""
+
+    def __init__(self, properties):
+        self.properties = properties
+
+    def GetFields(self):
+        """Raise the way the older API does, so callers fall back."""
+        raise AttributeError("GetFields")
+
+    def GetProperties(self):
+        """Return the footprint's properties."""
+        return self.properties
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+class TestReadingTheField:
+    """A part number is recognised whatever spacing or case it was typed in."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "C12345",
+            "C12345 ",
+            " C12345",
+            "  C12345  ",
+            "C12345\n",
+            "\tC12345",
+            "c12345",
+        ],
+    )
+    def test_a_part_number_is_found(self, text):
+        r"""Stray whitespace or lower case no longer hides the part.
+
+        Reported as issue #773: a schematic field of "C12345 " left the part
+        blank in the parts list, because the value went straight into
+        re.match(r"^C\\d+$", ...) which a trailing space fails. Lower case
+        failed the same test, and a trailing newline passed it, since $ also
+        matches before a final newline.
+        """
+        footprint = FakeFootprint(FakeField("LCSC Part #", text))
+        assert get_lcsc_value(footprint) == "C12345"
+
+    @pytest.mark.parametrize("text", ["", "  ", "not a part", "C", "12345", "CC12345"])
+    def test_a_non_part_number_is_still_rejected(self, text):
+        """Values that do not name a part are still ignored."""
+        footprint = FakeFootprint(FakeField("LCSC Part #", text))
+        assert get_lcsc_value(footprint) == ""
+
+    def test_the_users_own_field_wins_over_a_plugin_written_one(self):
+        """An untrimmed field is preferred over a later duplicate.
+
+        Before normalisation the untrimmed field failed the match, so a second
+        field written by the plugin was returned instead -- the BOM, CPL and
+        corrections all silently used a different part than the schematic said.
+        """
+        footprint = FakeFootprint(
+            FakeField("LCSC Part #", "C12345 "),
+            FakeField("LCSC", "C99999"),
+        )
+        assert get_lcsc_value(footprint) == "C12345"
+
+    def test_legacy_properties_are_normalised_too(self):
+        """The KiCad <= 7 properties path gets the same treatment."""
+        footprint = LegacyFootprint({"LCSC Part #": " c12345 "})
+        assert get_lcsc_value(footprint) == "C12345"
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+
+
+class TestWritingTheField:
+    """Assignments write the canonical form, and reuse the field already there."""
+
+    def test_an_untrimmed_field_is_reused_not_duplicated(self):
+        """Assigning a part overwrites the existing field and repairs it.
+
+        The original set_lcsc_value used the reader's raw regex to find the
+        field to overwrite, so an untrimmed one was invisible to it and a
+        second field named LCSC was added alongside. #809 already widened the
+        write-side test; this guards that the shared predicate keeps it wide.
+        """
+        field = FakeField("LCSC Part #", "C12345 ")
+        footprint = FakeFootprint(field)
+        set_lcsc_value(footprint, "C99999")
+        assert [f.GetName() for f in footprint.GetFields()] == ["LCSC Part #"]
+        assert field.GetText() == "C99999"
+
+    def test_it_writes_the_field_that_reading_will_use(self):
+        """Assignment lands in the field get_lcsc_value reads back.
+
+        A footprint can carry more than one matching field -- the duplicate
+        pair older releases created is exactly that. Reading takes the first
+        match and writing (since #809) fills every claiming field, so the two
+        agree by construction; this guards that the read side's new tolerance
+        does not reopen a gap between them.
+        """
+        footprint = FakeFootprint(
+            FakeField("LCSC Part #", "C12345 "),
+            FakeField("LCSC", "C99999"),
+        )
+        set_lcsc_value(footprint, "C77777")
+        assert get_lcsc_value(footprint) == "C77777"
+
+    def test_every_field_claiming_the_part_is_rewritten(self):
+        """A duplicate is repaired rather than left holding a stale number.
+
+        Writing into every field that claims the part is #809's behaviour,
+        kept here: leaving the second field on its old value would only move
+        the disagreement, since a later read that picks the other field still
+        returns a part the user never assigned.
+        """
+        user_field = FakeField("LCSC Part #", "C12345 ")
+        stale = FakeField("LCSC", "C99999")
+        set_lcsc_value(FakeFootprint(user_field, stale), "C77777")
+        assert user_field.GetText() == "C77777"
+        assert stale.GetText() == "C77777"
+
+    def test_clearing_removes_every_claim_on_the_part(self):
+        """Removal clears all matching fields, not just the first.
+
+        remove_lcsc_number exists to say "this part has no LCSC number". A
+        duplicate field left over from an older version still claiming one
+        would put the part straight back on the next reload, since the store
+        is rebuilt from the board. #809's write-all loop covers this; the
+        guard is that an untrimmed duplicate now counts as claiming too.
+        """
+        footprint = FakeFootprint(
+            FakeField("LCSC Part #", "C12345 "),
+            FakeField("LCSC", "C99999"),
+        )
+        set_lcsc_value(footprint, "")
+        assert get_lcsc_value(footprint) == ""
+
+    def test_the_written_value_is_canonical(self):
+        """A part number is stored trimmed and upper case."""
+        footprint = FakeFootprint(FakeField("LCSC Part #", "C12345"))
+        set_lcsc_value(footprint, " c99999 ")
+        assert footprint.GetFields()[0].GetText() == "C99999"
+
+    def test_a_footprint_without_a_field_gains_a_hidden_one(self):
+        """The existing behaviour of adding an LCSC field is unchanged."""
+        footprint = FakeFootprint()
+        set_lcsc_value(footprint, "C12345")
+        assert [f.GetName() for f in footprint.GetFields()] == ["LCSC"]
+        assert footprint.GetFields()[0].GetText() == "C12345"
+
+    def test_clearing_the_value_still_works(self):
+        """Removing a part number empties the field rather than writing junk."""
+        field = FakeField("LCSC Part #", "C12345")
+        footprint = FakeFootprint(field)
+        set_lcsc_value(footprint, "")
+        assert field.GetText() == ""

--- a/tests/test_lcsc.py
+++ b/tests/test_lcsc.py
@@ -1,10 +1,12 @@
-"""Tests for the two questions lcsc.py answers about a part number.
+"""Tests for the questions lcsc.py answers about a part number.
 
 normalize_lcsc has its own file, tests/test_lcsc_normalization.py. What is
-covered here is the pair that sits on top of it: the strict predicate a field
-has to satisfy, and the lenient parser that reads pasted text.
+covered here is what sits on top of it: the strict predicate a field has to
+satisfy, the lenient parser that reads pasted text, and the Lcsc value type
+that both of those define.
 """
 
+import dataclasses
 import importlib.util
 from pathlib import Path
 
@@ -19,6 +21,8 @@ _spec.loader.exec_module(_lcsc)
 
 is_lcsc_part = _lcsc.is_lcsc_part
 extract_lcsc = _lcsc.extract_lcsc
+Lcsc = _lcsc.Lcsc
+format_lcsc = _lcsc.format_lcsc
 
 
 class TestIsLcscPart:
@@ -82,3 +86,147 @@ class TestExtractLcsc:
         text = "LCSC Part C12345 in stock"
         assert extract_lcsc(text) == "C12345"
         assert not is_lcsc_part(text)
+
+
+# ---------------------------------------------------------------------------
+# The value type
+# ---------------------------------------------------------------------------
+
+
+class TestLcscConstruction:
+    """An Lcsc in hand is a real part number in canonical form."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("C12345", "C12345"),
+            ("c12345", "C12345"),
+            (" C12345 ", "C12345"),
+            ("\tc12345\n", "C12345"),
+            ("C9900101779", "C9900101779"),
+        ],
+    )
+    def test_it_canonicalises_what_it_is_given(self, value, expected):
+        """Every spelling of one number produces the same part."""
+        assert str(Lcsc(value)) == expected
+
+    @pytest.mark.parametrize(
+        "value", ["", None, "C", "12345", "CC1", "C12a45", "foo C12345 bar"]
+    )
+    def test_it_refuses_anything_that_is_not_one(self, value):
+        """The constructor is the check, so holding one needs no further test."""
+        with pytest.raises((ValueError, TypeError)):
+            Lcsc(value)
+
+    @pytest.mark.parametrize("value", ["C１２３", "C١٢٣"])
+    def test_digits_from_other_scripts_do_not_build_a_part(self, value):
+        r"""Only ASCII digits count, and the type inherits that from the pattern.
+
+        Python's ``\d`` matches every Unicode decimal, so full-width and
+        Arabic-Indic digits would otherwise build a validated part that no
+        catalogue contains and no query can find.
+        """
+        assert Lcsc.parse(value) is None
+
+    def test_parse_answers_none_instead_of_raising(self):
+        """Values merely claimed to be part numbers go through parse."""
+        assert Lcsc.parse("C12345") == Lcsc("C12345")
+        assert Lcsc.parse("not a part") is None
+        assert Lcsc.parse(None) is None
+
+    def test_find_in_reads_pasted_text(self):
+        """find_in is lenient about surroundings, strict about the number."""
+        assert Lcsc.find_in("LCSC Part C12345 in stock") == Lcsc("C12345")
+        assert Lcsc.find_in("no part here") is None
+        assert Lcsc.find_in("") is None
+
+
+class TestLcscBehaviour:
+    """It formats and compares as the thing it represents."""
+
+    def test_it_renders_as_the_bare_number(self):
+        """Rendering gives the canonical number, not a repr."""
+        part = Lcsc.parse(" c12345 ")
+        assert str(part) == "C12345"
+        assert f"ordering {part}" == "ordering C12345"
+
+    def test_spellings_compare_equal(self):
+        """Two spellings of one number are one part."""
+        assert Lcsc("c12345 ") == Lcsc("C12345")
+
+    def test_different_parts_are_not_equal(self):
+        """Distinct numbers stay distinct."""
+        assert Lcsc("C12345") != Lcsc("C12346")
+
+    def test_it_works_as_a_dict_key(self):
+        """Being frozen makes it usable as a cache key, which is how it is used.
+
+        The details cache in the parts list is keyed on it, so two spellings
+        collapsing to one entry is the property that matters.
+        """
+        cache = {Lcsc("C12345"): "details"}
+        assert cache[Lcsc(" c12345 ")] == "details"
+        assert len({Lcsc("C12345"), Lcsc("c12345")}) == 1
+
+    def test_it_is_immutable(self):
+        """A part cannot be edited into a different part after validation."""
+        part = Lcsc("C12345")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            part.value = "C99999"
+
+    def test_parts_do_not_compare_as_greater_or_lesser(self):
+        """Ordering is left undefined on purpose, so nobody relies on a wrong one.
+
+        String order puts C10000 before C9999, and numeric order would invent
+        a ranking that means nothing, since part numbers are identifiers
+        rather than quantities. Refusing the comparison is better than
+        answering it misleadingly.
+        """
+        with pytest.raises(TypeError):
+            Lcsc("C10000") < Lcsc("C9999")
+
+
+class TestHelpersAgreeWithTheType:
+    """The string helpers and the type are one definition, not two."""
+
+    @pytest.mark.parametrize(
+        "value", ["C12345", "c12345", " C12345 ", "C999", "C", "", None, "junk"]
+    )
+    def test_is_lcsc_part_matches_parse(self, value):
+        """is_lcsc_part is true exactly when parse returns a part."""
+        assert is_lcsc_part(value) == (Lcsc.parse(value) is not None)
+
+    @pytest.mark.parametrize(
+        "text", ["C12345", "buy C12345 now", "C1,C2", "", None, "no part"]
+    )
+    def test_extract_lcsc_matches_find_in(self, text):
+        """extract_lcsc is find_in rendered as a string."""
+        found = Lcsc.find_in(text)
+        assert extract_lcsc(text) == (str(found) if found else "")
+
+
+class TestAbsence:
+    """Absence is None inside the plugin and "" only at the edges."""
+
+    def test_there_is_no_empty_part(self):
+        """No value of Lcsc represents "no part"; that is what None is for."""
+        assert Lcsc.parse("") is None
+        assert Lcsc.parse(None) is None
+        with pytest.raises(ValueError):
+            Lcsc("")
+
+    def test_format_renders_a_part_as_its_number(self):
+        """A part renders as the bare canonical number."""
+        assert format_lcsc(Lcsc(" c12345 ")) == "C12345"
+
+    def test_format_renders_absence_as_empty(self):
+        """None becomes the empty string the storage layers expect."""
+        assert format_lcsc(None) == ""
+
+    def test_format_is_what_a_string_boundary_should_call(self):
+        """Rendering an absent part never produces "None" in a cell.
+
+        str(None) would put the text "None" into a CSV cell or a list column,
+        which is the failure this helper exists to make impossible.
+        """
+        assert format_lcsc(None) != str(None)

--- a/tests/test_lcsc.py
+++ b/tests/test_lcsc.py
@@ -1,0 +1,84 @@
+"""Tests for the two questions lcsc.py answers about a part number.
+
+normalize_lcsc has its own file, tests/test_lcsc_normalization.py. What is
+covered here is the pair that sits on top of it: the strict predicate a field
+has to satisfy, and the lenient parser that reads pasted text.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+_spec = importlib.util.spec_from_file_location("standalone_lcsc", _ROOT / "lcsc.py")
+assert _spec is not None and _spec.loader is not None
+_lcsc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_lcsc)
+
+is_lcsc_part = _lcsc.is_lcsc_part
+extract_lcsc = _lcsc.extract_lcsc
+
+
+class TestIsLcscPart:
+    """is_lcsc_part answers whether a value names a part, strictly."""
+
+    @pytest.mark.parametrize("value", ["C12345", "c12345", " C12345 ", "C9900101779"])
+    def test_a_part_number_is_recognised(self, value):
+        """A part number is recognised however it was typed."""
+        assert is_lcsc_part(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", None, "C", "12345", "CC1", "C12a45", "foo C12345 bar", "C12345,C9"],
+    )
+    def test_anything_else_is_rejected(self, value):
+        """A value that is not exactly one part number is not one."""
+        assert not is_lcsc_part(value)
+
+    @pytest.mark.parametrize("value", ["C１２３", "C١٢٣"])
+    def test_digits_from_other_scripts_are_not_a_part_number(self, value):
+        """Only ASCII digits count, because only those are issued.
+
+        The pattern spells its digits out as [0-9] for this reason, rather
+        than using the shorthand class, which is not limited to ASCII. The
+        part-preference validator folded onto this predicate rejected
+        full-width digits before it was folded, and still has to.
+        """
+        assert not is_lcsc_part(value)
+
+
+class TestExtractLcsc:
+    """extract_lcsc is the lenient counterpart, for text a person pasted."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("C12345", "C12345"),
+            ("c12345", "C12345"),
+            ("  C12345  ", "C12345"),
+            ("LCSC Part C12345 in stock", "C12345"),
+            ("https://jlcpcb.com/partdetail/C12345", "C12345"),
+            ("C12345, C99999", "C12345"),
+        ],
+    )
+    def test_a_part_number_is_pulled_out_canonically(self, text, expected):
+        """A number is found inside surrounding text and returned canonically."""
+        assert extract_lcsc(text) == expected
+
+    @pytest.mark.parametrize("text", ["", None, "no part here", "12345"])
+    def test_text_without_a_part_number_yields_empty(self, text):
+        """Text carrying no part number produces the empty string."""
+        assert extract_lcsc(text) == ""
+
+    def test_it_is_more_lenient_than_is_lcsc_part(self):
+        """The two answer different questions and are not interchangeable.
+
+        Pasted text should give up its part number; a schematic field claiming
+        to *be* a part number should not be accepted when it is something else
+        with a number buried in it.
+        """
+        text = "LCSC Part C12345 in stock"
+        assert extract_lcsc(text) == "C12345"
+        assert not is_lcsc_part(text)

--- a/tests/test_lcsc_normalization.py
+++ b/tests/test_lcsc_normalization.py
@@ -1,0 +1,35 @@
+"""Tests for canonical LCSC part numbers and the lookups keyed on them."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+_spec = importlib.util.spec_from_file_location("standalone_lcsc", _ROOT / "lcsc.py")
+assert _spec is not None and _spec.loader is not None
+_lcsc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_lcsc)
+
+normalize_lcsc = _lcsc.normalize_lcsc
+
+
+class TestNormalizeLcsc:
+    """normalize_lcsc folds the forms a part number arrives in into one."""
+
+    @pytest.mark.parametrize(
+        "value", ["C12345", "c12345", " C12345 ", "\tc12345\n", "C12345 "]
+    )
+    def test_all_spellings_reach_one_key(self, value):
+        """Case and surrounding whitespace do not change the key."""
+        assert normalize_lcsc(value) == "C12345"
+
+    @pytest.mark.parametrize("value", ["", None, 0])
+    def test_absent_values_become_empty(self, value):
+        """A missing part number normalizes to the empty string, not "NONE"."""
+        assert normalize_lcsc(value) == ""
+
+    def test_distinct_parts_stay_distinct(self):
+        """Normalization does not merge different part numbers."""
+        assert normalize_lcsc("C1234") != normalize_lcsc("C12345")

--- a/tests/test_library_lcsc_corrections.py
+++ b/tests/test_library_lcsc_corrections.py
@@ -1,0 +1,374 @@
+"""Store, validate and carry per-part corrections beside the pattern rules."""
+
+from collections.abc import Iterator
+from contextlib import closing
+from pathlib import Path
+import sqlite3
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.correction_test_support import fresh_library, make_library, raw_rows
+from tests.wx_harness import load_correction_modules
+
+
+@pytest.fixture
+def modules() -> Iterator[SimpleNamespace]:
+    """Keep the real storage and value modules under one scoped package."""
+    with load_correction_modules() as loaded:
+        yield loaded
+
+
+@pytest.fixture
+def library(modules: SimpleNamespace, tmp_path: Path) -> Any:
+    """Create real SQLite correction storage away from user databases."""
+    return make_library(modules.library, tmp_path)
+
+
+def execute(path: str, sql: str, parameters: tuple = ()) -> list[tuple[Any, ...]]:
+    """Run one statement through an independent connection."""
+    with closing(sqlite3.connect(path)) as con, con:
+        return con.execute(sql, parameters).fetchall()
+
+
+def lcsc_rows(library: Any, path: Any = None) -> list[tuple[Any, ...]]:
+    """Read the exact persisted part-number rows."""
+    return execute(
+        path or library.correctionsdb_file,
+        "SELECT rowid, * FROM lcsc_correction ORDER BY rowid",
+    )
+
+
+def table_names(path: str) -> set[str]:
+    """Return the ordinary tables in the database at path."""
+    return {
+        row[0]
+        for row in execute(path, "SELECT name FROM sqlite_master WHERE type='table'")
+    }
+
+
+def part_rules(modules: SimpleNamespace, library: Any, path: Any = None) -> list:
+    """Expose the validated part-number rules of a fresh snapshot."""
+    snapshot = fresh_library(library).read_correction_data(path)
+    assert snapshot.corrections is not None, snapshot.issues
+    return [
+        (rule.lcsc, rule.rotation, rule.offset)
+        for rule in snapshot.corrections
+        if isinstance(rule, modules.data.LcscCorrection)
+    ]
+
+
+def test_part_rule_round_trips_through_its_own_table(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A part-number rule is stored beside, not among, the pattern rules."""
+    rowid = library.insert_lcsc_correction_data("C12345", 90, (0.5, -0.25))
+
+    assert lcsc_rows(library) == [(rowid, "C12345", 90, 0.5, -0.25)]
+    assert raw_rows(library) == []
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.READY
+    (row,) = snapshot.rows
+    assert (row.kind, row.rowid, row.pattern) == ("lcsc", rowid, "C12345")
+    assert row.correction == modules.data.LcscCorrection("C12345", 90, (0.5, -0.25))
+    assert snapshot.corrections == (row.correction,)
+
+
+@pytest.mark.parametrize("spelling", ["c12345", "  C12345 ", "\tc12345\n"])
+def test_key_is_stored_in_canonical_form(library: Any, spelling: str) -> None:
+    """Whatever spelling arrives, the table holds the form lookups use."""
+    library.insert_lcsc_correction_data(spelling, 90, (0, 0))
+    assert [row[1] for row in lcsc_rows(library)] == ["C12345"]
+
+
+@pytest.mark.parametrize(
+    "key", ["^C12345$", "C12345|C999", "SOT-23", "", "C", " ", None, 12345]
+)
+def test_invalid_key_is_rejected_before_any_write(
+    modules: SimpleNamespace, library: Any, key: Any
+) -> None:
+    """An exact-match key that is not a bare part number would never fire."""
+    with pytest.raises(modules.data.CorrectionDataError) as error:
+        library.insert_lcsc_correction_data(key, 90, (0, 0))
+    assert [issue.field for issue in error.value.issues] == ["lcsc"]
+    assert "C12345" in str(error.value)
+    assert lcsc_rows(library) == []
+
+
+@pytest.mark.parametrize(
+    ("rotation", "offset", "field"),
+    [("47u", (0, 0), "rotation"), (90, ("x", 0), "offset_x"), (90, (0,), "offset")],
+)
+def test_numbers_share_the_pattern_rules_validation(
+    modules: SimpleNamespace, library: Any, rotation: Any, offset: Any, field: str
+) -> None:
+    """Rotation and offsets are checked the same way for both kinds of rule."""
+    with pytest.raises(modules.data.CorrectionDataError) as error:
+        library.insert_lcsc_correction_data("C1", rotation, offset)
+    assert [issue.field for issue in error.value.issues] == [field]
+    assert lcsc_rows(library) == []
+
+
+def test_exact_keys_do_not_collide_by_prefix(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """C1234 and C12345 are two rules, not one rule and a duplicate."""
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    library.insert_lcsc_correction_data("C1234", 180, (0, 0))
+    assert part_rules(modules, library) == [
+        ("C1234", 180, (0.0, 0.0)),
+        ("C12345", 90, (0.0, 0.0)),
+    ]
+
+
+@pytest.mark.parametrize("spelling", ["C12345", "c12345", " C12345"])
+def test_duplicate_key_is_refused_without_replace(
+    modules: SimpleNamespace, library: Any, spelling: str
+) -> None:
+    """A second rule for the same part, however spelled, needs explicit replacement."""
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    before = lcsc_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError) as error:
+        library.insert_lcsc_correction_data(spelling, 180, (0, 0))
+    assert "already uses this part number" in str(error.value)
+    assert lcsc_rows(library) == before
+
+
+def test_replace_removes_every_row_for_that_part(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Replacing collapses case variants of one part number into the saved row."""
+    execute(
+        library.correctionsdb_file,
+        "INSERT INTO lcsc_correction VALUES ('C12345', 90, 0, 0), ('c12345', 45, 1, 1)",
+    )
+    rowid = library.save_correction_data(
+        "C12345", 180, (0, 0), kind=modules.data.KIND_LCSC, replace=True
+    )
+    assert lcsc_rows(library) == [(rowid, "C12345", 180, 0.0, 0.0)]
+
+
+def test_invalid_stored_row_needs_repair_and_repairs_in_place(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A malformed part rule blocks the set until it is fixed, like a pattern rule."""
+    execute(
+        library.correctionsdb_file,
+        "INSERT INTO lcsc_correction VALUES ('C1', '47u', 0, 0)",
+    )
+    snapshot = library.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.NEEDS_REPAIR
+    assert snapshot.corrections is None
+    (row,) = snapshot.rows
+    assert row.kind == "lcsc"
+    assert [issue.field for issue in row.issues] == ["rotation"]
+    assert row.issues[0].rowid == row.rowid
+
+    library.save_correction_data(
+        "C1", 90, (0, 0), rowid=row.rowid, expected_record=row, kind=row.kind
+    )
+    assert lcsc_rows(library) == [(row.rowid, "C1", 90, 0.0, 0.0)]
+    assert part_rules(modules, library) == [("C1", 90, (0.0, 0.0))]
+
+
+def test_case_variants_with_different_values_conflict(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Two spellings of one part number cannot both claim to be its rule."""
+    execute(
+        library.correctionsdb_file,
+        "INSERT INTO lcsc_correction VALUES ('C1', 90, 0, 0), ('c1', 180, 0, 0)",
+    )
+    snapshot = library.read_correction_data()
+    assert snapshot.corrections is None
+    assert all("part number" in str(row.issues[0]) for row in snapshot.rows)
+    assert {issue.rowid for issue in snapshot.issues} == {1, 2}
+
+
+def test_case_variants_with_identical_values_resolve_to_one_rule(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Agreeing duplicates are redundant, not contradictory."""
+    execute(
+        library.correctionsdb_file,
+        "INSERT INTO lcsc_correction VALUES ('C1', 90, 0, 0), ('c1', 90, 0, 0)",
+    )
+    assert part_rules(modules, library) == [("C1", 90, (0.0, 0.0))]
+
+
+def test_rowids_are_independent_across_the_two_tables(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Deleting row 1 of one kind must not touch row 1 of the other."""
+    assert library.insert_correction_data("R1", 90, (0, 0)) == 1
+    assert library.insert_lcsc_correction_data("C1", 180, (0, 0)) == 1
+    rows = {row.kind: row for row in library.read_correction_data().rows}
+    assert {kind: row.rowid for kind, row in rows.items()} == {
+        "footprint": 1,
+        "lcsc": 1,
+    }
+
+    library.delete_correction_row(1, expected_record=rows["lcsc"])
+    assert lcsc_rows(library) == []
+    assert raw_rows(library) == [(1, "R1", 90, 0.0, 0.0)]
+
+    library.delete_correction_row(1, kind=modules.data.KIND_FOOTPRINT)
+    assert raw_rows(library) == []
+
+
+def test_delete_and_repair_reject_a_changed_part_rule(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A stale selection cannot act on a row another window has since edited."""
+    library.insert_lcsc_correction_data("C1", 90, (0, 0))
+    (row,) = library.read_correction_data().rows
+    execute(library.correctionsdb_file, "UPDATE lcsc_correction SET rotation=180")
+    for operation in (
+        lambda: library.delete_correction_row(row.rowid, expected_record=row),
+        lambda: library.save_correction_data(
+            "C1", 0, (0, 0), rowid=row.rowid, expected_record=row, kind=row.kind
+        ),
+    ):
+        with pytest.raises(modules.data.CorrectionDataError) as error:
+            operation()
+        assert "stored correction changed" in str(error.value)
+    assert lcsc_rows(library) == [(row.rowid, "C1", 180, 0.0, 0.0)]
+
+
+def test_database_from_an_earlier_release_reads_and_gains_the_table(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A corrections database that predates part rules is valid without them."""
+    library.insert_correction_data("R1", 90, (0, 0))
+    execute(library.correctionsdb_file, "DROP TABLE lcsc_correction")
+    assert "lcsc_correction" not in table_names(library.correctionsdb_file)
+
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.READY
+    assert [row.kind for row in snapshot.rows] == ["footprint"]
+    assert "lcsc_correction" not in table_names(library.correctionsdb_file)
+
+    fresh_library(library).insert_lcsc_correction_data("C1", 180, (0, 0))
+    assert lcsc_rows(library) == [(1, "C1", 180, 0.0, 0.0)]
+
+
+def test_unsupported_part_table_schema_is_reported_not_repaired(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A part table with the wrong columns is an error, like the pattern table."""
+    execute(library.correctionsdb_file, "DROP TABLE lcsc_correction")
+    execute(library.correctionsdb_file, "CREATE TABLE lcsc_correction (lcsc, angle)")
+    snapshot = library.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.UNAVAILABLE
+    assert "lcsc_correction table must contain exactly lcsc" in str(snapshot.issues[0])
+
+
+def test_get_all_correction_data_lists_both_kinds(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """One typed set carries pattern rules first and part rules after them."""
+    library.insert_lcsc_correction_data("C1", 180, (0, 0))
+    library.insert_correction_data("R1", 90, (0, 0))
+    assert library.get_all_correction_data() == (
+        modules.data.Correction("R1", 90, (0, 0)),
+        modules.data.LcscCorrection("C1", 180, (0, 0)),
+    )
+
+
+def test_csv_batches_leave_part_rules_alone(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Imports address the pattern table only; part rules are not a CSV concern."""
+    library.insert_lcsc_correction_data("C1", 180, (0, 0))
+    result = library.apply_corrections([("R1", 90, (0, 0)), ("C1", 45, (1, 1))])
+    assert (result.inserted, result.updated) == (2, 0)
+    assert lcsc_rows(library) == [(1, "C1", 180, 0.0, 0.0)]
+    assert [row[1] for row in raw_rows(library)] == ["R1", "C1"]
+
+
+def test_switch_to_local_copies_both_kinds_and_keeps_global(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Part rules follow the pattern rules into a board-local database."""
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    library.insert_lcsc_correction_data("C12345", 90, (0.5, -0.5))
+
+    library.switch_to_global_correction_database(False)
+
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert part_rules(modules, library) == [("C12345", 90, (0.5, -0.5))]
+    assert [row[1] for row in raw_rows(library)] == ["^SOT-23"]
+    assert part_rules(modules, library, library.globalcorrectionsdb_file) == [
+        ("C12345", 90, (0.5, -0.5))
+    ]
+
+
+def test_switch_to_global_drops_both_local_tables(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Returning to global leaves no part rules stranded in the project database."""
+    library.insert_correction_data("^SOT-23", 180, (0, 0))
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    library.switch_to_global_correction_database(False)
+    fresh_library(library).insert_lcsc_correction_data("C99999", 45, (0, 0))
+
+    library.switch_to_global_correction_database(True)
+
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert not {"correction", "lcsc_correction"} & table_names(
+        library.localcorrectionsdb_file
+    )
+    assert library.uses_global_correction_database()
+    assert part_rules(modules, library) == [("C12345", 90, (0.0, 0.0))]
+
+
+def test_switch_to_a_global_database_predating_the_table(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """An older global database gains the table on the first write after a switch."""
+    library.switch_to_global_correction_database(False)
+    execute(library.globalcorrectionsdb_file, "DROP TABLE lcsc_correction")
+
+    library.switch_to_global_correction_database(True)
+
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert part_rules(modules, library) == []
+    library.insert_lcsc_correction_data("C12345", 90, (0, 0))
+    assert part_rules(modules, library) == [("C12345", 90, (0.0, 0.0))]
+
+
+def test_invalid_local_part_rule_does_not_block_return_to_global(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Discarding the local database needs a healthy global one, not a healthy local one."""
+    library.switch_to_global_correction_database(False)
+    execute(
+        library.correctionsdb_file,
+        "INSERT INTO lcsc_correction VALUES ('C1', '47u', 0, 0)",
+    )
+    library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert library.read_correction_data().state is (
+        modules.library.CorrectionState.READY
+    )
+
+
+def test_save_refuses_an_expected_record_of_the_other_kind(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A part rule cannot be saved over a selected pattern row, nor the reverse."""
+    library.insert_correction_data("R1", 90, (0, 0))
+    (row,) = library.read_correction_data().rows
+    with pytest.raises(modules.data.CorrectionDataError) as error:
+        library.save_correction_data(
+            "C1",
+            90,
+            (0, 0),
+            rowid=row.rowid,
+            expected_record=row,
+            kind=modules.data.KIND_LCSC,
+        )
+    assert "different kind" in str(error.value)
+    assert lcsc_rows(library) == []
+    assert raw_rows(library) == [(1, "R1", 90, 0.0, 0.0)]

--- a/tests/test_library_part_details.py
+++ b/tests/test_library_part_details.py
@@ -1,0 +1,126 @@
+"""Tests for looking a part up in the parts database by an LCSC number."""
+
+import importlib.util
+from pathlib import Path
+import sqlite3
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+
+for _mod in ["pcbnew", "wx", "wx.dataview", "requests"]:
+    sys.modules.setdefault(_mod, MagicMock())
+
+_pkg = sys.modules.get("kicadplugin")
+if _pkg is None:
+    _pkg = types.ModuleType("kicadplugin")
+    _pkg.__path__ = [str(_ROOT)]
+    sys.modules["kicadplugin"] = _pkg
+for _name in [
+    "dblib",
+    "events",
+    "partselector_columns",
+    "search_escape",
+    "unzip_parts",
+]:
+    sys.modules.setdefault(f"kicadplugin.{_name}", MagicMock())
+
+# helpers supplies dict_factory, which get_part_details depends on for real
+_helpers_spec = importlib.util.spec_from_file_location(
+    "kicadplugin.helpers", _ROOT / "helpers.py"
+)
+assert _helpers_spec is not None and _helpers_spec.loader is not None
+_helpers = importlib.util.module_from_spec(_helpers_spec)
+_helpers.__package__ = "kicadplugin"
+sys.modules["kicadplugin.helpers"] = _helpers
+_helpers_spec.loader.exec_module(_helpers)
+
+_spec = importlib.util.spec_from_file_location(
+    "kicadplugin.library", _ROOT / "library.py"
+)
+assert _spec is not None and _spec.loader is not None
+_library = importlib.util.module_from_spec(_spec)
+_library.__package__ = "kicadplugin"
+sys.modules["kicadplugin.library"] = _library
+_spec.loader.exec_module(_library)
+
+Library = _library.Library
+
+# Mirrors common/partsdb.py, including the trigram tokenizer -- the tokenizer
+# is case-insensitive, so MATCH was never the half that failed.
+_CREATE_PARTS = """
+    CREATE virtual TABLE IF NOT EXISTS parts using fts5 (
+        'LCSC Part', 'First Category', 'Second Category', 'MFR.Part', 'Package',
+        'Solder Joint' unindexed, 'Manufacturer', 'Library Type', 'Description',
+        'Datasheet' unindexed, 'Price' unindexed, 'Stock' unindexed
+    , tokenize="trigram")
+"""
+
+
+@pytest.fixture
+def library(tmp_path):
+    """Build a bare Library over a parts database holding one known part."""
+    partsdb = tmp_path / "parts.db"
+    with sqlite3.connect(partsdb) as con:
+        con.execute(_CREATE_PARTS)
+        con.execute(
+            "INSERT INTO parts VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                "C12345",
+                "Capacitors",
+                "MLCC",
+                "CL10B104KB8NNNC",
+                "0603",
+                "",
+                "Samsung",
+                "Basic",
+                "100nF 50V X7R",
+                "",
+                "0.0035",
+                "5000",
+            ),
+        )
+    lib = object.__new__(Library)
+    lib.logger = MagicMock()
+    lib.partsdb_file = str(partsdb)
+    return lib
+
+
+class TestGetPartDetails:
+    """A part is found however its number was spelled."""
+
+    @pytest.mark.parametrize(
+        "number", ["C12345", "c12345", "C12345 ", " C12345", " c12345\n", "\tC12345 "]
+    )
+    def test_every_spelling_finds_the_part(self, library, number):
+        """Case and padding no longer decide whether stock and type appear.
+
+        The FTS5 tokenizer is trigram, which folds case, so MATCH always
+        returned the row. The confirming comparison did not: it was
+        n["lcsc"] == number against the raw argument, so a lower-case or
+        padded number returned {} and the parts list showed blank Stock and
+        Library Type with no error anywhere.
+        """
+        details = library.get_part_details(number)
+        assert details.get("stock") == "5000"
+        assert details.get("type") == "Basic"
+
+    def test_a_different_part_is_still_not_found(self, library):
+        """Normalizing does not make unrelated numbers match."""
+        assert library.get_part_details("C99999") == {}
+
+    def test_a_prefix_is_not_a_match(self, library):
+        """C1234 does not resolve to C12345."""
+        assert library.get_part_details("C1234") == {}
+
+    @pytest.mark.parametrize("number", ["", "   "])
+    def test_an_empty_number_is_not_a_query(self, library, number):
+        """A blank number returns nothing rather than reaching FTS5.
+
+        'parts MATCH " "' raises OperationalError: fts5: syntax error, so a
+        whitespace-only store value used to take down the lookup.
+        """
+        assert library.get_part_details(number) == {}

--- a/tests/test_library_part_details.py
+++ b/tests/test_library_part_details.py
@@ -48,6 +48,7 @@ sys.modules["kicadplugin.library"] = _library
 _spec.loader.exec_module(_library)
 
 Library = _library.Library
+Lcsc = _library.Lcsc
 
 # Mirrors common/partsdb.py, including the trigram tokenizer -- the tokenizer
 # is case-insensitive, so MATCH was never the half that failed.
@@ -115,6 +116,32 @@ class TestGetPartDetails:
     def test_a_prefix_is_not_a_match(self, library):
         """C1234 does not resolve to C12345."""
         assert library.get_part_details("C1234") == {}
+
+    def test_it_accepts_a_part_object(self, library):
+        """An Lcsc can be passed straight in, and resolves the same way."""
+        assert library.get_part_details(Lcsc("C12345")).get("stock") == "5000"
+        assert library.get_part_details(Lcsc(" c12345 ")).get("stock") == "5000"
+
+    @pytest.mark.parametrize("number", ["R1234", "12345", "C12a45"])
+    def test_a_value_that_cannot_name_a_part_is_not_looked_up(self, library, number):
+        """Anything failing the part-number shape resolves to no details.
+
+        This is narrower than before: the lookup used to send any non-empty
+        string to FTS5, whatever shape it had. Nothing real is lost, since the
+        shape is the one the plugin already requires of a footprint field.
+        """
+        assert library.get_part_details(number) == {}
+
+    @pytest.mark.parametrize("number", ['foo"bar', "*", "C12345-", "AND"])
+    def test_fts5_metacharacters_do_not_reach_the_query(self, library, number):
+        """A value carrying FTS5 syntax returns no details rather than raising.
+
+        These used to reach 'parts MATCH ...' and raise OperationalError:
+        fts5: syntax error. The BOM estimator and the assignment path pass
+        values straight from the store, which is not guaranteed to hold a
+        part number.
+        """
+        assert library.get_part_details(number) == {}
 
     @pytest.mark.parametrize("number", ["", "   "])
     def test_an_empty_number_is_not_a_query(self, library, number):

--- a/tests/test_mainwindow_lcsc_assignments.py
+++ b/tests/test_mainwindow_lcsc_assignments.py
@@ -76,7 +76,10 @@ def test_assignment_caches_missing_catalog_details_once_per_action(
         window.init_store()
     else:
         act(action, window, mainwindow, monkeypatch, "C200")
-    window.library.get_part_details.assert_called_once_with("C200")
+    # Rendered rather than compared: the assignment path parses the number
+    # once at its boundary, so the lookup is asked for a part, not a string.
+    lookups = window.library.get_part_details.call_args_list
+    assert [str(lookup.args[0]) for lookup in lookups] == ["C200"]
     assert [row["lcsc"] for row in project_rows(window)] == ["C200", "C200"]
     assert [row["lcsc"] for row in window.test_rows.values()] == ["C200", "C200"]
     assert all(
@@ -544,3 +547,30 @@ def test_assignment_preserves_other_supplier_fields_when_assigning_and_clearing(
     }
     window.init_store()
     assert window.store.get_part("R1")["lcsc"] == ""
+
+
+def test_an_assignment_that_names_no_part_is_skipped_and_the_rest_applied(
+    make_window: Callable[..., Any],
+) -> None:
+    """One unusable number does not abandon the action, and it is reported.
+
+    Assignments arrive as strings from a part selector, the clipboard and
+    saved preferences, so the boundary parses them. A value naming no part is
+    skipped the way a reference the board no longer has is skipped, rather
+    than being written into a footprint field and sent to FTS5 as a query.
+    The numbers that do name a part are written canonically.
+    """
+    window = make_window(footprints=[Footprint(), Footprint("R2")])
+
+    assigned = window._apply_lcsc_assignments({"R1": "10k resistor", "R2": " c200 "})
+
+    assert assigned == ["R2"]
+    board = window.pcbnew.GetBoard()
+    assert window.store.get_part("R1")["lcsc"] == "C100"
+    assert board.FindFootprintByReference("R1").field.text == "C100"
+    assert window.store.get_part("R2")["lcsc"] == "C200"
+    assert board.FindFootprintByReference("R2").field.text == "C200"
+    assert [
+        str(call.args[0]) % call.args[1:]
+        for call in window.logger.warning.call_args_list
+    ] == ["Skipped R1: '10k resistor' does not name an LCSC part."]

--- a/tests/test_mainwindow_lcsc_correction.py
+++ b/tests/test_mainwindow_lcsc_correction.py
@@ -1,0 +1,217 @@
+"""Open the Corrections Manager on a part number from the parts list."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.correction_test_support import seed_raw
+from tests.part_preferences_test_support import Board, Footprint
+from tests.test_corrections_import_export import install_manager_controls
+from tests.test_mainwindow_correction_recovery import (
+    _population_window,
+    runtime as correction_runtime,
+)
+from tests.test_standard_only_indicator import PartListDataModel, _row
+
+runtime = correction_runtime
+
+
+def _add_correction_by_lcsc(runtime: SimpleNamespace, *lcsc: str) -> None:
+    """Invoke the context-menu handler with one selected part per number given."""
+    window = _population_window(runtime)
+    selections = [f"item{index}" for index in range(len(lcsc))]
+    window.footprint_list = SimpleNamespace(GetSelections=lambda: selections)
+    numbers = dict(zip(selections, lcsc))
+    window.partlist_data_model.get_lcsc.side_effect = numbers.get
+    window.partlist_data_model.get_reference.side_effect = lambda item: (
+        f"U{selections.index(item) + 1}"
+    )
+    event_id = runtime.mainwindow.ID_CONTEXT_MENU_ADD_ROT_BY_LCSC
+    window.add_correction(SimpleNamespace(GetId=lambda: event_id))
+
+
+def test_add_correction_by_lcsc_opens_the_manager_in_part_mode(
+    runtime: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dialog arrives prefilled with the part's number and the box ticked."""
+    install_manager_controls(runtime.modules, runtime.library, monkeypatch)
+    opened = []
+    monkeypatch.setattr(
+        runtime.wx.Dialog,
+        "ShowModal",
+        lambda dialog: opened.append(dialog) or runtime.wx.ID_OK,
+        raising=False,
+    )
+
+    _add_correction_by_lcsc(runtime, "c12345")
+
+    (dialog,) = opened
+    assert dialog.regex.GetValue() == "c12345"
+    assert dialog.lcsc_mode.GetValue() is True
+    runtime.wx.MessageBox.assert_not_called()
+
+
+def test_add_correction_by_lcsc_warns_once_for_unassigned_parts(
+    runtime: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parts without a number cannot have a part rule; one warning names them all."""
+    install_manager_controls(runtime.modules, runtime.library, monkeypatch)
+    opened = []
+    monkeypatch.setattr(
+        runtime.wx.Dialog,
+        "ShowModal",
+        lambda dialog: opened.append(dialog) or runtime.wx.ID_OK,
+        raising=False,
+    )
+
+    _add_correction_by_lcsc(runtime, "", "C12345", "")
+
+    assert [dialog.regex.GetValue() for dialog in opened] == ["C12345"]
+    runtime.wx.MessageBox.assert_called_once()
+    assert "U1, U3" in runtime.wx.MessageBox.call_args.args[0]
+    assert "No LCSC number" in str(runtime.wx.MessageBox.call_args)
+
+
+def _window_with_part(runtime: SimpleNamespace, lcsc: str) -> tuple[Any, dict]:
+    """Bind the real handlers to one part whose store row follows assignments."""
+    part = {
+        "reference": "U1",
+        "value": "Device",
+        "footprint": "SOT-23-3",
+        "lcsc": lcsc,
+        "exclude_from_bom": 0,
+        "exclude_from_pos": 0,
+    }
+    window = _population_window(runtime)
+    board = Board([Footprint("U1", value="Device", footprint="SOT-23-3", lcsc=lcsc)])
+    window.pcbnew = SimpleNamespace(GetBoard=lambda: board)
+    # The refreshed cell, not the remembered preference, is what is under test.
+    window.settings = {"part_preferences": {"remember_lcsc_assignments": False}}
+    window.store.get_part = lambda _reference: part
+    window.store.set_lcsc_assignments = lambda assignments: [
+        part.__setitem__("lcsc", number) for _reference, number, _stock in assignments
+    ]
+    window.library.get_part_details = lambda _lcsc: {"type": "Basic", "stock": 1}
+    window.start_assembly_enrichment = MagicMock()
+    window.recompute_bom_estimate = MagicMock()
+    window.logger = MagicMock()
+    window.footprint_list = SimpleNamespace(GetSelections=lambda: ["item"])
+    window.partlist_data_model.get_reference.return_value = "U1"
+    window.partlist_data_model.get_footprint.return_value = "SOT-23-3"
+    window.partlist_data_model.get_value.return_value = "Device"
+    return window, part
+
+
+def _seed_rules(runtime: SimpleNamespace) -> None:
+    """Store a family rule and a part rule that overrides it."""
+    runtime.library.apply_corrections([("SOT-23-3", 180, (1, 1))])
+    runtime.library.insert_lcsc_correction_data("C12345", 90, (0.5, -0.5))
+
+
+PART_RULE = "90°, 0.5/-0.5 (lcsc)"
+FAMILY_RULE = "180°, 1.0/1.0 (fpt)"
+
+
+def test_assigning_a_part_refreshes_its_correction_cell(
+    runtime: SimpleNamespace,
+) -> None:
+    """The rule shown follows the part number the part selector assigns."""
+    _seed_rules(runtime)
+    window, part = _window_with_part(runtime, "")
+
+    window.assign_parts(
+        SimpleNamespace(lcsc="C12345", references=["U1"], type="Basic", stock=1)
+    )
+
+    assert part["lcsc"] == "C12345"
+    window.partlist_data_model.set_correction.assert_called_once_with("U1", PART_RULE)
+    window.partlist_data_model.AddEntry.assert_not_called()
+
+
+def test_removing_a_part_number_refreshes_its_correction_cell(
+    runtime: SimpleNamespace,
+) -> None:
+    """Without its number the part falls back to the family rule, visibly."""
+    _seed_rules(runtime)
+    window, part = _window_with_part(runtime, "C12345")
+
+    window.remove_lcsc_number()
+
+    assert part["lcsc"] == ""
+    window.partlist_data_model.set_correction.assert_called_once_with("U1", FAMILY_RULE)
+
+
+def test_pasting_a_part_number_refreshes_its_correction_cell(
+    runtime: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pasted number reaches the store sanitized and still finds its rule."""
+    _seed_rules(runtime)
+    window, part = _window_with_part(runtime, "")
+    monkeypatch.setattr(
+        runtime.wx,
+        "TextDataObject",
+        lambda: SimpleNamespace(GetText=lambda: "c12345"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        runtime.wx,
+        "TheClipboard",
+        SimpleNamespace(
+            Open=lambda: True, GetData=lambda _data: True, Close=lambda: None
+        ),
+        raising=False,
+    )
+
+    window.paste_part_lcsc()
+
+    assert part["lcsc"] == "C12345"
+    window.partlist_data_model.set_correction.assert_called_once_with("U1", PART_RULE)
+
+
+def test_an_applied_part_preference_refreshes_its_correction_cell(
+    runtime: SimpleNamespace,
+) -> None:
+    """Apply part preferences changes the number, so it changes the rule."""
+    _seed_rules(runtime)
+    window, part = _window_with_part(runtime, "")
+    window.library.get_part_preference = lambda _footprint, _value: "C12345"
+
+    window.apply_selected_part_preferences()
+
+    assert part["lcsc"] == "C12345"
+    window.partlist_data_model.set_correction.assert_called_once_with("U1", PART_RULE)
+
+
+def test_refresh_shows_unresolved_and_the_status_when_storage_needs_repair(
+    runtime: SimpleNamespace,
+) -> None:
+    """A refreshed cell never shows a partial correction set as valid."""
+    _seed_rules(runtime)
+    seed_raw(runtime.library, [("R1", "47u", 0, 0)])
+    window, _part = _window_with_part(runtime, "")
+
+    window.assign_parts(
+        SimpleNamespace(lcsc="C12345", references=["U1"], type="Basic", stock=1)
+    )
+
+    window.partlist_data_model.set_correction.assert_called_once_with(
+        "U1", "Unresolved"
+    )
+    assert window.correction_status.IsShown()
+
+
+def test_set_correction_changes_only_that_rows_cell() -> None:
+    """The data model updates one Correction cell in place, or nothing."""
+    model = PartListDataModel(scale_factor=1.0)
+    model.AddEntry(_row("R1"))
+    model.AddEntry(_row("R2"))
+    model.ItemChanged = MagicMock()
+    column = model.columns["ROT_COL"]
+
+    model.set_correction("R2", PART_RULE)
+    model.set_correction("R9", FAMILY_RULE)
+
+    assert [row[column] for row in model.data] == ["0", PART_RULE]
+    model.ItemChanged.assert_called_once()

--- a/tests/test_mainwindow_part_preferences.py
+++ b/tests/test_mainwindow_part_preferences.py
@@ -219,8 +219,6 @@ def test_assignment_with_incomplete_part_preference_key_still_updates_project(
     [
         {"LCSC": "Z123"},
         {"LCSC": "A456"},
-        {"LCSC": "c123"},
-        {"LCSC": "C123 "},
         {"LCSC": "not assigned yet"},
         {"LCSC": " \t "},
         {"LCSC": "", "JLCPCB": "Z123"},
@@ -250,6 +248,31 @@ def test_opening_preserves_every_occupied_assignment_field(
     reopened.init_store()
 
     assert {name: field.text for name, field in footprint.fields.items()} == fields
+
+
+@pytest.mark.parametrize("text", ["c123", "C123 "])
+def test_opening_reads_an_untidily_typed_assignment_as_the_part_it_names(
+    make_window: Callable[..., Any], text: str
+) -> None:
+    """A field needing only normalisation names a part, so it is not empty.
+
+    These two spellings used to be rejected identifiers, and the fill only
+    left them alone because the occupied-field check caught them. Now the
+    reader normalises before testing (issue #773), so the part is assigned to
+    C123 outright, the fill skips it as it skips any assigned part, and
+    nothing is logged or written back over what the user typed.
+    """
+    footprint = Footprint(fields={"LCSC": text})
+    window = make_window(
+        footprints=[footprint], part_preferences={("R_0603", "10k"): "C999"}
+    )
+
+    window.init_store()
+
+    assert window.store.get_part("R1")["lcsc"] == "C123"
+    assert info_messages(window) == []
+    window.library.get_part_preference.assert_not_called()
+    assert footprint.fields["LCSC"].text == text
 
 
 @pytest.mark.parametrize("action", ["open", "apply"])

--- a/tests/test_mainwindow_stale_footprints.py
+++ b/tests/test_mainwindow_stale_footprints.py
@@ -95,13 +95,13 @@ def _window(*, footprints: dict[str, object], selections: tuple[int, ...] = ()) 
     return window
 
 
-def _part(reference):
+def _part(reference, lcsc=""):
     """Return the complete store row consumed by populate_footprint_list."""
     return {
         "reference": reference,
         "value": "10k",
         "footprint": "R_0603",
-        "lcsc": "",
+        "lcsc": lcsc,
         "stock": None,
         "exclude_from_bom": 0,
         "exclude_from_pos": 0,
@@ -240,3 +240,32 @@ def test_toggle_handlers_skip_stale_refs_and_continue_live_refs(
         "model_bom_pos": window.partlist_data_model.toggle_bom_pos.call_args_list,
     }
     assert observed == expected
+
+
+def test_populate_footprint_list_looks_a_part_up_once_per_part(monkeypatch):
+    """Two spellings of one number are one part, so one lookup serves both.
+
+    The details cache is keyed on the canonical number rather than on the raw
+    column, so a store holding "C12345" on one row and " c12345 " on another
+    -- which it can, since several paths write the column unnormalised -- does
+    not fetch the same part twice, and both rows get the details.
+    """
+    window = _window(footprints={"R1": _LiveFootprint(), "R2": _LiveFootprint()})
+    window.hide_bom_parts = False
+    window.hide_pos_parts = False
+    window.pending_assembly_enrichment = set()
+    window.store.read_all.return_value = [
+        _part("R1", "C12345"),
+        _part("R2", " c12345 "),
+    ]
+    window.library.get_part_details.return_value = {"type": "Basic", "stock": "27"}
+
+    JLCPCBTools.populate_footprint_list(window)
+
+    lookups = window.library.get_part_details.call_args_list
+    assert len(lookups) == 1, f"expected one lookup per part, got {lookups}"
+    assert str(lookups[0].args[0]) == "C12345"
+
+    rows = window.partlist_data_model.AddEntry.call_args_list
+    assert len(rows) == 2
+    assert [row.args[0][4] for row in rows] == ["Basic", "Basic"]

--- a/tests/test_mainwindow_stale_footprints.py
+++ b/tests/test_mainwindow_stale_footprints.py
@@ -245,10 +245,12 @@ def test_toggle_handlers_skip_stale_refs_and_continue_live_refs(
 def test_populate_footprint_list_looks_a_part_up_once_per_part(monkeypatch):
     """Two spellings of one number are one part, so one lookup serves both.
 
-    The details cache is keyed on the canonical number rather than on the raw
+    The details cache is keyed on the parsed part rather than on the raw
     column, so a store holding "C12345" on one row and " c12345 " on another
-    -- which it can, since several paths write the column unnormalised -- does
-    not fetch the same part twice, and both rows get the details.
+    -- which it can, since several paths write the column unnormalised --
+    does not fetch the same part twice, and both rows get the details. The
+    LCSC column renders that same parsed part, so the number a row shows
+    agrees with the type and stock shown beside it.
     """
     window = _window(footprints={"R1": _LiveFootprint(), "R2": _LiveFootprint()})
     window.hide_bom_parts = False
@@ -268,4 +270,5 @@ def test_populate_footprint_list_looks_a_part_up_once_per_part(monkeypatch):
 
     rows = window.partlist_data_model.AddEntry.call_args_list
     assert len(rows) == 2
+    assert [row.args[0][3] for row in rows] == ["C12345", "C12345"]
     assert [row.args[0][4] for row in rows] == ["Basic", "Basic"]


### PR DESCRIPTION
Draft, and a nice-to-have rather than a fix — no need for this to compete for attention with the bug PRs.

> **Stacked on #814**, which stacks on #813 and #807. The first five commits are theirs; the last two are this PR: the type with its first adopter, the parts lookup and cache, and then the assignment boundary.

### Why

The last several defects in this area were all raw-string assumptions. A number differing only in case found no part and reported nothing. One differing only in padding read as no part at all. Three separate regexes disagreed about which strings were part numbers. A `str` carries no evidence of having been checked or canonicalised, so every boundary has to remember, and forgetting is silent.

### The type

`Lcsc` is a frozen dataclass whose `__post_init__` **is** the check: it rejects anything that is not a part number and stores the canonical form. A value in hand therefore needs no further testing, which is the whole return on having it.

```
Lcsc.parse(" c12345 ")  ->  Lcsc(value='C12345')
str(part)               ->  'C12345'
f"ordering {part}"      ->  'ordering C12345'
{Lcsc("C12345"): x}[Lcsc("c12345")]  ->  x
Lcsc.parse("C12345-")   ->  None        (not a part number)
```

The type is built on the helpers #807, #813 and #814 put in `lcsc.py` rather than beside them: the constructor normalises with `normalize_lcsc` and asks `is_lcsc_part`, and `find_in` is `extract_lcsc` with the result handed back as a part, so there is still one pattern and one search of it. `parse()` and `find_in()` answer `None` rather than raising — one for values merely *claimed* to be part numbers, one for text a person pasted. Frozen means hashable, which is how the details cache uses it. `__str__` gives the bare number, so it drops into a query, a CSV cell or a log line.

Deliberately **not** ordered. `order=True` gave a lexicographic comparison that puts `C10000` before `C9999`, and numeric order would invent a ranking that means nothing, since a part number identifies a part rather than measuring anything. Comparison raises.

### Absence is `None`

There is no empty `Lcsc` and no `.valid()`. An empty instance would make every value "might be a part number" again — the raw-string situation with extra ceremony, failing the same silent way. So a part that may be absent is `Optional[Lcsc]`, and the uncertainty lives in the question rather than the answer.

Empty-string-as-absent is a serialisation convention, not a domain one. `format_lcsc()` is the single place that applies it, at the edge. That makes the migration path concrete and mechanical: `if row["lcsc"]` becomes `if part is not None`, and whatever hands a value to sqlite, a CSV writer or a wx cell wraps it in `format_lcsc`.

### Scope

Adopted end to end in **one** path rather than everywhere: `get_part_details` takes an `Lcsc` or anything that might name one, and the footprint list's details cache is keyed on the parsed part, so two spellings of one number are one entry and one round trip. Its LCSC column now renders through `format_lcsc`, so it agrees with the type and stock beside it instead of showing whatever spelling the store held; a stored value that names no part renders empty. (That goes one step past #814's "the raw column is still what the row displays"; it is the same hunk the original branch carried, and since #809 and #813 every write and read is canonical, only rows written by earlier releases can differ.)

The second commit is the assignment boundary: #809 routed every assignment path (part selector, paste, Apply part preferences, the fill on open) through `_apply_lcsc_assignments`, which took the strings it was handed and keyed its catalog, wrote the store and the footprint field, and queried FTS5 with them unexamined. It now parses each number once at that boundary, skips and logs a reference whose number names no part the way it already skips a reference the board lacks, keys the catalog on the part, and hands `str(part)` to the store, `set_lcsc_value` and the data model. Those interfaces still take strings.

Full adoption is roughly 97 call sites, and the real work is the 27 that use `""` as absent — each needs the `Optional` decision made deliberately. That is a separate change, and the point of showing the shape here first.

`normalize_lcsc`, `is_lcsc_part` and `extract_lcsc` remain for boundaries that must hand a plain string to sqlite, wx or a CSV writer; the type is built on them, so there is one implementation of the rules. #809's part-preference validator now reads `format_lcsc(Lcsc.parse(value)) or None`, so a stored preference is a part by the same definition.

### Also in here

`get_part_details` no longer looks up values that cannot name a part, which fixes a latent crash: `'foo"bar'`, `'*'`, `'C12345-'` and `'AND'` reached `parts MATCH` and raised `OperationalError: fts5: syntax error` (verified against a real trigram table). The BOM estimator passes the store's `lcsc` column straight through, and the store is not guaranteed to hold a part number.

### Testing

1791 tests pass, 49 of them new. The cache test fails without the keying, reporting two lookups for one part; the assignment test covers a two-reference action where one number names no part and is reported while the other is written canonically from a padded lower-case spelling. One #809 assertion changed shape: `get_part_details.assert_called_once_with("C200")` became a comparison on `str(lookup.args[0])`, because the boundary now passes an `Lcsc` and equality against a `str` is not defined.

### Known

A minimum digit count is deliberately not part of this stack, so `Lcsc.parse("C12")` is a part, exactly as `is_lcsc_part` accepts it; see #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

