### PR TITLE
Validate correction imports and recover invalid stored corrections

### DIFF
--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -1,0 +1,141 @@
+# Importing and repairing corrections
+
+The Corrections Manager stores rotation and position corrections for footprint,
+value, or reference patterns. Corrections can use a global database or a database
+in the current project's `jlcpcb` directory.
+
+## CSV formats
+
+The current exported format is:
+
+```csv
+Pattern,Rotation,Offset X,Offset Y
+^SOT-23$,-90,0,0
+^USB_C_Receptacle$,0,1.44,0
+```
+
+Historical files using `Footprint pattern,Correction` and downloaded files using
+`Footprint pattern,Rotation,Offset X,Offset Y` are also supported. Recognized
+columns may be reordered. The importer rejects unknown or duplicate columns
+instead of guessing their meaning.
+
+Rotation must be a finite whole number of degrees. For example, `90`, `-90`, and
+`90.0` are accepted; `47u` and `90.5` are rejected. Signed values are preserved.
+Offsets must be finite numbers in millimeters. Patterns must be nonempty and
+valid for the plugin's regular-expression matching.
+
+Missing trailing offsets default to zero, including two-field records beneath
+a four-column header. An explicitly empty numeric cell is an error. A missing
+rotation is always an error. UTF-8 files, including files with a byte-order mark,
+Windows line endings, and ordinary CSV quoting are supported.
+
+A file containing only a recognized header imports no records. Blank lines are
+ignored; an entirely empty file or a row containing only delimiters is rejected.
+
+## Import behavior
+
+The complete file is validated before any corrections are changed. If one row
+is invalid, the entire import is rejected and the existing database stays
+unchanged. The error identifies the source, line, field, and invalid value.
+
+A successful user import updates existing patterns and adds new ones. If the
+same pattern appears more than once, its last occurrence wins. Every row must
+still be valid. Downloading corrections preserves existing entries and adds
+missing patterns only.
+
+Database writes are transactional. A write failure rolls back earlier inserts
+and updates from that operation. Correct the reported problem and import again.
+
+## Repairing existing invalid data
+
+Earlier plugin versions could store invalid numeric text from a CSV. Issue #531
+reported a rotation of `47u`, which then prevented the plugin from reopening.
+
+The manager shows invalid records with their original values and errors. Select
+one to repair or delete it. If another window changes the selected record or a
+record approved for replacement, the operation stops and retains your entered
+text. Reselect the current record before retrying. Repair affects only the
+selected record, even when several records have the same pattern.
+
+The main window remains accessible while correction errors are unresolved.
+Fabrication and correction CSV export require a valid active database; invalid
+corrections are never omitted or replaced with zero. Fabrication also checks
+transformed placement coordinates before generating files. An unrepresentable
+position identifies the footprint and correction to repair, preserving existing
+output files.
+
+An empty correction database is valid. A part with no matching rule uses its
+uncorrected placement. Unreadable storage or unresolved records are shown as
+`Unresolved`, rather than being treated as an empty set of corrections.
+
+## Matching and displayed corrections
+
+The parts table and placement output use the same correction selection rules.
+Reference matches take priority over value matches, which take priority over
+footprint matches. For each of those fields, patterns matching the end of the
+text are tried before ordinary substring matches. Ties retain database order.
+For example, `SOT-23-3` wins over `SOT-23` for a footprint named `SOT-23-3`.
+
+A matched correction of zero degrees and zero offset still takes precedence
+over lower-priority rules. The table labels the match source as `(ref)`, `(val)`,
+or `(fpt)`.
+
+## Legacy data and database scope
+
+Existing patterns in the current correction database take precedence over
+legacy rotation archives. This preserves corrections already repaired or
+customized after an older migration, including their position offsets. A stale
+archive cannot add a conflicting copy of an established pattern.
+
+For patterns absent from the destination, the dedicated `rotations.db` archive
+takes precedence over the selected parts database's old rotation table. A
+lower-priority archive cannot add a conflicting copy. Original values are
+preserved, including invalid values and contradictions within the winning
+archive that need repair. The source archives are retained, and imported rows
+and their completion records commit together.
+
+Migration is checked at startup, when switching to global corrections, and when
+opening Corrections Manager for global corrections. Ordinary list refreshes,
+exports, and fabrication checks do not reopen legacy archives. Missing sources,
+empty rotation tables, and files without a rotation table are recorded as
+examined; they do not block healthy corrections or need repeated examination.
+
+If an archive cannot be read and its corrections are unknown, the manager shows
+a warning identifying the file. Healthy active corrections remain usable.
+Restore access to the archive and reopen Corrections Manager to retry. Automatic
+imports from lower-priority sources and the initial default download wait for
+this retry so they cannot take precedence over recovered custom corrections.
+
+If corrections were identified but could not be transferred, the incomplete
+transfer remains blocking across reopening. The manager identifies the source
+and failure; resolve that failure and reopen the manager to retry. An archive
+disappearing afterward does not make a known incomplete transfer successful.
+
+If a custom database schema would change a legacy value during transfer, the
+whole transfer is rejected and the archives remain intact. Correct the reported
+storage incompatibility before retrying.
+
+Older versions did not record whether a missing pattern was never imported,
+deleted, or renamed. If an old archive remains, a missing pattern can be
+restored during its first migration. Completed migrations do not replay that
+archive over later repairs or deletions. Records restored after a source was
+already examined can be imported explicitly using the supported CSV formats.
+An interrupted initial default download resumes after recovery. Failure to start
+that optional download warns without disabling healthy corrections. Reopening
+does not refill corrections that were deliberately deleted.
+
+Automatic legacy CSV imports archive the source only after the import commits.
+An archive failure is reported separately from a successful database import.
+Rejected CSV input leaves the current stored corrections usable. Warnings about
+unreadable archives are separate from errors in active corrections and known
+incomplete transfers.
+
+Global-to-local copying completes before the active database changes. A failed
+switch preserves the active scope and its data. Errors in an inactive database
+do not block a healthy active database.
+
+Switching back to global corrections discards the project's local corrections
+after an explicit confirmation and a successful check of the global database.
+Invalid local values do not prevent this choice. If global corrections cannot
+be used or the switch fails, the local corrections and active scope remain in
+place. Other project data is preserved.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ This tool will automatically export all additional layers with the JLC_ prefix a
 JLCPCB seems to need corrected rotation information. @matthewlai implemented that in his [JLCKicadTools](https://github.com/matthewlai/JLCKicadTools) and I adopted his work in this plugin as well.
 You can download Matthews file from GitHub and manage your own corrections in the Rotation manager.
 
+See [Importing and repairing corrections](CORRECTIONS.md) for supported CSV
+formats, validation rules, and recovery of invalid records from older versions.
+
 ## Icons
 
 This plugin makes use of a lot of icons from the excellent [Material Design Icons](https://materialdesignicons.com/)

--- a/correction_data.py
+++ b/correction_data.py
@@ -1,0 +1,382 @@
+"""Validate correction values and CSV files without GUI or database dependencies."""
+
+from collections.abc import Iterable, Iterator, Sequence
+import csv
+from dataclasses import dataclass, field, replace
+from decimal import Decimal, InvalidOperation
+from io import StringIO
+import math
+import re
+from typing import Literal, Optional
+
+_MIN_ROTATION = -(2**63)
+_MAX_ROTATION = 2**63 - 1
+_NUMBER = re.compile(r"[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?")
+_HEADER_FIELDS = {
+    "pattern": "pattern",
+    "footprint pattern": "pattern",
+    "rotation": "rotation",
+    "correction": "rotation",
+    "offset x": "offset_x",
+    "offset y": "offset_y",
+}
+
+
+@dataclass(frozen=True, init=False)
+class Correction:
+    """A validated correction ready for persistence or matching."""
+
+    pattern: str
+    rotation: int
+    offset: tuple[float, float]
+    _regex: re.Pattern[str] = field(init=False, repr=False, compare=False)
+    _suffix_regex: re.Pattern[str] = field(init=False, repr=False, compare=False)
+
+    def __init__(self, pattern: object, rotation: object, offset: object) -> None:
+        """Enforce the value contract at every construction or replacement."""
+        pattern, rotation, offset, regex, suffix_regex = _validated_values(
+            pattern, rotation, offset
+        )
+        object.__setattr__(self, "pattern", pattern)
+        object.__setattr__(self, "rotation", rotation)
+        object.__setattr__(self, "offset", offset)
+        object.__setattr__(self, "_regex", regex)
+        object.__setattr__(self, "_suffix_regex", suffix_regex)
+
+    @classmethod
+    def parse(
+        cls, pattern: object, rotation: object, offset: object
+    ) -> Optional["Correction"]:  # noqa: UP045
+        """Return a normalized correction, or None for invalid input values."""
+        try:
+            return cls(pattern, rotation, offset)
+        except CorrectionDataError:
+            return None
+
+    def db_row(self) -> tuple[str, int, float, float]:
+        """Return native SQLite values in the correction table column order."""
+        return self.pattern, self.rotation, self.offset[0], self.offset[1]
+
+    def csv_row(self) -> tuple[str, int, float, float]:
+        """Return values whose CSV representation retains numeric precision."""
+        return self.db_row()
+
+    def editor_values(self) -> tuple[str, str, str, str]:
+        """Return lossless text for the pattern, rotation and two offset fields."""
+        return (
+            self.pattern,
+            str(self.rotation),
+            str(self.offset[0]),
+            str(self.offset[1]),
+        )
+
+    def __str__(self) -> str:
+        """Format the correction consistently for display without rounding."""
+        return f"{self.rotation}°, {self.offset[0]}/{self.offset[1]}"
+
+
+@dataclass(frozen=True)
+class CorrectionMatch:
+    """A selected correction and the footprint field that matched it."""
+
+    correction: Correction
+    source: Literal["ref", "val", "fpt"]
+
+
+def find_correction(
+    corrections: Sequence[Correction], value: str
+) -> Optional[Correction]:  # noqa: UP045
+    """Prefer a suffix match, then the first unanchored match in input order."""
+    for correction in corrections:
+        if correction._suffix_regex.search(value):
+            return correction
+    for correction in corrections:
+        if correction._regex.search(value):
+            return correction
+    return None
+
+
+def match_correction(
+    corrections: Sequence[Correction], reference: str, value: str, footprint: str
+) -> Optional[CorrectionMatch]:  # noqa: UP045
+    """Resolve reference, then value, then footprint using one matching policy."""
+    targets: tuple[tuple[Literal["ref", "val", "fpt"], str], ...] = (
+        ("ref", reference),
+        ("val", value),
+        ("fpt", footprint),
+    )
+    for source, target in targets:
+        correction = find_correction(corrections, target)
+        if correction is not None:
+            return CorrectionMatch(correction, source)
+    return None
+
+
+@dataclass(frozen=True)
+class CorrectionIssue:
+    """Describe an invalid value together with its repair location."""
+
+    field: str
+    value: object
+    message: str
+    source: str = ""
+    # KiCad can evaluate these annotations under Python 3.9.
+    line: Optional[int] = None  # noqa: UP045
+    pattern: Optional[str] = None  # noqa: UP045
+    rowid: Optional[int] = None  # noqa: UP045
+
+    def __str__(self) -> str:
+        """Format an actionable diagnostic without losing the original value."""
+        location = [self.source] if self.source else []
+        if self.line is not None:
+            location.append(f"line {self.line}")
+        if self.rowid is not None:
+            location.append(f"row {self.rowid}")
+        if self.pattern is not None:
+            location.append(f"pattern {self.pattern!r}")
+        prefix = ", ".join(location)
+        detail = f"{self.field}: {self.value!r}; {self.message}"
+        return f"{prefix}: {detail}" if prefix else detail
+
+
+class CorrectionDataError(ValueError):
+    """Report all correction issues found before an operation can proceed."""
+
+    def __init__(self, issues: Iterable[CorrectionIssue]) -> None:
+        self.issues = tuple(issues)
+        super().__init__("\n".join(str(issue) for issue in self.issues))
+
+
+def _number_text(value: object) -> str:
+    """Return decimal text only for supported, explicitly numeric values."""
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise TypeError("expected a number")
+    text = str(value).strip()
+    if not _NUMBER.fullmatch(text):
+        raise ValueError("expected a number")
+    return text
+
+
+def _rotation(value: object) -> int:
+    """Parse whole degrees exactly, without float rounding or truncation."""
+    number = Decimal(_number_text(value))
+    if (
+        not number.is_finite()
+        or number < _MIN_ROTATION
+        or number > _MAX_ROTATION
+        or number != number.to_integral_value()
+    ):
+        raise ValueError("rotation is not a representable whole number")
+    return int(number)
+
+
+def _offset(value: object) -> float:
+    """Parse a finite offset suitable for SQLite REAL storage."""
+    number = float(_number_text(value))
+    if not math.isfinite(number):
+        raise ValueError("offset is not finite")
+    return number
+
+
+def _validated_values(
+    pattern: object, rotation: object, offset: object
+) -> tuple[str, int, tuple[float, float], re.Pattern[str], re.Pattern[str]]:
+    """Validate all fields once and return normalized constructor values.
+
+    Pattern text is preserved exactly. Both matching expressions are compiled
+    and retained. Rotations are signed whole degrees within SQLite's
+    integer range; offsets must be finite floats. No invalid value is defaulted.
+    """
+    issues = []
+
+    def issue(field: str, value: object, message: str) -> None:
+        issues.append(
+            CorrectionIssue(
+                field,
+                value,
+                message,
+                pattern=pattern if isinstance(pattern, str) else None,
+            )
+        )
+
+    regex = None
+    suffix_regex = None
+    if not isinstance(pattern, str) or not pattern.strip():
+        issue("pattern", pattern, "expected a nonempty regular expression")
+    else:
+        try:
+            regex = re.compile(pattern)
+            suffix_regex = re.compile(f"(?:{pattern})$")
+        except (re.error, OverflowError, RecursionError) as error:
+            issue("pattern", pattern, f"invalid correction regular expression: {error}")
+
+    validated_rotation = None
+    try:
+        validated_rotation = _rotation(rotation)
+    except (TypeError, ValueError, InvalidOperation, OverflowError):
+        issue(
+            "rotation",
+            rotation,
+            f"expected finite whole degrees between {_MIN_ROTATION} and {_MAX_ROTATION}",
+        )
+
+    validated_offsets = []
+    if not isinstance(offset, (tuple, list)) or len(offset) != 2:
+        issue("offset", offset, "expected exactly two offsets (X and Y)")
+    else:
+        for field, value in zip(("offset_x", "offset_y"), offset):
+            try:
+                validated_offsets.append(_offset(value))
+            except (TypeError, ValueError, OverflowError):
+                issue(field, value, "expected a finite numeric offset")
+
+    if issues:
+        raise CorrectionDataError(issues)
+    # Field validation above guarantees these types when there are no issues.
+    assert isinstance(pattern, str)
+    assert validated_rotation is not None
+    assert regex is not None
+    assert suffix_regex is not None
+    return (
+        pattern,
+        validated_rotation,
+        (validated_offsets[0], validated_offsets[1]),
+        regex,
+        suffix_regex,
+    )
+
+
+def validate_correction(
+    pattern: object,
+    rotation: object,
+    offset: object,
+    *,
+    source: str = "",
+    line: Optional[int] = None,  # noqa: UP045
+    rowid: Optional[int] = None,  # noqa: UP045
+) -> Correction:
+    """Construct a correction and attach source locations to field errors."""
+    try:
+        return Correction(pattern, rotation, offset)
+    except CorrectionDataError as error:
+        raise CorrectionDataError(
+            replace(issue, source=source, line=line, rowid=rowid)
+            for issue in error.issues
+        ) from error
+
+
+def _header_columns(row: list[str], source: str, line: int) -> list[str]:
+    """Map known header aliases and reject ambiguous or incomplete headers."""
+    columns = []
+    issues = []
+    for name in row:
+        field = _HEADER_FIELDS.get(" ".join(name.split()).casefold())
+        if field is None:
+            issues.append(
+                CorrectionIssue(
+                    "header", name, "unknown correction column", source, line
+                )
+            )
+        elif field in columns:
+            issues.append(
+                CorrectionIssue(
+                    "header", name, "duplicate correction column", source, line
+                )
+            )
+        columns.append(field)
+    for field in ("pattern", "rotation"):
+        if field not in columns:
+            issues.append(
+                CorrectionIssue(
+                    "header", row, f"missing required {field} column", source, line
+                )
+            )
+    if issues:
+        raise CorrectionDataError(issues)
+    return columns
+
+
+def _csv_rows(
+    stream: StringIO,
+    *,
+    source: str,
+    skipinitialspace: bool = False,
+    line_offset: int = 0,
+) -> Iterator[tuple[list[str], int, int]]:
+    """Yield nonblank CSV records with their starting physical line numbers."""
+    reader = csv.reader(stream, strict=True, skipinitialspace=skipinitialspace)
+    while True:
+        start = stream.tell()
+        line = line_offset + reader.line_num + 1
+        try:
+            row = next(reader)
+        except StopIteration:
+            return
+        except csv.Error as error:
+            raise CorrectionDataError(
+                (CorrectionIssue("csv", None, str(error), source, line),)
+            ) from error
+        # Ignore physical whitespace-only lines, but validate explicit empty
+        # fields such as `""` and delimiter-only records like `,,,`.
+        if not stream.getvalue()[start : stream.tell()].strip():
+            continue
+        yield row, line, line_offset + reader.line_num
+
+
+def parse_corrections_csv(text: str, source: str = "") -> tuple[Correction, ...]:
+    """Parse and validate an entire current, historical, or remote CSV file.
+
+    Header names determine column positions. Missing trailing offsets default
+    to zero, while explicit blank fields and missing required values fail.
+    Duplicate patterns remain in input order so callers can apply their policy
+    only after every row has validated. Any error rejects the complete input.
+    """
+    if not isinstance(text, str):
+        raise CorrectionDataError(
+            (CorrectionIssue("csv", text, "expected decoded CSV text", source),)
+        )
+    stream = StringIO(text.removeprefix("\ufeff"), newline="")
+    # The remote source has spaces before a quoted header. Restrict this
+    # tolerance to headers so leading spaces in user patterns stay unchanged.
+    header = next(_csv_rows(stream, source=source, skipinitialspace=True), None)
+    if header is None:
+        raise CorrectionDataError(
+            (
+                CorrectionIssue(
+                    "header", None, "expected a correction CSV header", source
+                ),
+            )
+        )
+    row, line, header_end_line = header
+    columns = _header_columns(row, source, line)
+    corrections = []
+    issues = []
+    try:
+        for row, line, _end_line in _csv_rows(
+            stream, source=source, line_offset=header_end_line
+        ):
+            if len(row) > len(columns):
+                issues.append(
+                    CorrectionIssue(
+                        "csv", row, "more values than header columns", source, line
+                    )
+                )
+                continue
+            values = dict(zip(columns, row))
+            try:
+                corrections.append(
+                    validate_correction(
+                        values.get("pattern"),
+                        values.get("rotation"),
+                        (values.get("offset_x", 0), values.get("offset_y", 0)),
+                        source=source,
+                        line=line,
+                    )
+                )
+            except CorrectionDataError as error:
+                issues.extend(error.issues)
+    except CorrectionDataError as error:
+        issues.extend(error.issues)
+    if issues:
+        raise CorrectionDataError(issues)
+    return tuple(corrections)

--- a/corrections.py
+++ b/corrections.py
@@ -1,20 +1,33 @@
 """Contains the corrections manager."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
 import csv
 import logging
 import os
+from typing import TYPE_CHECKING, Any
 
 import wx  # pylint: disable=import-error
 import wx.dataview  # pylint: disable=import-error
 
+from .correction_data import (
+    Correction,
+    CorrectionDataError,
+    parse_corrections_csv,
+    validate_correction,
+)
 from .events import PopulateFootprintListEvent
 from .helpers import PLUGIN_PATH, HighResWxSize, loadBitmapScaled
+
+if TYPE_CHECKING:
+    from .library import StoredCorrection
 
 
 class CorrectionManagerDialog(wx.Dialog):
     """Dialog for managing part corrections."""
 
-    def __init__(self, parent, footprint):
+    def __init__(self, parent: Any, footprint: str) -> None:
         wx.Dialog.__init__(
             self,
             parent,
@@ -27,11 +40,10 @@ class CorrectionManagerDialog(wx.Dialog):
 
         self.logger = logging.getLogger(__name__)
         self.parent = parent
-        self.selection_regex = None
-        self.selection_rotation = None
-        self.selection_offset_x = None
-        self.selection_offset_y = None
-        self.import_legacy_corrections()
+        self.selected_record = None
+        self.selection_db_path = None
+        self.correction_snapshot = None
+        self._populating = False
 
         # ---------------------------------------------------------------------
         # ---------------------------- Hotkeys --------------------------------
@@ -161,7 +173,7 @@ class CorrectionManagerDialog(wx.Dialog):
             wx.ID_ANY,
             wx.DefaultPosition,
             wx.DefaultSize,
-            style=wx.dataview.DV_MULTIPLE,
+            style=wx.dataview.DV_SINGLE,
         )
 
         self.corrections_list.AppendTextColumn(
@@ -188,6 +200,14 @@ class CorrectionManagerDialog(wx.Dialog):
             width=int(parent.scale_factor * 100),
             align=wx.ALIGN_LEFT,
         )
+
+        self.corrections_list.AppendTextColumn(
+            "Status",
+            mode=wx.dataview.DATAVIEW_CELL_INERT,
+            width=int(parent.scale_factor * 280),
+            align=wx.ALIGN_LEFT,
+        )
+        self.correction_status = wx.StaticText(self, wx.ID_ANY, "")
 
         self.corrections_list.SetMinSize(
             HighResWxSize(parent.window, wx.Size(600, 500))
@@ -310,9 +330,7 @@ class CorrectionManagerDialog(wx.Dialog):
         self.global_corrections.Bind(
             wx.EVT_CHECKBOX, self.on_global_corrections_changed
         )
-        self.global_corrections.SetValue(
-            self.parent.library.uses_global_correction_database()
-        )
+        self.global_corrections.SetValue(self._uses_global_corrections())
 
         tool_sizer = wx.BoxSizer(wx.VERTICAL)
         tool_sizer.Add(self.save_button, 0, wx.ALL, 5)
@@ -331,20 +349,24 @@ class CorrectionManagerDialog(wx.Dialog):
 
         layout = wx.BoxSizer(wx.VERTICAL)
         layout.Add(add_edit_sizer, 1, wx.ALL | wx.EXPAND, 5)
+        layout.Add(self.correction_status, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(table_sizer, 20, wx.ALL | wx.EXPAND, 5)
 
         self.SetSizer(layout)
         self.Layout()
         self.Centre(wx.BOTH)
         self.enable_toolbar_buttons()
+        if self._uses_global_corrections():
+            self.parent.library.retry_correction_migrations()
+        self.import_legacy_corrections()
         self.populate_corrections_list()
 
-    def quit_dialog(self, *_):
+    def quit_dialog(self, *_: object) -> None:
         """Close this dialog."""
         self.Destroy()
         self.EndModal(0)
 
-    def enable_toolbar_buttons(self):
+    def enable_toolbar_buttons(self) -> None:
         """Control the state of all the buttons in toolbar on the right side."""
         if (
             self.regex.GetValue()
@@ -361,237 +383,342 @@ class CorrectionManagerDialog(wx.Dialog):
         else:
             self.delete_button.Enable(False)
 
-    def to_float(self, value):
-        """Convert the given value to a float, return 0 if convertion fails."""
+    def _clear_selection(self) -> None:
+        """Forget the stored row identity without changing unsaved input fields."""
+        self.selected_record = None
+        self.selection_db_path = None
+
+    def _input_values(self) -> tuple[str, str, str, str]:
+        """Read exact editor text to distinguish actual edits from stale display values."""
+        return tuple(
+            control.GetValue()
+            for control in (self.regex, self.rotation, self.offset_x, self.offset_y)
+        )
+
+    @staticmethod
+    def _record_editor_values(record: StoredCorrection) -> tuple[str, str, str, str]:
+        """Present valid values consistently while preserving invalid original text."""
+        if record.correction is not None:
+            return record.correction.editor_values()
+        return (
+            str(record.pattern),
+            str(record.rotation),
+            str(record.offset[0]),
+            str(record.offset[1]),
+        )
+
+    def _select_record(self, record: StoredCorrection, db_path: str) -> None:
+        """Retain the exact stored record and synchronize the editor with it."""
+        self.selected_record = record
+        self.selection_db_path = db_path
+        for control, value in zip(
+            (self.regex, self.rotation, self.offset_x, self.offset_y),
+            self._record_editor_values(record),
+        ):
+            control.SetValue(value)
+
+    def populate_corrections_list(
+        self, *, selected_rowid: int | None = None, preserve_inputs: bool = False
+    ) -> None:
+        """Refresh rows without granting stale unsaved edits a newer record identity."""
+        snapshot = self.parent.library.read_correction_data()
+        preserve_inputs = preserve_inputs or (
+            selected_rowid is None
+            and self.selected_record is not None
+            and self._input_values() != self._record_editor_values(self.selected_record)
+        )
+        if selected_rowid is None and self.selected_record is not None:
+            selected_rowid = self.selected_record.rowid
+        self._populating = True
         try:
-            return float(value)
-        except ValueError:
-            return 0
-
-    def str_from_float(self, value):
-        """Convert the given floating point value to a string.
-
-        Us as many decimal digits as required but for small numbers
-        at least two decimal digits are used.
-        """
-        s = str(value)
-        return f"{value:.2f}" if len(s) < 4 else s
-
-    def populate_corrections_list(self):
-        """Populate the list with the result of the search."""
-        self.corrections_list.DeleteAllItems()
-        for regex, rotation, offset in self.parent.library.get_all_correction_data():
-            self.corrections_list.AppendItem(
-                [
-                    str(regex),
-                    str(rotation),
-                    self.str_from_float(offset[0]),
-                    self.str_from_float(offset[1])
-                ]
-            )
-        selected_row = None
-        if self.selection_regex is not None:
-            for row in range(self.corrections_list.GetItemCount()):
-                row_regex = self.corrections_list.GetTextValue(row, 0)
-                if row_regex == self.selection_regex:
-                    selected_row = row
-            if selected_row is not None:
-                self.corrections_list.SelectRow(selected_row)
-
-    def save_correction(self, *_):
-        """Add/Update a correction in the database."""
-        regex = self.regex.GetValue()
-        rotation = int(self.to_float(self.rotation.GetValue()))
-        offset_x = self.to_float(self.offset_x.GetValue())
-        offset_y = self.to_float(self.offset_y.GetValue())
-        offset = (offset_x, offset_y)
-        if regex == self.selection_regex:
-            # the regex of the selection was not changed, just update values.
-            self.parent.library.update_correction_data(regex, rotation, offset)
-        else:
-            # regex was modified or nothing was selected.
-            # Check if there is a existing rule for that regex
-            row_of_that_regex = None
-            for row in range(self.corrections_list.GetItemCount()):
-                row_regex = self.corrections_list.GetTextValue(row, 0)
-                if row_regex == regex:
-                    row_of_that_regex = row
-
-            if row_of_that_regex is None:
-                # the regex is a new one, just create it or update the selected entry
-
-                if self.selection_regex is not None:
-                    # remove old line, if one existed
-                    self.parent.library.delete_correction_data(self.selection_regex)
-
-                # Add the modified regex and values
-                self.parent.library.insert_correction_data(regex, rotation, offset)
-                self.selection_regex = regex
-            else:
-                # The regex already exists.
-                existing_rotation = int(
-                    self.to_float(self.corrections_list.GetTextValue(row, 1))
+            self.corrections_list.DeleteAllItems()
+            self.correction_snapshot = snapshot
+            for index, record in enumerate(snapshot.rows):
+                self.corrections_list.AppendItem(
+                    [
+                        *self._record_editor_values(record),
+                        "; ".join(
+                            f"{issue.field}: {issue.message}" for issue in record.issues
+                        ),
+                    ]
                 )
-                existing_offset_x = self.to_float(
-                    self.corrections_list.GetTextValue(row, 2)
-                )
-                existing_offset_y = self.to_float(
-                    self.corrections_list.GetTextValue(row, 3)
-                )
-
-                if (
-                    rotation == existing_rotation
-                    and offset_x == existing_offset_x
-                    and offset_y == existing_offset_y
+                if record.rowid == selected_rowid and (
+                    self.selected_record is None
+                    or self.selection_db_path == snapshot.db_path
                 ):
-                    # User entered a regex that already exists, just select that one
-                    self.selection_regex = regex
-                else:
-                    # The regex exists with different values, ask the user what to do.
-                    existing_correction = "(" + \
-                        str(existing_rotation) + "°, " + \
-                        self.str_from_float(existing_offset_x) + "/" + \
-                        self.str_from_float(existing_offset_y) + \
-                        ")"
-                    new_correction = "(" + \
-                        str(rotation) + "°, " + \
-                        self.str_from_float(offset_x) + "/" + \
-                        self.str_from_float(offset_y) + \
-                        ")"
+                    if not preserve_inputs:
+                        self._select_record(record, snapshot.db_path)
+                        self.corrections_list.SelectRow(index)
+        finally:
+            self._populating = False
 
-                    dialog = wx.MessageDialog(
-                        self,
-                        f"A rule for '{regex}' already exists!",
-                        "Regex exists!",
-                        wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
-                    )
-                    if self.selection_regex is None:
-                        # The user entered a regex that already exists with different values.
-                        dialog.ExtendedMessage = "Do you want to update the corrections " + \
-                           existing_correction + \
-                           " to " + \
-                           new_correction
-                    else:
-                        # The user has selected regex_a, changed it to regex_b
-                        # (but regex_b exists).
-                        dialog.ExtendedMessage = "Do you want to replace the corrections " + \
-                           existing_correction + \
-                           " with " + \
-                           new_correction + \
-                           ",\n" + \
-                           f"removing the rule for '{self.selection_regex}'?"
-                    result = dialog.ShowModal()
+        warning = f"Using {snapshot.scope} corrections: {snapshot.db_path}"
+        if snapshot.issues:
+            if any(row.issues for row in snapshot.rows):
+                warning = (
+                    f"{snapshot.scope.capitalize()} corrections need repair "
+                    f"({len(snapshot.issues)} errors). "
+                    "Select a row to repair or delete it. "
+                )
+            else:
+                warning = f"{snapshot.scope.capitalize()} corrections are unavailable. "
+            warning += (
+                "Export and fabrication are blocked until all errors are resolved."
+            )
+            general_issues = [issue for issue in snapshot.issues if issue.rowid is None]
+            if general_issues:
+                warning += "\n" + "\n".join(map(str, general_issues))
+                warning += (
+                    "\nResolve the file errors above and reopen Corrections Manager "
+                    "to retry."
+                )
+        if snapshot.warnings:
+            warning += "\nCorrection warnings:\n" + "\n".join(
+                map(str, snapshot.warnings)
+            )
+            warning += (
+                "\nResolve the warnings above and reopen Corrections Manager to retry."
+            )
+        self.correction_status.SetLabel(warning)
+        self.correction_status.SetToolTip(
+            "\n".join(map(str, (*snapshot.issues, *snapshot.warnings)))
+        )
+        self.correction_status.Wrap(int(self.parent.scale_factor * 700))
+        self.Layout()
+        self.enable_toolbar_buttons()
 
-                    if result == wx.ID_YES:
-                        if self.selection_regex is not None:
-                            self.parent.library.delete_correction_data(self.selection_regex)
-                        self.parent.library.update_correction_data(regex, rotation, offset)
-                        self.selection_regex = regex
+    def _show_error(self, title: str, error: object) -> None:
+        """Show a handled correction error while preserving the current inputs."""
+        self.logger.warning("%s: %s", title, error)
+        wx.MessageBox(str(error), title, wx.OK | wx.ICON_ERROR, self)
 
-        self.rotation.SetValue(str(rotation))
-        self.offset_x.SetValue(self.str_from_float(offset_x))
-        self.offset_y.SetValue(self.str_from_float(offset_y))
+    def _selection_matches_database(self) -> bool:
+        """Refuse to reuse a selected row identity in a different database."""
+        return self.selected_record is None or os.path.realpath(
+            self.selection_db_path
+        ) == os.path.realpath(self.parent.library.correctionsdb_file)
+
+    def _confirm_replacement(
+        self, correction: Correction, conflicts: Sequence[StoredCorrection]
+    ) -> bool:
+        """Ask before atomically replacing other records with the same pattern."""
+        existing = "\n".join(
+            f"Row {row.rowid}: "
+            + (
+                str(row.correction)
+                if row.correction is not None
+                else f"{row.rotation}°, {row.offset[0]}/{row.offset[1]}"
+            )
+            for row in conflicts
+        )
+        dialog = wx.MessageDialog(
+            self,
+            f"A rule for '{correction.pattern}' already exists!",
+            "Regex exists!",
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
+        )
+        dialog.ExtendedMessage = (
+            f"{existing}\n\nReplace these {len(conflicts)} existing entries with "
+            f"{correction}?"
+        )
+        if self.selected_record is not None:
+            dialog.ExtendedMessage += (
+                f"\nThe selected row {self.selected_record.rowid} will become "
+                f"'{correction.pattern}'."
+            )
+        try:
+            return dialog.ShowModal() == wx.ID_YES
+        finally:
+            dialog.Destroy()
+
+    def save_correction(self, *_: object) -> bool:
+        """Validate input and save or repair one row in a single transaction."""
+        if not self._selection_matches_database():
+            self._show_error(
+                "Correction Save Error",
+                "The corrections database changed. Select the row again before saving.",
+            )
+            self.populate_corrections_list(preserve_inputs=True)
+            return False
+        library = self.parent.library
+        target = str(library.correctionsdb_file)
+        rowid = self.selected_record.rowid if self.selected_record else None
+        try:
+            correction = validate_correction(
+                self.regex.GetValue(),
+                self.rotation.GetValue(),
+                (self.offset_x.GetValue(), self.offset_y.GetValue()),
+                source=target,
+                rowid=rowid,
+            )
+            snapshot = library.read_correction_data(target)
+            conflicts = [
+                row
+                for row in snapshot.rows
+                if row.pattern == correction.pattern and row.rowid != rowid
+            ]
+            if (
+                self.selected_record is None
+                and len(conflicts) == 1
+                and conflicts[0].correction == correction
+            ):
+                self.populate_corrections_list(selected_rowid=conflicts[0].rowid)
+                return True
+            if conflicts and not self._confirm_replacement(correction, conflicts):
+                return False
+            rowid = library.save_correction_data(
+                correction,
+                rowid=rowid,
+                replace=bool(conflicts),
+                db_path=target,
+                expected_record=self.selected_record,
+                expected_conflicts=conflicts,
+            )
+        except CorrectionDataError as error:
+            self._show_error("Correction Save Error", error)
+            self.populate_corrections_list(preserve_inputs=True)
+            return False
+
+        self.populate_corrections_list(selected_rowid=rowid)
+        wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        return True
+
+    def delete_correction(self, *_: object) -> bool:
+        """Delete only the selected stored row, even for null or duplicate patterns."""
+        if self.selected_record is None:
+            return False
+        if not self._selection_matches_database():
+            self._show_error(
+                "Correction Delete Error",
+                "The corrections database changed. Select the row again before deleting.",
+            )
+            self.populate_corrections_list(preserve_inputs=True)
+            return False
+        try:
+            self.parent.library.delete_correction_row(
+                self.selected_record.rowid,
+                db_path=self.selection_db_path,
+                expected_record=self.selected_record,
+            )
+        except CorrectionDataError as error:
+            self._show_error("Correction Delete Error", error)
+            self.populate_corrections_list(preserve_inputs=True)
+            return False
+        self._clear_selection()
         self.populate_corrections_list()
         wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        return True
 
-    def delete_correction(self, *_):
-        """Delete a correction from the database."""
-        item = self.corrections_list.GetSelection()
-        row = self.corrections_list.ItemToRow(item)
-        if row == -1:
+    def on_correction_selected(self, event: wx.dataview.DataViewEvent) -> None:
+        """Copy original field text without coercing invalid values to zero."""
+        if self._populating:
             return
-        regex = self.corrections_list.GetTextValue(row, 0)
-        self.parent.library.delete_correction_data(regex)
-        self.populate_corrections_list()
-        wx.PostEvent(self.parent, PopulateFootprintListEvent())
-
-    def on_correction_selected(self, event):
-        """Enable the toolbar buttons when a selection was made."""
-        if len(self.corrections_list.GetSelections()) > 1:
-            for item in self.corrections_list.GetSelections():
-                if item != event.GetItem():
-                    self.corrections_list.Unselect(item)
-
-        if self.corrections_list.GetSelectedItemsCount() > 0:
-            item = self.corrections_list.GetSelection()
-            row = self.corrections_list.ItemToRow(item)
-            if row == -1:
-                return
-
-            self.selection_regex = self.corrections_list.GetTextValue(row, 0)
-            self.selection_rotation = int(
-                self.to_float(self.corrections_list.GetTextValue(row, 1))
-            )
-            self.selection_offset_x = self.to_float(
-                self.corrections_list.GetTextValue(row, 2)
-            )
-            self.selection_offset_y = self.to_float(
-                self.corrections_list.GetTextValue(row, 3)
-            )
-            self.regex.SetValue(self.selection_regex)
-            self.rotation.SetValue(str(self.selection_rotation))
-            self.offset_x.SetValue(self.str_from_float(self.selection_offset_x))
-            self.offset_y.SetValue(self.str_from_float(self.selection_offset_y))
+        row = self.corrections_list.GetSelectedRow()
+        if row == wx.NOT_FOUND or not 0 <= row < len(self.correction_snapshot.rows):
+            self._clear_selection()
         else:
-            self.selection_row = None
-            self.selection_regex = None
-
-        self.enable_toolbar_buttons()
-
-    def on_textfield_change(self, *_):
-        """Check if the texfield change affects toolbars."""
-        self.enable_toolbar_buttons()
-
-    def on_global_corrections_changed(self, use_global):
-        """Switch between global or local correction database file."""
-        if self.parent.library.uses_global_correction_database():
-            dialog = wx.MessageDialog(
-                self,
-                "Do you want to switch to the local corrections database?",
-                "Switching corrections database",
-                wx.YES_NO | wx.YES_DEFAULT | wx.ICON_QUESTION,
+            self._select_record(
+                self.correction_snapshot.rows[row], self.correction_snapshot.db_path
             )
+        self.enable_toolbar_buttons()
+
+    def on_textfield_change(self, *_: object) -> None:
+        """Check whether changed text enables saving."""
+        self.enable_toolbar_buttons()
+
+    def _uses_global_corrections(self) -> bool:
+        """Read the active scope without inferring it from unrelated stored tables."""
+        library = self.parent.library
+        return os.path.realpath(library.correctionsdb_file) == os.path.realpath(
+            library.globalcorrectionsdb_file
+        )
+
+    def on_global_corrections_changed(self, *_: object) -> bool:
+        """Switch scope only after a successful, validated database transfer."""
+        library = self.parent.library
+        was_global = self._uses_global_corrections()
+        dialog = wx.MessageDialog(
+            self,
+            "Do you want to switch to the "
+            + ("local" if was_global else "global")
+            + " corrections database?",
+            "Switching corrections database",
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+        )
+        if was_global:
             dialog.ExtendedMessage = "Switching to a board local database copies the current global database."
         else:
-            dialog = wx.MessageDialog(
+            dialog.ExtendedMessage = (
+                "The project-specific corrections will be discarded. "
+                "The global corrections will be used for this board."
+            )
+        try:
+            confirmed = dialog.ShowModal() == wx.ID_YES
+        finally:
+            dialog.Destroy()
+        if not confirmed:
+            self.global_corrections.SetValue(was_global)
+            return False
+        try:
+            library.switch_to_global_correction_database(not was_global)
+        except CorrectionDataError as error:
+            self.global_corrections.SetValue(was_global)
+            self._show_error(
+                "Correction Database Error",
+                f"{error}\nResolve the file errors and try switching databases again.",
+            )
+            return False
+        self._clear_selection()
+        self.populate_corrections_list()
+        wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        self.global_corrections.SetValue(self._uses_global_corrections())
+        return True
+
+    def download_correction_data(self, *_: object) -> bool:
+        """Refresh the display only after the remote batch has committed."""
+        result = self.parent.library.fetch_remote_corrections()
+        if result is None:
+            return False
+        self.populate_corrections_list()
+        wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        return True
+
+    def import_legacy_corrections(self) -> bool:
+        """Import an old CSV once, after controls exist, and preserve its archive."""
+        path = os.path.join(PLUGIN_PATH, "corrections", "cpl_rotations_db.csv")
+        if not os.path.isfile(path):
+            return False
+        library = self.parent.library
+        try:
+            with open(path, "rb") as source:
+                contents = source.read()
+            key = library.correction_csv_migration_key(path, contents)
+            completed = library.has_correction_migration(key)
+        except (OSError, CorrectionDataError) as error:
+            self._show_error("Legacy Correction Import Error", f"{path}: {error}")
+            return False
+        if not completed and not self._import_corrections(
+            path, contents=contents, migration_key=key, refresh=False
+        ):
+            return False
+        try:
+            # A hard link refuses an existing archive atomically. Keep the source
+            # if archival fails; the committed marker prevents replay after repair.
+            os.link(path, f"{path}.backup")
+            os.unlink(path)
+        except OSError as error:
+            wx.MessageBox(
+                f"The legacy corrections were already imported successfully. "
+                f"The source remains at {path}, but could not be archived: {error}. "
+                "It will not be imported again unless its contents change.",
+                "Legacy Correction Archive Warning",
+                wx.OK | wx.ICON_WARNING,
                 self,
-                "Do you want to switch to the global corrections database?",
-                "Switching corrections database",
-                wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
             )
-        result = dialog.ShowModal()
+        return True
 
-        if result == wx.ID_NO:
-            self.global_corrections.SetValue(
-                self.parent.library.uses_global_correction_database()
-            )
-            return
-
-        self.parent.library.switch_to_global_correction_database(
-            not self.parent.library.uses_global_correction_database()
-        )
-        self.populate_corrections_list()
-        wx.PostEvent(self.parent, PopulateFootprintListEvent())
-        self.global_corrections.SetValue(
-            self.parent.library.uses_global_correction_database()
-        )
-
-    def download_correction_data(self, *_):
-        """Fetch the latest rotation correction table from Matthew Lai's JLCKicadTool repo."""
-        self.parent.library.create_correction_table()
-        self.parent.library.fetch_remote_corrections()
-        self.populate_corrections_list()
-        wx.PostEvent(self.parent, PopulateFootprintListEvent())
-
-    def import_legacy_corrections(self):
-        """Check if corrections in CSV format are found and import them into the database."""
-        csv_file = os.path.join(PLUGIN_PATH, "corrections", "cpl_rotations_db.csv")
-        if os.path.isfile(csv_file):
-            self._import_corrections(csv_file)
-            os.rename(csv_file, f"{csv_file}.backup")
-
-    def import_corrections_dialog(self, *_):
-        """Dialog to import correctios from a CSV file."""
+    def import_corrections_dialog(self, *_: object) -> bool:
+        """Ask for a correction CSV and import it after confirmation."""
         with wx.FileDialog(
             self,
             "Import",
@@ -599,14 +726,13 @@ class CorrectionManagerDialog(wx.Dialog):
             "",
             "CSV files (*.csv)|*.csv",
             wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
-        ) as importFileDialog:
-            if importFileDialog.ShowModal() == wx.ID_CANCEL:
-                return
-            path = importFileDialog.GetPath()
-            self._import_corrections(path)
+        ) as file_dialog:
+            if file_dialog.ShowModal() == wx.ID_CANCEL:
+                return False
+            return self._import_corrections(file_dialog.GetPath())
 
-    def export_corrections_dialog(self, *_):
-        """Dialog to export correctios to a CSV file."""
+    def export_corrections_dialog(self, *_: object) -> bool:
+        """Ask for the destination of a validated correction CSV."""
         with wx.FileDialog(
             self,
             "Export",
@@ -614,63 +740,59 @@ class CorrectionManagerDialog(wx.Dialog):
             "",
             "CSV files (*.csv)|*.csv",
             wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
-        ) as exportFileDialog:
-            if exportFileDialog.ShowModal() == wx.ID_CANCEL:
-                return
-            path = exportFileDialog.GetPath()
-            self._export_corrections(path)
+        ) as file_dialog:
+            if file_dialog.ShowModal() == wx.ID_CANCEL:
+                return False
+            return self._export_corrections(file_dialog.GetPath())
 
-    def _import_corrections(self, path):
-        """Corrections import logic."""
-        if os.path.isfile(path):
-            with open(path, encoding="utf-8") as f:
-                csvreader = csv.DictReader(
-                    f, fieldnames=("regex", "rotation", "offset_x", "offset_y")
-                )
-                next(csvreader)
-                for row in csvreader:
-                    if "regex" in row and row["regex"] is not None:
-                        regex = row["regex"]
-                        rotation = row["rotation"] if row["rotation"] is not None else 0
-                        offset_x = row["offset_x"] if row["offset_x"] is not None else 0
-                        offset_y = row["offset_y"] if row["offset_y"] is not None else 0
-                        existing_data = self.parent.library.get_correction_data(regex)
-                        if existing_data:
-                            self.parent.library.update_correction_data(
-                                regex, rotation, (offset_x, offset_y)
-                            )
-                            self.logger.info(
-                                "Correction '%s' exists already in database with correction value '%s, %s/%s'. Overwrite it with local values from CSV (%s, %s/%s).",
-                                regex,
-                                existing_data[1],
-                                existing_data[2],
-                                existing_data[3],
-                                rotation,
-                                offset_x,
-                                offset_y,
-                            )
-                        else:
-                            self.parent.library.insert_correction_data(
-                                regex, rotation, (offset_x, offset_y)
-                            )
-                            self.logger.info(
-                                "Correction '%s' with correction value '%s, %s/%s' is added to the database from local CSV.",
-                                regex,
-                                rotation,
-                                offset_x,
-                                offset_y,
-                            )
-            self.populate_corrections_list()
+    def _import_corrections(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        contents: bytes | None = None,
+        migration_key: str | None = None,
+        refresh: bool = True,
+    ) -> bool:
+        """Validate the complete CSV before committing any insert or replacement."""
+        library = self.parent.library
+        target = str(library.correctionsdb_file)
+        try:
+            if contents is None:
+                with open(path, "rb") as source:
+                    contents = source.read()
+            corrections = parse_corrections_csv(
+                contents.decode("utf-8"), source=str(path)
+            )
+            result = library.apply_corrections(
+                corrections, db_path=target, migration_key=migration_key
+            )
+        except (OSError, UnicodeError, CorrectionDataError) as error:
+            self._show_error("Correction Import Error", f"{path}: {error}")
+            return False
+        if result.changed:
+            if refresh:
+                self.populate_corrections_list()
             wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        return True
 
-    def _export_corrections(self, path):
-        """Corrections export logic."""
-        with open(path, "w", newline="", encoding="utf-8") as f:
-            csvwriter = csv.writer(f, quotechar='"', quoting=csv.QUOTE_ALL)
-            csvwriter.writerow(["Pattern", "Rotation", "Offset X", "Offset Y"])
-            for (
-                regex,
-                rotation,
-                offset,
-            ) in self.parent.library.get_all_correction_data():
-                csvwriter.writerow([regex, rotation, offset[0], offset[1]])
+    def _export_corrections(self, path: str | os.PathLike[str]) -> bool:
+        """Validate a complete snapshot before opening the export destination."""
+        try:
+            snapshot = self.parent.library.read_correction_data()
+            corrections = snapshot.corrections
+            if corrections is None:
+                self._show_error(
+                    "Correction Export Error",
+                    f"{path}: The active {snapshot.scope} corrections are not ready. "
+                    "Resolve the errors shown in Corrections Manager before exporting.",
+                )
+                return False
+            with open(path, "w", newline="", encoding="utf-8") as destination:
+                writer = csv.writer(destination, quotechar='"', quoting=csv.QUOTE_ALL)
+                writer.writerow(["Pattern", "Rotation", "Offset X", "Offset Y"])
+                for correction in corrections:
+                    writer.writerow(correction.csv_row())
+        except (OSError, UnicodeError, CorrectionDataError) as error:
+            self._show_error("Correction Export Error", f"{path}: {error}")
+            return False
+        return True

--- a/fabrication.py
+++ b/fabrication.py
@@ -6,7 +6,8 @@ import logging
 import math
 import os
 from pathlib import Path
-import re
+from types import SimpleNamespace
+from typing import Any, Optional
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from pcbnew import (  # pylint: disable=import-error
@@ -15,7 +16,6 @@ from pcbnew import (  # pylint: disable=import-error
     PCB_VIA,
     PLOT_CONTROLLER,
     PLOT_FORMAT_GERBER,
-    VECTOR2I,
     ZONE_FILLER,
     B_Cu,
     B_Mask,
@@ -33,6 +33,7 @@ from pcbnew import (  # pylint: disable=import-error
     wxPoint,
 )
 
+from .correction_data import Correction, CorrectionMatch, match_correction
 from .footprint_helpers import get_is_dnp
 
 # Compatibility hack for V6 / V7 / V7.99
@@ -47,6 +48,13 @@ except ImportError:
 # 128 characters of headroom for the other fields (Comment, Footprint, LCSC,
 # Quantity) so the Designator chunk alone is capped at 1920 characters.
 _BOM_DESIGNATOR_MAX_LEN = 1920  # 2048 - 128 padding for remaining CSV fields
+
+
+def _checked_position(x: float, y: float) -> Any:
+    """Reject overflow before wxPoint converts doubles to signed 32-bit integers."""
+    if any(not -(2**31) <= int(value) <= 2**31 - 1 for value in (x, y)):
+        raise ValueError("position exceeds KiCad's signed 32-bit coordinate range")
+    return wxPoint(x, y)
 
 
 def split_bom_designators(
@@ -91,11 +99,11 @@ def split_bom_designators(
 class Fabrication:
     """Contains all functionality to generate the JLCPCB production files."""
 
-    def __init__(self, parent, board):
+    def __init__(self, parent: Any, board: Any) -> None:
         self.parent = parent
         self.logger = logging.getLogger(__name__)
         self.board = board
-        self.corrections = []
+        self.corrections: tuple[Correction, ...] = ()
         self.path, self.filename = os.path.split(self.board.GetFileName())
         self.create_folders()
 
@@ -150,23 +158,27 @@ class Fabrication:
                 empty_pours.append(f"{zone.GetNetname() or 'no net'} on {name}")
         return empty_pours
 
-    def _find_correction(self, value):
-        """Return (rotation, offset) for the first correction matching value.
+    def _correction_for_footprint(self, footprint: Any) -> Optional[CorrectionMatch]:  # noqa: UP045
+        """Select the same reference, value, or package rule as the parts table."""
+        return match_correction(
+            self.corrections,
+            str(footprint.GetReference()),
+            str(footprint.GetValue()),
+            str(footprint.GetFPID().GetLibItemName()),
+        )
 
-        Tries anchored match (pattern + '$') before falling back to unanchored,
-        so 'SOT-23-3' beats 'SOT-23' when both patterns exist.
-        """
-        anchored = [(f"(?:{r})$", rot, off) for r, rot, off in self.corrections]
-        for regex, rotation, offset in anchored:
-            if re.search(regex, value):
-                return rotation, offset
-        for regex, rotation, offset in self.corrections:
-            if re.search(regex, value):
-                return rotation, offset
-        return None
-
-    def fix_rotation(self, footprint):
+    def fix_rotation(self, footprint: Any) -> float:
         """Fix the rotation of footprints in order to be correct for JLCPCB."""
+        return self._rotation_for_match(
+            footprint, self._correction_for_footprint(footprint)
+        )
+
+    def _rotation_for_match(
+        self,
+        footprint: Any,
+        match: Optional[CorrectionMatch],  # noqa: UP045
+    ) -> float:
+        """Apply the already selected rule, including an explicit no-match result."""
         original = footprint.GetOrientation()
         # `.AsDegrees()` added in KiCAD 6.99
         try:
@@ -178,19 +190,14 @@ class Fabrication:
         if footprint.GetLayer() != 0:
             # bottom angles need to be mirrored on Y-axis
             rotation = (180 - rotation) % 360
-        for getter in (
-            lambda: str(footprint.GetReference()),
-            lambda: str(footprint.GetValue()),
-            lambda: str(footprint.GetFPID().GetLibItemName()),
-        ):
-            match = self._find_correction(getter())
-            if match:
-                return self.rotate(footprint, rotation, match[0])
+        if match is not None:
+            return self.rotate(footprint, rotation, match.correction.rotation)
         return rotation
 
-    def rotate(self, footprint, rotation, correction):
+    def rotate(self, footprint: Any, rotation: float, correction: int) -> float:
         """Calculate the actual correction."""
-        rotation = (rotation + int(correction)) % 360
+        # Keep exact whole degrees before adding KiCad's floating point angle.
+        rotation = (rotation + correction % 360) % 360
         self.logger.info(
             "Fixed rotation of %s (%s / %s) on %s Layer by %d degrees",
             footprint.GetReference(),
@@ -201,26 +208,16 @@ class Fabrication:
         )
         return rotation
 
-    def reposition(self, footprint, position, offset):
+    def reposition(
+        self, footprint: Any, position: Any, offset: tuple[float, float]
+    ) -> Any:
         """Adjust the position of the footprint, returning the new position as a wxPoint."""
         if offset[0] != 0 or offset[1] != 0:
-            original = footprint.GetOrientation()
-            # `.AsRadians()` added in KiCAD 6.99
-            try:
-                rotation = original.AsDegrees()
-            except AttributeError:
-                # we need to divide by 10 to get 180 out of 1800 for example.
-                # This might be a bug in 5.99 / 6.0 RC
-                rotation = original / 10
-            if footprint.GetLayer() != 0:
-                # bottom angles need to be mirrored on Y-axis
-                rotation = (180 - rotation) % 360
-            offset_x = FromMM(offset[0]) * math.cos(math.radians(rotation)) + FromMM(
-                offset[1]
-            ) * math.sin(math.radians(rotation))
-            offset_y = -FromMM(offset[0]) * math.sin(math.radians(rotation)) + FromMM(
-                offset[1]
-            ) * math.cos(math.radians(rotation))
+            rotation = math.radians(self._rotation_for_match(footprint, None))
+            x, y = map(FromMM, offset)
+            cosine, sine = math.cos(rotation), math.sin(rotation)
+            offset_x = x * cosine + y * sine
+            offset_y = -x * sine + y * cosine
             if footprint.GetLayer() != 0:
                 # mirrored coordinate system needs to be taken into account on the bottom
                 offset_x = -offset_x
@@ -233,19 +230,24 @@ class Fabrication:
                 offset[0],
                 offset[1],
             )
-            return wxPoint(position.x + offset_x, position.y + offset_y)
+            return _checked_position(position.x + offset_x, position.y + offset_y)
         return position
 
-    def fix_position(self, footprint, position):
-        """Fix the position of footprints in order to be correct for JLCPCB."""
-        for getter in (
-            lambda: str(footprint.GetReference()),
-            lambda: str(footprint.GetValue()),
-            lambda: str(footprint.GetFPID().GetLibItemName()),
-        ):
-            match = self._find_correction(getter())
-            if match:
-                return self.reposition(footprint, position, match[1])
+    def fix_position(self, footprint: Any, position: Any) -> Any:
+        """Apply the offset from the same selected rule used for rotation."""
+        return self._position_for_match(
+            footprint, position, self._correction_for_footprint(footprint)
+        )
+
+    def _position_for_match(
+        self,
+        footprint: Any,
+        position: Any,
+        match: Optional[CorrectionMatch],  # noqa: UP045
+    ) -> Any:
+        """Apply the selected offset without resolving the footprint again."""
+        if match is not None:
+            return self.reposition(footprint, position, match.correction.offset)
         return position
 
     def get_position(self, footprint):
@@ -421,43 +423,66 @@ class Fabrication:
                     zipfile.write(filePath, os.path.basename(filePath))
         self.logger.info("Finished generating ZIP file %s", zip_path)
 
-    def generate_cpl(self):
-        """Generate placement file (CPL)."""
-        cpl_path = self.get_cpl_csv_path()
-        self.corrections = self.parent.library.get_all_correction_data()
-        aux_orgin = self.board.GetDesignSettings().GetAuxOrigin()
+    def generate_cpl(
+        self,
+        corrections: Optional[tuple[Correction, ...]] = None,  # noqa: UP045
+    ) -> None:
+        """Prepare every placement before opening the output file."""
+        self.write_cpl(self.prepare_cpl(corrections))
+
+    def prepare_cpl(
+        self,
+        corrections: Optional[tuple[Correction, ...]] = None,  # noqa: UP045
+    ) -> tuple[tuple[Any, ...], ...]:
+        """Capture placement rows from one complete immutable correction set.
+
+        Direct calls read current storage; a supplied preflight tuple stays fixed
+        for the operation. Unavailable or unresolved storage is rejected before
+        touching the board or opening an existing output file.
+        """
+        if corrections is None:
+            snapshot = self.parent.library.read_correction_data()
+            corrections = snapshot.corrections
+            if corrections is None:
+                raise ValueError(
+                    f"Corrections are unresolved in the active {snapshot.scope} "
+                    f"database ({snapshot.db_path}). Open Corrections Manager "
+                    "to repair or retry loading before generating fabrication files."
+                )
+        if not isinstance(corrections, tuple) or any(
+            not isinstance(correction, Correction) for correction in corrections
+        ):
+            raise TypeError("Expected an immutable tuple of Correction values")
+        self.corrections = corrections
+        aux_origin = self.board.GetDesignSettings().GetAuxOrigin()
         add_without_lcsc = self.parent.settings.get("gerber", {}).get(
             "lcsc_bom_cpl", True
         )
-        with open(cpl_path, "w", newline="", encoding="utf-8") as csvfile:
-            writer = csv.writer(csvfile, delimiter=",")
-            writer.writerow(
-                ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
-            )
-            footprints = sorted(self.board.Footprints(), key=lambda x: x.GetReference())
-            for fp in footprints:
-                if get_is_dnp(fp):
-                    self.logger.info(
-                        "Component %s has 'Do not place' enabled: removing from CPL",
-                        fp.GetReference(),
-                    )
-                    continue
-                part = self.parent.store.get_part(fp.GetReference())
-                if not part:  # No matching part in the database, continue
-                    continue
-                if part["exclude_from_pos"] == 1:
-                    continue
-                if not add_without_lcsc and not part["lcsc"]:
-                    continue
-                try:  # Kicad <= 8.0
-                    position = self.get_position(fp) - aux_orgin
-                except TypeError:  # Kicad 8.99
-                    x1, y1 = self.get_position(fp)
-                    x2, y2 = aux_orgin
-                    position = VECTOR2I(x1 - x2, y1 - y2)
-                position = self.fix_position(fp, position)
-                writer.writerow(
-                    [
+        rows = []
+        footprints = sorted(self.board.Footprints(), key=lambda x: x.GetReference())
+        for fp in footprints:
+            if get_is_dnp(fp):
+                self.logger.info(
+                    "Component %s has 'Do not place' enabled: removing from CPL",
+                    fp.GetReference(),
+                )
+                continue
+            part = self.parent.store.get_part(fp.GetReference())
+            if not part or part["exclude_from_pos"] == 1:
+                continue
+            if not add_without_lcsc and not part["lcsc"]:
+                continue
+            match = self._correction_for_footprint(fp)
+            try:
+                center = self.get_position(fp)
+                # Subtract in Python, before native coordinate arithmetic can wrap.
+                position = SimpleNamespace(
+                    x=center.x - aux_origin.x, y=center.y - aux_origin.y
+                )
+                position = self._position_for_match(fp, position, match)
+                position = _checked_position(position.x, position.y)
+                rows.append(
+                    (
                         part["reference"],
                         part["value"],
                         part["footprint"],
@@ -467,10 +492,30 @@ class Fabrication:
                         # https://docs.kicad.org/doxygen/base__units_8h.html
                         f"{ToMM(position.x):.6f}",
                         f"{ToMM(position.y) * -1:.6f}",
-                        self.fix_rotation(fp),
+                        self._rotation_for_match(fp, match),
                         "top" if fp.GetLayer() == 0 else "bottom",
-                    ]
+                    )
                 )
+            except (OverflowError, ValueError) as error:
+                source = (
+                    f"correction {match.correction.pattern!r}"
+                    if match
+                    else "no correction"
+                )
+                raise ValueError(
+                    f"Cannot generate CPL for {fp.GetReference()} ({source}): {error}"
+                ) from error
+        return tuple(rows)
+
+    def write_cpl(self, rows: tuple[tuple[Any, ...], ...]) -> None:
+        """Write prepared placements without rereading the board or corrections."""
+        cpl_path = self.get_cpl_csv_path()
+        with open(cpl_path, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile, delimiter=",")
+            writer.writerow(
+                ["Designator", "Val", "Package", "Mid X", "Mid Y", "Rotation", "Layer"]
+            )
+            writer.writerows(rows)
         self.logger.info("Finished generating CPL file %s", cpl_path)
 
     def generate_bom(self):

--- a/library.py
+++ b/library.py
@@ -1,19 +1,29 @@
 """Handle the JLCPCB parts database."""
 
+from collections.abc import Iterable, Iterator, Sequence
 import contextlib
-import csv
+from dataclasses import dataclass, replace
 from enum import Enum
+import hashlib
+import json
 import logging
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 import sqlite3
 from threading import Lock, Thread
 import time
-from typing import NamedTuple, Optional
+from typing import Any, NamedTuple, Optional, Union
 
 import requests  # pylint: disable=import-error
 import wx  # pylint: disable=import-error
 
+from .correction_data import (
+    Correction,
+    CorrectionDataError,
+    CorrectionIssue,
+    parse_corrections_csv,
+    validate_correction,
+)
 from .dblib import DEFAULT_LIBRARY, LIBRARY_CONFIGS
 from .events import (
     DownloadCompletedEvent,
@@ -25,6 +35,19 @@ from .helpers import PLUGIN_PATH, dict_factory, natural_sort_collation
 from .partselector_columns import DB_FIELDS, SORTABLE_COLUMN_INDEX_TO_DB
 from .search_escape import escape_fts_phrase, escape_like_term
 from .unzip_parts import unzip_parts
+
+DatabasePath = Union[str, os.PathLike[str]]
+_INITIAL_DEFAULTS_KEY = "remote:initial-defaults:v1"
+_INITIAL_DOWNLOAD_LOCK = Lock()
+_INITIAL_DOWNLOAD_TARGETS: set[str] = set()
+
+
+def _sqlite_file_uri(path: PurePath) -> str:
+    """Keep UNC hosts in SQLite's path while retaining pathlib's escaping."""
+    uri = path.as_uri()
+    if uri.startswith("file://") and not uri.startswith("file:///"):
+        return "file:////" + uri[len("file://") :]
+    return uri
 
 
 class PartsDatabaseInfo(NamedTuple):
@@ -43,10 +66,66 @@ class LibraryState(Enum):
     DOWNLOAD_RUNNING = 2
 
 
+@dataclass(frozen=True)
+class StoredCorrection:
+    """Preserve a stored row and its validation errors for precise repair."""
+
+    rowid: int
+    pattern: object
+    rotation: object
+    offset: tuple[object, object]
+    issues: tuple[CorrectionIssue, ...]
+    correction: Optional[Correction] = None  # noqa: UP045
+
+    @property
+    def identity(self) -> tuple[tuple[type, object], ...]:
+        """Identify the exact raw record, distinguishing SQLite storage types."""
+        return tuple(
+            (type(value), value)
+            for value in (self.rowid, self.pattern, self.rotation, *self.offset)
+        )
+
+
+class CorrectionState(Enum):
+    """Whether a complete correction set is ready, repairable, or unavailable."""
+
+    READY = "ready"
+    NEEDS_REPAIR = "needs_repair"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class CorrectionSnapshot:
+    """An immutable read of one explicitly identified correction database."""
+
+    db_path: str
+    scope: str
+    rows: tuple[StoredCorrection, ...]
+    corrections: Optional[tuple[Correction, ...]]  # noqa: UP045
+    issues: tuple[CorrectionIssue, ...]
+    csv_migrations: tuple[tuple[str, str], ...] = ()
+    state: CorrectionState = CorrectionState.READY
+    warnings: tuple[CorrectionIssue, ...] = ()
+
+
+@dataclass(frozen=True)
+class CorrectionBatchResult:
+    """Describe a committed operation, including input records intentionally skipped."""
+
+    inserted: int = 0
+    updated: int = 0
+    skipped: int = 0
+
+    @property
+    def changed(self) -> int:
+        """Report how many stored records were inserted or updated."""
+        return self.inserted + self.updated
+
+
 class Library:
     """A storage class to get data from a sqlite database and write it back."""
 
-    def __init__(self, parent):
+    def __init__(self, parent: Any) -> None:
         self.logger = logging.getLogger(__name__)
         self.parent = parent
         self.order_by = "LCSC Part"
@@ -62,6 +141,8 @@ class Library:
         self.state = None
         self.download_lock = Lock()
         self.category_map = {}
+        self._migration_session_diagnostics = {}
+        self._known_legacy_sources = {}
 
         self.refresh_library_config()
 
@@ -122,7 +203,7 @@ class Library:
         else:
             self.logger.info("Data directory '%s' exists, not creating", self.datadir)
 
-    def check_library(self):
+    def check_library(self) -> None:
         """Check if the database files exists, if not trigger update / create database."""
         if (
             not os.path.isfile(self.partsdb_file)
@@ -131,20 +212,32 @@ class Library:
             self.state = LibraryState.UPDATE_NEEDED
         else:
             self.state = LibraryState.INITIALIZED
-        corrections_file_missing = not os.path.isfile(self.correctionsdb_file)
-        if corrections_file_missing or os.path.getsize(self.correctionsdb_file) == 0:
-            self.create_correction_table()
-            self.migrate_corrections()
+        try:
             if (
-                corrections_file_missing
-                and self.correctionsdb_file == self.globalcorrectionsdb_file
+                not os.path.isfile(self.correctionsdb_file)
+                or os.path.getsize(self.correctionsdb_file) == 0
             ):
-                db_path = self.globalcorrectionsdb_file
-                Thread(
-                    target=self.fetch_remote_corrections,
-                    args=(db_path,),
-                    daemon=True,
-                ).start()
+                with self._correction_transaction(
+                    self.correctionsdb_file, create=True
+                ) as con:
+                    if (
+                        self.correctionsdb_file == self.globalcorrectionsdb_file
+                        and _INITIAL_DEFAULTS_KEY
+                        not in self._correction_metadata(con)[0]
+                    ):
+                        con.execute(
+                            "INSERT OR IGNORE INTO correction_migration_state VALUES (?, ?, ?, ?)",
+                            (
+                                _INITIAL_DEFAULTS_KEY,
+                                self.globalcorrectionsdb_file,
+                                "seed-pending",
+                                json.dumps(self._legacy_correction_sources()),
+                            ),
+                        )
+            self.retry_correction_migrations()
+        except (CorrectionDataError, OSError) as error:
+            # Recovery reads report these errors while keeping the manager usable.
+            self.logger.warning("Correction storage is unavailable: %s", error)
         if (
             not os.path.isfile(self.mappingsdb_file)
             or os.path.getsize(self.mappingsdb_file) == 0
@@ -153,58 +246,82 @@ class Library:
             self.migrate_mappings()
 
     def uses_global_correction_database(self):
-        """Check if there is a board specific corrections database or not.
-
-        Returns True if the global database is used.
-        """
-
-        try:
-            with (
-                contextlib.closing(
-                    sqlite3.connect(self.localcorrectionsdb_file)
-                ) as ldb,
-                ldb as lcur,
-            ):
-                result = lcur.execute(
-                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='correction')"
-                ).fetchone()
-                if not result:
-                    return True
-
-                return result[0] != 1
-        except sqlite3.OperationalError:
+        """Check for a project correction table without creating a project database."""
+        if not Path(self.localcorrectionsdb_file).exists():
             return True
+        try:
+            with contextlib.closing(
+                self._read_database(self.localcorrectionsdb_file)
+            ) as con:
+                return not con.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='correction'"
+                ).fetchone()
+        except (sqlite3.Error, OSError):
+            # Expose an unreadable project database for repair rather than
+            # silently changing which correction set a board uses.
+            return False
 
-        return True
+    def _validate_local_destination(self) -> None:
+        """Validate an existing correction table while allowing unrelated project data."""
+        target = self.localcorrectionsdb_file
+        if not Path(target).exists():
+            return
+        try:
+            with contextlib.closing(self._read_database(target)) as con:
+                exists = con.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='correction'"
+                ).fetchone()
+            if exists:
+                snapshot = self.read_correction_data(target)
+                if snapshot.corrections is None:
+                    raise CorrectionDataError(snapshot.issues)
+        except (sqlite3.Error, OSError) as error:
+            raise self._storage_error(target, error) from error
 
-    def switch_to_global_correction_database(self, use_global):
-        """Switches to global or board local database."""
-
+    def switch_to_global_correction_database(self, use_global: bool) -> None:
+        """Switch only after validation and a complete successful storage transaction."""
         currently_using_global = (
             self.correctionsdb_file == self.globalcorrectionsdb_file
         )
         if currently_using_global == use_global:
             return
-
         if use_global:
-            try:
-                with (
-                    contextlib.closing(
-                        sqlite3.connect(self.localcorrectionsdb_file)
-                    ) as con,
-                    con as cur,
-                ):
-                    cur.execute("DROP TABLE IF EXISTS correction")
-                    cur.commit()
-                self.correctionsdb_file = self.globalcorrectionsdb_file
-            except OSError:
-                self.logger.warning("Failed to remove board local corrections file.")
+            if (
+                not Path(self.globalcorrectionsdb_file).exists()
+                or Path(self.globalcorrectionsdb_file).stat().st_size == 0
+            ):
+                self.create_correction_table(self.globalcorrectionsdb_file)
+            migration_issues = self.migrate_corrections()
+            if migration_issues:
+                raise CorrectionDataError(migration_issues)
+            destination = self.read_correction_data(self.globalcorrectionsdb_file)
+            if destination.corrections is None:
+                raise CorrectionDataError(destination.issues)
+            with self._correction_transaction(self.localcorrectionsdb_file) as con:
+                con.execute("DROP TABLE correction")
+                # Keep automatic CSV provenance when leaving local scope, so
+                # an unarchived source cannot replay into the global database.
+            self.correctionsdb_file = self.globalcorrectionsdb_file
+            self._start_initial_remote_corrections(self.globalcorrectionsdb_file)
         else:
-            global_corrections = self.get_all_correction_data()
+            source_snapshot = self.read_correction_data()
+            source = source_snapshot.corrections
+            if source is None:
+                raise CorrectionDataError(source_snapshot.issues)
+            self._validate_local_destination()
+            with self._correction_transaction(
+                self.localcorrectionsdb_file, create=True
+            ) as con:
+                con.execute("DELETE FROM correction")
+                con.executemany(
+                    "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
+                    [correction.db_row() for correction in source],
+                )
+                con.executemany(
+                    "INSERT OR IGNORE INTO correction_migrations VALUES (?, ?)",
+                    source_snapshot.csv_migrations,
+                )
             self.correctionsdb_file = self.localcorrectionsdb_file
-            self.create_correction_table()
-            for regex, rotation, offset in global_corrections:
-                self.insert_correction_data(regex, rotation, offset)
 
     def set_order_by(self, n):
         """Set which value we want to order by when getting data from the database."""
@@ -344,75 +461,577 @@ class Library:
             )
             cur.commit()
 
-    def create_correction_table(self):
-        """Create the correction table."""
-        self.logger.debug("Create SQLite table for corrections")
-        with (
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as con,
-            con as cur,
-        ):
-            cur.execute(
-                "CREATE TABLE IF NOT EXISTS correction ('regex', 'rotation', 'offset_x', 'offset_y')"
-            )
-            cur.commit()
+    @staticmethod
+    def _correction_schema(con: sqlite3.Connection) -> None:
+        """Create additive correction tables inside the caller's transaction."""
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS correction ('regex', 'rotation', 'offset_x', 'offset_y')"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS correction_migrations "
+            "(migration_key TEXT PRIMARY KEY, source TEXT NOT NULL)"
+        )
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS correction_migration_state "
+            "(migration_key TEXT PRIMARY KEY, source TEXT NOT NULL, "
+            "status TEXT NOT NULL, message TEXT NOT NULL)"
+        )
 
-    def get_correction_data(self, regex, db_path=None):
-        """Get the correction data by its regex."""
+    @staticmethod
+    def _sqlite_affinity(declaration: str) -> str:
+        """Determine column affinity using SQLite's ordered declaration rules."""
+        declared_type = declaration.upper()
+        if "INT" in declared_type:
+            return "INTEGER"
+        if any(name in declared_type for name in ("CHAR", "CLOB", "TEXT")):
+            return "TEXT"
+        if not declared_type or "BLOB" in declared_type:
+            return "BLOB"
+        if any(name in declared_type for name in ("REAL", "FLOA", "DOUB")):
+            return "REAL"
+        return "NUMERIC"
+
+    @classmethod
+    def _validate_correction_schema(cls, con: sqlite3.Connection) -> None:
+        """Require named correction fields and unambiguous physical row identities."""
+        table = con.execute(
+            "SELECT type FROM sqlite_master WHERE name='correction'"
+        ).fetchone()
+        if table is None or table[0] != "table":
+            raise sqlite3.DatabaseError("correction storage must be an ordinary table")
+        columns = con.execute("PRAGMA table_xinfo(correction)").fetchall()
+        expected = {"regex", "rotation", "offset_x", "offset_y"}
+        if (
+            len(columns) != len(expected)
+            or {column[1].casefold() for column in columns} != expected
+            or any(column[6] for column in columns)
+        ):
+            raise sqlite3.DatabaseError(
+                "correction table must contain exactly regex, rotation, offset_x, "
+                "and offset_y; unsupported schemas cannot be repaired automatically"
+            )
+        affinities = {
+            column[1].casefold(): cls._sqlite_affinity(column[2]) for column in columns
+        }
+        if affinities["regex"] not in {"TEXT", "BLOB"}:
+            raise sqlite3.DatabaseError(
+                "unsupported correction schema: regex must have TEXT or BLOB affinity "
+                "to preserve pattern text; use a supported correction database schema"
+            )
+        if affinities["rotation"] == "REAL":
+            raise sqlite3.DatabaseError(
+                "unsupported correction schema: rotation must not have REAL affinity "
+                "because it can round whole degrees; use a supported correction database schema"
+            )
+        if any(affinities[name] == "TEXT" for name in ("offset_x", "offset_y")):
+            raise sqlite3.DatabaseError(
+                "unsupported correction schema: offsets must not have TEXT affinity "
+                "because it can round their numeric values; use a supported correction database schema"
+            )
+        # The exact-column check rules out aliases that shadow SQLite's rowid.
+        # This query also rejects WITHOUT ROWID tables before exposing repair IDs.
+        try:
+            con.execute("SELECT rowid FROM correction LIMIT 0")
+        except sqlite3.Error as error:
+            raise sqlite3.DatabaseError(
+                "correction table requires SQLite row identities for safe repair"
+            ) from error
+
+    @staticmethod
+    def _read_database(target: DatabasePath) -> sqlite3.Connection:
+        """Open an existing database without creating missing files."""
+        return sqlite3.connect(
+            _sqlite_file_uri(Path(target).resolve()) + "?mode=ro", uri=True
+        )
+
+    @staticmethod
+    def _storage_error(
+        target: DatabasePath, error: Exception, field: str = "database"
+    ) -> CorrectionDataError:
+        """Wrap storage failures in actionable correction diagnostics."""
+        return CorrectionDataError(
+            (CorrectionIssue(field, None, str(error), source=str(target)),)
+        )
+
+    @contextlib.contextmanager
+    def _correction_transaction(
+        self, target: DatabasePath, *, create: bool = False
+    ) -> Iterator[sqlite3.Connection]:
+        """Capture one target and roll back the entire operation on any failure."""
+        try:
+            if create:
+                Path(target).parent.mkdir(parents=True, exist_ok=True)
+            elif not Path(target).is_file():
+                raise OSError("correction database does not exist")
+            connection = (
+                sqlite3.connect(target)
+                if create
+                else sqlite3.connect(
+                    _sqlite_file_uri(Path(target).resolve()) + "?mode=rw", uri=True
+                )
+            )
+            with contextlib.closing(connection) as con, con:
+                con.execute("BEGIN IMMEDIATE")
+                if create:
+                    self._correction_schema(con)
+                self._validate_correction_schema(con)
+                yield con
+        except (sqlite3.Error, OSError) as error:
+            raise self._storage_error(target, error) from error
+
+    def create_correction_table(
+        self,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> None:
+        """Initialize correction storage without rewriting existing user records."""
         target = db_path if db_path is not None else self.correctionsdb_file
-        with (
-            contextlib.closing(sqlite3.connect(target)) as con,
-            con as cur,
-        ):
-            return cur.execute(
-                f"SELECT * FROM correction WHERE regex = '{regex}'"
-            ).fetchone()
+        with self._correction_transaction(target, create=True):
+            pass
 
-    def delete_correction_data(self, regex):
-        """Delete a correction from the database."""
-        with (
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as con,
-            con as cur,
-        ):
-            cur.execute(f"DELETE FROM correction WHERE regex = '{regex}'")
-            cur.commit()
+    @staticmethod
+    def correction_csv_migration_key(
+        path: DatabasePath, contents: Union[bytes, str]
+    ) -> str:
+        """Identify an automatic CSV import by canonical path and exact contents."""
+        if isinstance(contents, str):
+            contents = contents.encode("utf-8")
+        digest = hashlib.sha256(contents).hexdigest()
+        return f"csv:{Path(path).resolve()}:{digest}"
 
-    def update_correction_data(self, regex, rotation, offset):
-        """Update a correction in the database."""
-        with (
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as con,
-            con as cur,
-        ):
-            cur.execute(
-                f"UPDATE correction SET rotation = '{rotation}', offset_x = '{offset[0]}', offset_y = '{offset[1]}' WHERE regex = '{regex}'"
-            )
-            cur.commit()
+    @staticmethod
+    def _correction_metadata(
+        con: sqlite3.Connection,
+    ) -> tuple[dict[object, str], list[tuple[object, str, str, str]]]:
+        """Read optional metadata once, including databases from earlier releases."""
+        tables = {
+            row[0]
+            for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        completed = (
+            dict(con.execute("SELECT migration_key, source FROM correction_migrations"))
+            if "correction_migrations" in tables
+            else {}
+        )
+        states = (
+            con.execute(
+                "SELECT migration_key, source, status, message FROM correction_migration_state ORDER BY rowid"
+            ).fetchall()
+            if "correction_migration_state" in tables
+            else []
+        )
+        return completed, states
 
-    def insert_correction_data(self, regex, rotation, offset, db_path=None):
-        """Insert a correction into the database."""
+    @staticmethod
+    def _complete_correction_migration(
+        con: sqlite3.Connection, key: str, source: str
+    ) -> None:
+        """Commit completion and remove superseded pending state in the caller's transaction."""
+        con.execute("INSERT INTO correction_migrations VALUES (?, ?)", (key, source))
+        con.execute(
+            "DELETE FROM correction_migration_state WHERE migration_key=?", (key,)
+        )
+
+    def has_correction_migration(
+        self,
+        key: str,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> bool:
+        """Check completion, including the current project's archived CSV provenance."""
         target = db_path if db_path is not None else self.correctionsdb_file
-        with (
-            contextlib.closing(sqlite3.connect(target)) as con,
-            con as cur,
-        ):
-            cur.execute(
-                "INSERT INTO correction VALUES (?, ?, ?, ?)",
-                (regex, rotation, offset[0], offset[1]),
+        candidates = [target]
+        if key.startswith("csv:"):
+            candidates.extend(
+                path
+                for path in (
+                    self.localcorrectionsdb_file,
+                    self.globalcorrectionsdb_file,
+                )
+                if Path(path).resolve() != Path(target).resolve()
+                and Path(path).exists()
             )
-            cur.commit()
+        try:
+            for candidate in candidates:
+                with contextlib.closing(self._read_database(candidate)) as con:
+                    if key in self._correction_metadata(con)[0]:
+                        return True
+            return False
+        except (sqlite3.Error, OSError) as error:
+            raise self._storage_error(candidate, error, "migration") from error
 
-    def get_all_correction_data(self):
-        """Get all corrections from the database."""
-        with (
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as con,
-            con as cur,
-        ):
+    def _validated_corrections(
+        self, records: Iterable[object], target: DatabasePath
+    ) -> list[Correction]:
+        """Parse raw records once; retain already validated immutable corrections."""
+        validated = []
+        issues = []
+        for record in records:
             try:
-                result = cur.execute(
-                    "SELECT * FROM correction ORDER BY regex ASC"
+                if isinstance(record, Correction):
+                    validated.append(record)
+                    continue
+                if not isinstance(record, (tuple, list)) or len(record) != 3:
+                    raise CorrectionDataError(
+                        (
+                            CorrectionIssue(
+                                "record",
+                                record,
+                                "expected pattern, rotation, and offsets",
+                                str(target),
+                            ),
+                        )
+                    )
+                validated.append(validate_correction(*record, source=str(target)))
+            except CorrectionDataError as error:
+                issues.extend(error.issues)
+        if issues:
+            raise CorrectionDataError(issues)
+        return validated
+
+    def apply_corrections(
+        self,
+        records: Iterable[object],
+        *,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+        overwrite: bool = True,
+        migration_key: Optional[str] = None,  # noqa: UP045
+    ) -> CorrectionBatchResult:
+        """Validate a complete batch, then commit its writes and marker atomically."""
+        target = db_path if db_path is not None else self.correctionsdb_file
+        validated = self._validated_corrections(records, target)
+        if migration_key and self.has_correction_migration(migration_key, target):
+            return CorrectionBatchResult(skipped=len(validated))
+        selected = {}
+        for correction in validated:
+            if overwrite or correction.pattern not in selected:
+                selected[correction.pattern] = correction
+        inserted = updated = 0
+        skipped = len(validated) - len(selected)
+        with self._correction_transaction(target) as con:
+            if (
+                migration_key
+                and migration_key != _INITIAL_DEFAULTS_KEY
+                and migration_key in self._correction_metadata(con)[0]
+            ):
+                return CorrectionBatchResult(skipped=len(validated))
+            if (
+                migration_key == _INITIAL_DEFAULTS_KEY
+                and not self._initial_seed_is_eligible(con, str(target))
+            ):
+                # A concurrent retry discovered a higher-priority source while
+                # the HTTP request was in flight. Leave initial seeding pending.
+                return CorrectionBatchResult(skipped=len(validated))
+            for correction in selected.values():
+                exists = con.execute(
+                    "SELECT 1 FROM correction WHERE regex = ?", (correction.pattern,)
+                ).fetchone()
+                if exists and not overwrite:
+                    skipped += 1
+                elif exists:
+                    result = con.execute(
+                        "UPDATE correction SET rotation=?, offset_x=?, offset_y=? WHERE regex=?",
+                        (*correction.db_row()[1:], correction.pattern),
+                    )
+                    updated += result.rowcount
+                else:
+                    con.execute(
+                        "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
+                        correction.db_row(),
+                    )
+                    inserted += 1
+            if migration_key:
+                self._correction_schema(con)
+                self._complete_correction_migration(con, migration_key, migration_key)
+        return CorrectionBatchResult(inserted, updated, skipped)
+
+    def get_correction_data(
+        self,
+        regex: str,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> Optional[tuple[object, object, object, object]]:  # noqa: UP045
+        """Get original stored values for a pattern using a parameterized lookup."""
+        target = db_path if db_path is not None else self.correctionsdb_file
+        try:
+            with contextlib.closing(self._read_database(target)) as con:
+                self._validate_correction_schema(con)
+                return con.execute(
+                    "SELECT regex, rotation, offset_x, offset_y FROM correction WHERE regex = ?",
+                    (regex,),
+                ).fetchone()
+        except (sqlite3.Error, OSError) as error:
+            raise self._storage_error(target, error) from error
+
+    def delete_correction_data(self, regex: str) -> None:
+        """Delete a pattern without interpreting its contents as SQL."""
+        target = self.correctionsdb_file
+        with self._correction_transaction(target) as con:
+            con.execute("DELETE FROM correction WHERE regex = ?", (regex,))
+
+    def _check_expected_corrections(
+        self,
+        actual: Sequence[tuple[object, ...]],
+        expected: Optional[Sequence[StoredCorrection]],  # noqa: UP045
+        target: DatabasePath,
+    ) -> None:
+        """Check existence or exact raw identities under the write lock."""
+        if expected is None:
+            if actual:
+                return
+        elif [tuple((type(value), value) for value in row) for row in actual] == [
+            row.identity for row in sorted(expected, key=lambda row: row.rowid)
+        ]:
+            return
+        raise self._storage_error(
+            target,
+            ValueError("stored correction changed; refresh and select it again"),
+            "row",
+        )
+
+    def delete_correction_row(
+        self,
+        rowid: int,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+        *,
+        expected_record: Optional[StoredCorrection] = None,  # noqa: UP045
+    ) -> None:
+        """Delete the selected original row, rejecting a concurrent edit or reused ID."""
+        target = db_path if db_path is not None else self.correctionsdb_file
+        with self._correction_transaction(target) as con:
+            if expected_record is not None:
+                self._check_expected_corrections(
+                    con.execute(
+                        "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction WHERE rowid=?",
+                        (rowid,),
+                    ).fetchall(),
+                    (expected_record,),
+                    target,
+                )
+            con.execute("DELETE FROM correction WHERE rowid = ?", (rowid,))
+
+    def update_correction_data(
+        self, regex: object, rotation: object, offset: object
+    ) -> None:
+        """Validate and update an existing pattern in one transaction."""
+        target = self.correctionsdb_file
+        correction = validate_correction(regex, rotation, offset, source=str(target))
+        with self._correction_transaction(target) as con:
+            con.execute(
+                "UPDATE correction SET rotation=?, offset_x=?, offset_y=? WHERE regex=?",
+                (*correction.db_row()[1:], correction.pattern),
+            )
+
+    def insert_correction_data(
+        self,
+        regex: object,
+        rotation: object,
+        offset: object,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> int:
+        """Validate and insert a correction, refusing accidental duplicate patterns."""
+        return self.save_correction_data(regex, rotation, offset, db_path=db_path)
+
+    def save_correction_data(
+        self,
+        pattern: object,
+        rotation: object = None,
+        offset: object = None,
+        *,
+        rowid: Optional[int] = None,  # noqa: UP045
+        replace: bool = False,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+        expected_record: Optional[StoredCorrection] = None,  # noqa: UP045
+        expected_conflicts: Optional[Sequence[StoredCorrection]] = None,  # noqa: UP045
+    ) -> int:
+        """Save or repair one row, with optional collision replacement in the same transaction."""
+        target = db_path if db_path is not None else self.correctionsdb_file
+        correction = (
+            pattern
+            if isinstance(pattern, Correction)
+            else validate_correction(
+                pattern, rotation, offset, source=str(target), rowid=rowid
+            )
+        )
+        with self._correction_transaction(target) as con:
+            if rowid is not None or expected_record is not None:
+                self._check_expected_corrections(
+                    con.execute(
+                        "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction WHERE rowid=?",
+                        (rowid,),
+                    ).fetchall(),
+                    (expected_record,) if expected_record is not None else None,
+                    target,
+                )
+            conflicts = con.execute(
+                "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction "
+                "WHERE regex=? AND (? IS NULL OR rowid != ?) ORDER BY rowid",
+                (correction.pattern, rowid, rowid),
+            ).fetchall()
+            if expected_conflicts is not None:
+                self._check_expected_corrections(conflicts, expected_conflicts, target)
+            if conflicts and not replace:
+                raise CorrectionDataError(
+                    (
+                        CorrectionIssue(
+                            "pattern",
+                            correction.pattern,
+                            "another correction already uses this pattern",
+                            str(target),
+                            pattern=correction.pattern,
+                            rowid=rowid,
+                        ),
+                    )
+                )
+            if conflicts:
+                con.executemany(
+                    "DELETE FROM correction WHERE rowid=?",
+                    [(row[0],) for row in conflicts],
+                )
+            if rowid is None:
+                return con.execute(
+                    "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, ?, ?)",
+                    correction.db_row(),
+                ).lastrowid
+            con.execute(
+                "UPDATE correction SET regex=?, rotation=?, offset_x=?, offset_y=? WHERE rowid=?",
+                (*correction.db_row(), rowid),
+            )
+        return rowid
+
+    def read_correction_data(
+        self,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> CorrectionSnapshot:
+        """Read recoverable original rows and a validated snapshot without creating storage."""
+        target = str(db_path if db_path is not None else self.correctionsdb_file)
+        scope = (
+            "global"
+            if Path(target).resolve() == Path(self.globalcorrectionsdb_file).resolve()
+            else "local"
+        )
+        rows = []
+        issues = []
+        corrections = {}
+        csv_migrations = ()
+        raw_rows = []
+        unavailable = False
+        warnings = []
+        try:
+            with contextlib.closing(self._read_database(target)) as con:
+                con.execute("BEGIN")
+                self._validate_correction_schema(con)
+                raw_rows = con.execute(
+                    "SELECT rowid, regex, rotation, offset_x, offset_y FROM correction ORDER BY regex ASC, rowid ASC"
                 ).fetchall()
-                return [(c[0], int(c[1]), (float(c[2]), float(c[3]))) for c in result]
-            except sqlite3.OperationalError:
-                return []
+                completed, states = self._correction_metadata(con)
+                csv_migrations = tuple(
+                    (key, source)
+                    for key, source in completed.items()
+                    if isinstance(key, str) and key.startswith("csv:")
+                )
+                if scope == "global":
+                    for _, source, status, message in states:
+                        if status in {"pending", "deferred"}:
+                            (issues if status == "pending" else warnings).append(
+                                CorrectionIssue(
+                                    "migration", None, message, source=source
+                                )
+                            )
+                unavailable = bool(issues)
+        except (sqlite3.Error, OSError) as error:
+            issues.extend(self._storage_error(target, error).issues)
+            unavailable = True
+        session_issues, session_warnings = self._migration_session_diagnostics.get(
+            str(Path(target).resolve()), ((), ())
+        )
+        issues.extend(session_issues)
+        warnings.extend(session_warnings)
+        unavailable = unavailable or bool(session_issues)
+        for rowid, pattern, rotation, offset_x, offset_y in raw_rows:
+            correction = None
+            row_issues = ()
+            try:
+                correction = validate_correction(
+                    pattern,
+                    rotation,
+                    (offset_x, offset_y),
+                    source=target,
+                    rowid=rowid,
+                )
+            except CorrectionDataError as error:
+                row_issues = error.issues
+                issues.extend(row_issues)
+            rows.append(
+                StoredCorrection(
+                    rowid,
+                    pattern,
+                    rotation,
+                    (offset_x, offset_y),
+                    row_issues,
+                    correction,
+                )
+            )
+            if correction is not None:
+                corrections.setdefault(pattern, correction)
+        rows, conflicts = self._mark_conflicting_corrections(rows, target)
+        issues.extend(conflicts)
+        state = (
+            CorrectionState.UNAVAILABLE
+            if unavailable
+            else CorrectionState.NEEDS_REPAIR
+            if issues
+            else CorrectionState.READY
+        )
+        return CorrectionSnapshot(
+            target,
+            scope,
+            tuple(rows),
+            None if issues else tuple(corrections.values()),
+            tuple(issues),
+            csv_migrations,
+            state,
+            tuple(warnings),
+        )
+
+    @staticmethod
+    def _mark_conflicting_corrections(
+        rows: Sequence[StoredCorrection], target: str
+    ) -> tuple[list[StoredCorrection], list[CorrectionIssue]]:
+        """Identify every member of a conflicting pattern group for explicit repair."""
+        groups = {}
+        for row in rows:
+            if isinstance(row.pattern, str):
+                groups.setdefault(row.pattern, []).append(row)
+        conflicting = {
+            pattern
+            for pattern, group in groups.items()
+            if len(group) > 1
+            and (
+                any(row.correction is None for row in group)
+                or len({row.correction for row in group}) > 1
+            )
+        }
+        issues = []
+        result = []
+        for row in rows:
+            if row.pattern in conflicting:
+                issue = CorrectionIssue(
+                    "pattern",
+                    row.pattern,
+                    "conflicting stored corrections use this pattern; repair or delete the duplicate rows",
+                    target,
+                    pattern=row.pattern,
+                    rowid=row.rowid,
+                )
+                issues.append(issue)
+                row = replace(row, issues=(*row.issues, issue))
+            result.append(row)
+        return result, issues
+
+    def get_all_correction_data(
+        self,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> Optional[tuple[Correction, ...]]:  # noqa: UP045
+        """Return a complete typed set, or None when storage is not ready."""
+        return self.read_correction_data(db_path).corrections
 
     def create_mapping_table(self):
         """Create the mapping table."""
@@ -767,90 +1386,430 @@ class Library:
         """Get the subcategories associated with the given category."""
         return self.category_map[category]
 
-    def migrate_corrections_from_rotation(self):
-        """Migrate existing rotations from rotation db to correction db."""
-        if not os.path.exists(self.rotationsdb_file):
-            return
-        with (
-            contextlib.closing(sqlite3.connect(self.rotationsdb_file)) as rdb,
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as cdb,
-            rdb as rcur,
-            cdb as ccur,
-        ):
-            try:
-                result = rcur.execute(
-                    "SELECT * FROM rotation ORDER BY regex ASC"
-                ).fetchall()
-                if not result:
-                    return
-                for r in result:
-                    ccur.execute(
-                        "INSERT INTO correction VALUES (?, ?, 0, 0)",
-                        (r[0], r[1]),
-                    )
-                    ccur.commit()
-                self.logger.debug(
-                    "Migrated %d rotations to corrections database.", len(result)
+    def _legacy_correction_sources(self) -> tuple[str, str]:
+        """Associate global legacy archives with stable completion identities."""
+        return self.rotationsdb_file, self.partsdb_file
+
+    @staticmethod
+    def _legacy_migration_key(source: str) -> str:
+        """Keep completed legacy archives from replaying over repaired records."""
+        return f"rotation:{Path(source).resolve()}:rotation"
+
+    def _legacy_rotation_rows(
+        self, source: str
+    ) -> Optional[list[tuple[object, object]]]:  # noqa: UP045
+        """Read a legacy archive without creating or removing source storage."""
+        if not Path(source).exists():
+            return None
+        with contextlib.closing(self._read_database(source)) as con:
+            table = con.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='rotation'"
+            ).fetchone()
+            if not table:
+                return None
+            # Legacy releases named the second column differently; preserve its
+            # original value by position while requiring the original two fields.
+            cursor = con.execute("SELECT * FROM rotation")
+            if len(cursor.description) != 2:
+                raise sqlite3.DatabaseError(
+                    "legacy rotation table must have exactly two columns"
                 )
-                os.remove(self.rotationsdb_file)
-                self.logger.debug("Deleted rotations database.")
-            except sqlite3.OperationalError:
-                return
-            except OSError:
-                return
+            return cursor.fetchall()
 
-    def migrate_corrections_from_parts(self):
-        """Migrate existing rotations from parts db to correction db."""
-        with (
-            contextlib.closing(sqlite3.connect(self.partsdb_file)) as pdb,
-            contextlib.closing(sqlite3.connect(self.correctionsdb_file)) as rdb,
-            pdb as pcur,
-            rdb as rcur,
-        ):
-            try:
-                result = pcur.execute(
-                    "SELECT * FROM rotation ORDER BY regex ASC"
-                ).fetchall()
-                if not result:
-                    return
-                for r in result:
-                    rcur.execute(
-                        "INSERT INTO correction VALUES (?, ?, 0, 0)",
-                        (r[0], r[1]),
-                    )
-                    rcur.commit()
-                self.logger.debug(
-                    "Migrated %d rotations to separate database.", len(result)
+    def _migrate_correction_sources(
+        self, sources: Iterable[str]
+    ) -> CorrectionBatchResult:
+        """Inspect once, retain unresolved work, and atomically copy eligible archives."""
+        target = self.globalcorrectionsdb_file
+        if not Path(target).exists() or Path(target).stat().st_size == 0:
+            self.create_correction_table(target)
+        try:
+            with contextlib.closing(self._read_database(target)) as con:
+                con.execute("BEGIN")
+                self._validate_correction_schema(con)
+                completed, metadata = self._correction_metadata(con)
+                states = {key: status for key, _, status, _ in metadata}
+                candidates = {}
+                for source in sources:
+                    key = self._legacy_migration_key(source)
+                    if key not in completed and states.get(key) != "empty":
+                        candidates.setdefault(key, source)
+        except (sqlite3.Error, OSError) as error:
+            raise self._storage_error(target, error, "migration") from error
+        if not candidates:
+            return CorrectionBatchResult()
+
+        identity = str(Path(target).resolve())
+        known_sources = self._known_legacy_sources.setdefault(identity, set())
+        outcomes = []
+        pending = []
+        deferred_by = None
+        for key, source in candidates.items():
+            known = states.get(key) == "pending" or key in known_sources
+            status = "pending" if known else "deferred"
+            if deferred_by is not None:
+                message = f"legacy transfer is waiting for higher-priority archive {deferred_by}; restore that archive and reopen Corrections Manager to retry"
+            else:
+                try:
+                    rows = self._legacy_rotation_rows(source)
+                    if rows is None or not rows:
+                        if known:
+                            message = "previously identified legacy corrections are no longer present; restore the source archive and reopen Corrections Manager to retry"
+                        else:
+                            outcomes.append((key, source, "empty", ""))
+                            continue
+                    else:
+                        known_sources.add(key)
+                        outcomes.append(
+                            (
+                                key,
+                                source,
+                                "pending",
+                                "legacy corrections have not been transferred; reopen Corrections Manager to retry before generating fabrication files",
+                            )
+                        )
+                        pending.append((source, key, rows))
+                        continue
+                except (sqlite3.Error, OSError) as error:
+                    message = f"cannot read legacy corrections: {error}; restore the source archive and reopen Corrections Manager to retry"
+            outcomes.append((key, source, status, message))
+            deferred_by = deferred_by or source
+
+        # Positive knowledge must survive a later transfer rollback or process
+        # interruption. Completion, in contrast, commits together with the rows.
+        try:
+            with self._correction_transaction(target, create=True) as con:
+                completed, metadata = self._correction_metadata(con)
+                current_states = {key: status for key, _, status, _ in metadata}
+                for outcome in outcomes:
+                    if outcome[0] in completed:
+                        continue
+                    current = current_states.get(outcome[0])
+                    if current == "pending" and outcome[2] != "pending":
+                        outcome = (
+                            outcome[0],
+                            outcome[1],
+                            "pending",
+                            outcome[3]
+                            or "previously identified legacy corrections still require transfer; restore the archive and retry",
+                        )
+                    if outcome[2] == "empty":
+                        self._complete_correction_migration(con, *outcome[:2])
+                    else:
+                        con.execute(
+                            "INSERT OR REPLACE INTO correction_migration_state VALUES (?, ?, ?, ?)",
+                            outcome,
+                        )
+        except CorrectionDataError as error:
+            if any(outcome[2] == "pending" for outcome in outcomes):
+                raise
+            # Failure to record absence or an unclassified archive is not
+            # evidence that valid active corrections are incomplete.
+            warnings = tuple(
+                CorrectionIssue("migration", None, message, source=source)
+                for _, source, status, message in outcomes
+                if status == "deferred"
+            )
+            self._migration_session_diagnostics[identity] = (
+                (),
+                (*warnings, *error.issues),
+            )
+            return CorrectionBatchResult()
+        if not pending:
+            return CorrectionBatchResult()
+
+        inserted = skipped = 0
+        with self._correction_transaction(target, create=True) as con:
+            established = {
+                pattern
+                for (pattern,) in con.execute("SELECT regex FROM correction")
+                if isinstance(pattern, str) and pattern.strip()
+            }
+            completed, metadata = self._correction_metadata(con)
+            current_states = {key: status for key, _, status, _ in metadata}
+            earlier = list(candidates)
+            for source, key, rows in pending:
+                if key in completed:
+                    continue
+                if any(
+                    current_states.get(earlier_key) in {"pending", "deferred"}
+                    for earlier_key in earlier[: earlier.index(key)]
+                ):
+                    # Another coordinator may have discovered a higher-priority
+                    # problem after our preflight. Keep lower-priority work pending.
+                    break
+                novel = [
+                    row
+                    for row in rows
+                    if not (isinstance(row[0], str) and row[0] in established)
+                ]
+                for pattern, rotation in novel:
+                    rowid = con.execute(
+                        "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES (?, ?, 0, 0)",
+                        (pattern, rotation),
+                    ).lastrowid
+                    stored = con.execute(
+                        "SELECT regex, rotation, offset_x, offset_y FROM correction WHERE rowid=?",
+                        (rowid,),
+                    ).fetchone()
+                    original = Correction.parse(pattern, rotation, (0, 0))
+                    if original is None:
+                        # Malformed input must remain verbatim for repair. In
+                        # particular, TEXT affinity must not turn numeric legacy
+                        # patterns into silently accepted regular expressions.
+                        preserved = (
+                            stored is not None
+                            and all(
+                                type(before) is type(after) and before == after
+                                for before, after in zip(
+                                    (pattern, rotation), stored[:2]
+                                )
+                            )
+                            and stored[2:] == (0, 0)
+                        )
+                    else:
+                        # Safe representation changes such as '90' to INTEGER 90
+                        # are allowed only when the complete normalized value agrees.
+                        preserved = (
+                            stored is not None
+                            and Correction.parse(stored[0], stored[1], stored[2:])
+                            == original
+                        )
+                    if not preserved:
+                        raise CorrectionDataError(
+                            (
+                                CorrectionIssue(
+                                    "migration",
+                                    (pattern, rotation),
+                                    f"destination schema at {target} cannot preserve this legacy correction; "
+                                    "restore a compatible correction schema before retrying; the source archive is unchanged",
+                                    source=source,
+                                ),
+                            )
+                        )
+                self._complete_correction_migration(
+                    con, key, str(Path(source).resolve())
                 )
-                pcur.execute("DROP TABLE IF EXISTS rotation")
-                pcur.commit()
-                self.logger.debug("Droped rotations table from parts database.")
-            except sqlite3.OperationalError:
-                return
+                current_states.pop(key, None)
+                # Preserve contradictions within this source before allowing it
+                # to take precedence over lower-priority historical archives.
+                established.update(
+                    pattern
+                    for pattern, _ in rows
+                    if isinstance(pattern, str) and pattern.strip()
+                )
+                inserted += len(novel)
+                skipped += len(rows) - len(novel)
+        self.logger.info(
+            "Transferred %d legacy corrections to %s; preserved %d established patterns.",
+            inserted,
+            target,
+            skipped,
+        )
+        return CorrectionBatchResult(inserted=inserted, skipped=skipped)
 
-    def migrate_corrections(self):
-        """Migrate existing rotations from old rotation db and parts db to correction db."""
-        self.migrate_corrections_from_rotation()
-        self.migrate_corrections_from_parts()
+    def migrate_corrections_from_rotation(self) -> CorrectionBatchResult:
+        """Transfer missing rotations.db patterns to global storage, retaining the archive."""
+        return self._migrate_correction_sources((self.rotationsdb_file,))
 
-    def fetch_remote_corrections(self, db_path=None):
-        """Download rotation corrections from Matthew Lai's JLCKicadTools repo."""
+    def migrate_corrections_from_parts(self) -> CorrectionBatchResult:
+        """Transfer missing legacy parts patterns without dropping their source."""
+        return self._migrate_correction_sources((self.partsdb_file,))
+
+    def migrate_corrections(self) -> tuple[CorrectionIssue, ...]:
+        """Retry incomplete global transfers while retaining failures for recovery."""
+        target = self.globalcorrectionsdb_file
+        identity = str(Path(target).resolve())
+        diagnostics = self._migration_session_diagnostics
+        diagnostics.pop(identity, None)
+        try:
+            current_sources = list(self._legacy_correction_sources())
+            sources = current_sources[:1]
+            if Path(self.globalcorrectionsdb_file).exists():
+                with contextlib.closing(
+                    self._read_database(self.globalcorrectionsdb_file)
+                ) as con:
+                    completed, states = self._correction_metadata(con)
+                    if _INITIAL_DEFAULTS_KEY not in completed:
+                        # Initial archives retain priority even if configuration
+                        # changes after storage creation but before examination.
+                        sources.extend(
+                            source
+                            for source in self._initial_seed_sources(states)
+                            if source not in sources
+                        )
+                    # Changing the selected parts library must not strand known
+                    # pending work for the same global correction database.
+                    sources.extend(
+                        source
+                        for key, source, status, _ in states
+                        if isinstance(key, str)
+                        and key.startswith("rotation:")
+                        and status in {"pending", "deferred"}
+                        and source not in sources
+                    )
+            sources.extend(
+                source for source in current_sources[1:] if source not in sources
+            )
+            self._migrate_correction_sources(sources)
+            with contextlib.closing(
+                self._read_database(self.globalcorrectionsdb_file)
+            ) as con:
+                return tuple(
+                    CorrectionIssue("migration", None, message, source=source)
+                    for _, source, status, message in self._correction_metadata(con)[1]
+                    if status == "pending"
+                )
+        except (sqlite3.Error, OSError, CorrectionDataError) as error:
+            self.logger.warning("Correction migration remains unresolved: %s", error)
+            issues = (
+                error.issues
+                if isinstance(error, CorrectionDataError)
+                else self._storage_error(target, error, "migration").issues
+            )
+            diagnostics[identity] = (issues, ())
+            return issues
+
+    def retry_correction_migrations(self) -> tuple[CorrectionIssue, ...]:
+        """Retry active global archives once and resume eligible initial defaults."""
+        if self.correctionsdb_file != self.globalcorrectionsdb_file:
+            return ()
+        issues = self.migrate_corrections()
+        if not issues:
+            self._start_initial_remote_corrections(self.globalcorrectionsdb_file)
+        return issues
+
+    def _start_initial_remote_corrections(self, target: str) -> None:
+        """Schedule optional defaults; failures warn without invalidating stored data."""
+        identity = str(Path(target).resolve())
+        claimed = False
+        try:
+            with contextlib.closing(self._read_database(target)) as con:
+                con.execute("BEGIN")
+                if not self._initial_seed_is_eligible(con, target):
+                    return
+            with _INITIAL_DOWNLOAD_LOCK:
+                if identity in _INITIAL_DOWNLOAD_TARGETS:
+                    return
+                _INITIAL_DOWNLOAD_TARGETS.add(identity)
+                claimed = True
+            Thread(
+                target=self._fetch_initial_remote_corrections,
+                args=(target,),
+                daemon=True,
+            ).start()
+        except (sqlite3.Error, OSError, RuntimeError) as error:
+            if claimed:
+                with _INITIAL_DOWNLOAD_LOCK:
+                    _INITIAL_DOWNLOAD_TARGETS.discard(identity)
+            issues, warnings = self._migration_session_diagnostics.get(
+                identity, ((), ())
+            )
+            self._migration_session_diagnostics[identity] = (
+                issues,
+                (
+                    *warnings,
+                    *self._storage_error(target, error, "initial download").issues,
+                ),
+            )
+
+    def _initial_seed_is_eligible(self, con: sqlite3.Connection, target: str) -> bool:
+        """Require durable classification of captured sources before seeding defaults."""
+        completed, states = self._correction_metadata(con)
+        if _INITIAL_DEFAULTS_KEY in completed:
+            return False
+        session = self._migration_session_diagnostics.get(
+            str(Path(target).resolve()), ((), ())
+        )
+        if any(session):
+            return False
+        if any(status in {"pending", "deferred"} for _, _, status, _ in states):
+            return False
+        sources = self._initial_seed_sources(states)
+        if not sources:
+            return False
+        terminal = {key for key, _, status, _ in states if status == "empty"}
+        return all(
+            self._legacy_migration_key(source) in terminal
+            or self._legacy_migration_key(source) in completed
+            for source in sources
+        )
+
+    @staticmethod
+    def _initial_seed_sources(
+        states: Sequence[tuple[object, str, str, str]],
+    ) -> list[str]:
+        """Decode the original source identities retained across interrupted startup."""
+        seed = next(
+            (
+                message
+                for key, _, status, message in states
+                if key == _INITIAL_DEFAULTS_KEY and status == "seed-pending"
+            ),
+            None,
+        )
+        if seed is None:
+            return []
+        try:
+            sources = json.loads(seed)
+        except (TypeError, ValueError) as error:
+            raise sqlite3.DatabaseError(
+                "initial correction source metadata is unreadable"
+            ) from error
+        if (
+            not isinstance(sources, list)
+            or not sources
+            or not all(isinstance(source, str) for source in sources)
+        ):
+            raise sqlite3.DatabaseError(
+                "initial correction source metadata must name its archives"
+            )
+        return sources
+
+    def _fetch_initial_remote_corrections(self, target: str) -> None:
+        """Release the in-process download claim even after an unsuccessful seed."""
+        try:
+            self.fetch_remote_corrections(target, initial=True)
+        finally:
+            with _INITIAL_DOWNLOAD_LOCK:
+                _INITIAL_DOWNLOAD_TARGETS.discard(str(Path(target).resolve()))
+
+    def fetch_remote_corrections(
+        self,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+        *,
+        initial: bool = False,
+    ) -> Optional[CorrectionBatchResult]:  # noqa: UP045
+        """Validate the entire remote CSV and add missing patterns in one transaction."""
         target = db_path if db_path is not None else self.correctionsdb_file
         url = "https://raw.githubusercontent.com/matthewlai/JLCKicadTools/master/jlc_kicad_tools/cpl_rotations_db.csv"
         try:
-            r = requests.get(url, timeout=10)
-            r.raise_for_status()
-            corrections = csv.reader(r.text.splitlines(), delimiter=",", quotechar='"')
-            next(corrections)
-            for row in corrections:
-                if len(row) < 2:
-                    continue
-                if not self.get_correction_data(row[0], db_path=target):
-                    offset = (row[2], row[3]) if len(row) >= 4 else (0, 0)
-                    self.insert_correction_data(row[0], row[1], offset, db_path=target)
-            self.logger.info("Downloaded corrections to %s.", target)
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            self.logger.debug("Failed to download corrections to %s: %s", target, exc)
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            corrections = parse_corrections_csv(response.text, source=url)
+            result = self.apply_corrections(
+                corrections,
+                db_path=target,
+                overwrite=False,
+                migration_key=_INITIAL_DEFAULTS_KEY if initial else None,
+            )
+            self.logger.info(
+                "Downloaded %d corrections to %s.", result.inserted, target
+            )
+            return result
+        except (requests.RequestException, CorrectionDataError, UnicodeError) as error:
+            self.logger.warning(
+                "Failed to download corrections to %s: %s", target, error
+            )
+            wx.PostEvent(
+                self.parent,
+                MessageEvent(
+                    title="Correction Download Error",
+                    text=f"Corrections were not imported into {target}.\n\n{error}",
+                    style="error",
+                ),
+            )
+            return None
 
     def migrate_mappings(self):
         """Migrate existing mappings from parts db to mappings db."""

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -3,10 +3,11 @@
 # pyright: reportMissingImports=false, reportMissingModuleSource=false
 # ruff: noqa: I001
 
+from collections.abc import Sequence
 from contextlib import contextmanager, suppress
 from datetime import datetime as dt
 from threading import Thread
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ from wx import adv  # pylint: disable=import-error
 from .bom_estimation.assembly_mode import classify_component_product_type
 from .bom_estimation.help_text import show_bom_estimator_help
 from .bom_widget import BomEstimatorController, BomEstimatorWidget
+from .correction_data import Correction, match_correction
 from .corrections import CorrectionManagerDialog
 from .datamodel import PartListDataModel, STANDARD_ONLY_TOOLTIP
 from .dataview_highlight import (
@@ -69,7 +71,7 @@ from .helpers import (
     loadBitmapScaled,
 )
 from .kicad_drc import DRCViolationCounter
-from .library import Library, LibraryState
+from .library import CorrectionState, Library, LibraryState
 from .partdetails import PartDetailsDialog
 from .partmapper import PartMapperManagerDialog
 from .partselector import PartSelectorDialog
@@ -77,6 +79,9 @@ from .schematicexport import SchematicExport
 from .settings import SettingsDialog
 from .store import Store
 from .why_standard_dialog import WhyStandardDialog
+
+if TYPE_CHECKING:
+    from .library import CorrectionSnapshot
 
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -118,7 +123,9 @@ class KicadProvider:
 class JLCPCBTools(wx.Dialog):
     """JLCPCBTools main dialog."""
 
-    def __init__(self, parent: Any, kicad_provider: Any = KicadProvider()) -> None:
+    def __init__(
+        self, parent: Any, kicad_provider: KicadProvider = KicadProvider()
+    ) -> None:
         while not wx.GetApp():
             time.sleep(1)
         wx.Dialog.__init__(
@@ -613,6 +620,11 @@ class JLCPCBTools(wx.Dialog):
         self.bom_estimator_help_button = self.bom_widget.help_button
         self.bom_estimator_summary = self.bom_widget.summary_label
 
+        # This status must exist before init_data() first populates the list.
+        # Invalid stored corrections remain repairable through the manager.
+        self.correction_status = wx.StaticText(self, label="")
+        self.correction_status.Hide()
+
         # ---------------------------------------------------------------------
         # ---------------------- Main Layout Sizer ----------------------------
         # ---------------------------------------------------------------------
@@ -621,6 +633,12 @@ class JLCPCBTools(wx.Dialog):
         layout = wx.BoxSizer(wx.VERTICAL)
         layout.Add(self.upper_toolbar, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(estimator_sizer, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 5)
+        layout.Add(
+            self.correction_status,
+            0,
+            wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND,
+            5,
+        )
         layout.Add(table_sizer, 20, wx.ALL | wx.EXPAND, 5)
         layout.Add(self.logbox, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(self.gauge, 0, wx.ALL | wx.EXPAND, 5)
@@ -1133,30 +1151,64 @@ class JLCPCBTools(wx.Dialog):
         }
         wx.MessageBox(e.text, e.title, style=styles.get(e.style, wx.ICON_INFORMATION))
 
-    def get_correction(self, part: dict, corrections: list) -> str:
-        """Try to find correction data for a given part."""
-        # First check if the part name matches
-        for regex, rotation, offset in corrections:
-            if re.search(regex, str(part["reference"])):
-                return f"{str(rotation)}°, {str(offset[0])}/{str(offset[1])} (ref)"
-        # Then try to match by value
-        for regex, rotation, offset in corrections:
-            if re.search(regex, str(part["value"])):
-                return f"{str(rotation)}°, {str(offset[0])}/{str(offset[1])} (val)"
-        # If there was no match for the part name or value, check if the package matches
-        for regex, rotation, offset in corrections:
-            if re.search(regex, str(part["footprint"])):
-                return f"{str(rotation)}°, {str(offset[0])}/{str(offset[1])} (fpt)"
-        return "0°, 0.0/0.0"
+    def get_correction(
+        self, part: dict[str, Any], corrections: Sequence[Correction]
+    ) -> str:
+        """Display the same complete correction rule used for fabrication."""
+        match = match_correction(
+            corrections,
+            str(part["reference"]),
+            str(part["value"]),
+            str(part["footprint"]),
+        )
+        if match is None:
+            return "0°, 0.0/0.0"
+        return f"{match.correction} ({match.source})"
 
-    def populate_footprint_list(self, *_):
+    def update_correction_status(self, snapshot: "CorrectionSnapshot") -> None:
+        """Show aggregate readiness; detailed repair diagnostics stay in the manager."""
+        unresolved = snapshot.corrections is None
+        if unresolved:
+            reason = (
+                "unavailable"
+                if snapshot.state == CorrectionState.UNAVAILABLE
+                else "unresolved"
+            )
+            label = (
+                f"Corrections {reason} in the active {snapshot.scope} database.\n"
+                "Open Corrections Manager to repair or retry loading before generating fabrication files."
+            )
+            details = str(snapshot.db_path)
+        else:
+            label = ""
+            details = ""
+        self.correction_status.SetLabel(label)
+        self.correction_status.SetToolTip(details)
+        self.correction_status.Show(unresolved)
+        self.Layout()
+
+    def read_valid_corrections_for_generation(self) -> tuple[Correction, ...]:
+        """Read a fresh complete snapshot before any generation side effects."""
+        snapshot = self.library.read_correction_data()
+        self.update_correction_status(snapshot)
+        if snapshot.corrections is None:
+            raise ValueError(
+                f"Corrections are unresolved in the active {snapshot.scope} "
+                f"database ({snapshot.db_path}). Open Corrections Manager "
+                "to repair or retry loading before generating fabrication files."
+            )
+        return snapshot.corrections
+
+    def populate_footprint_list(self, *_: object) -> None:
         """Populate list of footprints."""
         if not self.store:
             self.init_store()
         self.partlist_data_model.RemoveAll()
         parts = self.store.read_all()
         details = {}
-        corrections = self.library.get_all_correction_data()
+        snapshot = self.library.read_correction_data()
+        self.update_correction_status(snapshot)
+        corrections = snapshot.corrections
         for part in parts:
             fp = self.pcbnew.GetBoard().FindFootprintByReference(part["reference"])
             if fp is None:
@@ -1182,7 +1234,11 @@ class JLCPCBTools(wx.Dialog):
                     part["exclude_from_bom"],
                     part["exclude_from_pos"],
                     int(is_dnp),
-                    str(self.get_correction(part, corrections)),
+                    (
+                        str(self.get_correction(part, corrections))
+                        if corrections is not None
+                        else "Unresolved"
+                    ),
                     str(fp.GetLayer()),
                     params_for_part(details.get(part["lcsc"], {})),
                     self._get_enrichment_status_label(part),  # enrichment
@@ -1396,9 +1452,10 @@ class JLCPCBTools(wx.Dialog):
         """Update the library from the JLCPCB CSV file."""
         self.library.update()
 
-    def manage_corrections(self, *_):
-        """Manage corrections."""
+    def manage_corrections(self, *_: object) -> None:
+        """Refresh displayed corrections after the manager's recovery attempts."""
         CorrectionManagerDialog(self, "").ShowModal()
+        self.populate_footprint_list()
 
     def manage_mappings(self, *_):
         """Manage footprint mappings."""
@@ -1625,13 +1682,20 @@ class JLCPCBTools(wx.Dialog):
         )
         return False
 
-    def generate_fabrication_data(self, *_):
+    def generate_fabrication_data(self, *_: object) -> None:
         """Generate fabrication data."""
         self.generate_button.Enable(False)
         self.reset_gauge()
         wx.BeginBusyCursor()
         self._current_generation_step = "initialization"
         try:
+            corrections = self.run_generation_step(
+                "Validating corrections",
+                self.read_valid_corrections_for_generation,
+            )
+            placements = self.run_generation_step(
+                "Preparing placement data", self.fabrication.prepare_cpl, corrections
+            )
             warnings = self.run_generation_step(
                 "Checking part consistency",
                 self.fabrication.get_part_consistency_warnings,
@@ -1753,7 +1817,8 @@ class JLCPCBTools(wx.Dialog):
 
             self.run_generation_step(
                 "Generating placement file (CPL)",
-                self.fabrication.generate_cpl,
+                self.fabrication.write_cpl,
+                placements,
             )
 
             self.run_generation_step(
@@ -1895,7 +1960,7 @@ class JLCPCBTools(wx.Dialog):
                 self.start_assembly_enrichment(updated_references)
                 wx.PostEvent(self, BomDataChangedEvent(source="paste_part_lcsc"))
 
-    def add_correction(self, e):
+    def add_correction(self, e: "wx.CommandEvent") -> None:
         """Add part correction for the current part."""
         for item in self.footprint_list.GetSelections():
             if e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_REFERENCE:
@@ -1911,6 +1976,7 @@ class JLCPCBTools(wx.Dialog):
             elif e.GetId() == ID_CONTEXT_MENU_ADD_ROT_BY_NAME:
                 if value := self.partlist_data_model.get_value(item):
                     CorrectionManagerDialog(self, re.escape(value)).ShowModal()
+        self.populate_footprint_list()
 
     def save_all_mappings(self, *_):
         """Save all mappings."""

--- a/tests/correction_test_support.py
+++ b/tests/correction_test_support.py
@@ -1,0 +1,75 @@
+"""Real temporary storage and reopening helpers for correction tests."""
+
+from collections.abc import Iterable
+from contextlib import closing
+import logging
+from pathlib import Path
+import sqlite3
+import types
+from typing import Any, Union
+
+
+def make_library(
+    module: types.ModuleType,
+    directory: Union[str, Path],
+    rows: Iterable[tuple[Any, ...]] = (),
+    *,
+    local: bool = False,
+) -> Any:
+    """Create a real Library with all paths confined to the supplied directory."""
+    directory = Path(directory)
+    global_dir = directory / "global"
+    project_dir = directory / "project"
+    global_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "jlcpcb").mkdir(parents=True, exist_ok=True)
+    library = module.Library.__new__(module.Library)
+    library._migration_session_diagnostics = {}
+    library._known_legacy_sources = {}
+    library.logger = logging.getLogger(__name__)
+    library.parent = types.SimpleNamespace(settings={}, project_path=str(project_dir))
+    library.datadir = str(global_dir)
+    library.partsdb_file = str(global_dir / "parts.db")
+    library.rotationsdb_file = str(global_dir / "rotations.db")
+    library.mappingsdb_file = str(global_dir / "mappings.db")
+    library.globalcorrectionsdb_file = str(global_dir / "corrections.db")
+    library.localcorrectionsdb_file = str(project_dir / "jlcpcb" / "project.db")
+    library.correctionsdb_file = (
+        library.localcorrectionsdb_file if local else library.globalcorrectionsdb_file
+    )
+    library.state = module.LibraryState.INITIALIZED
+    library.create_correction_table()
+    seed_raw(library, rows)
+    return library
+
+
+def fresh_library(library: Any) -> Any:
+    """Reopen using the same paths without inheriting cached correction state."""
+    fresh = type(library).__new__(type(library))
+    fresh._migration_session_diagnostics = {}
+    fresh._known_legacy_sources = {}
+    for name in (
+        "logger",
+        "parent",
+        "datadir",
+        "partsdb_file",
+        "rotationsdb_file",
+        "mappingsdb_file",
+        "globalcorrectionsdb_file",
+        "localcorrectionsdb_file",
+        "correctionsdb_file",
+        "state",
+    ):
+        setattr(fresh, name, getattr(library, name))
+    return fresh
+
+
+def seed_raw(library: Any, rows: Iterable[tuple[Any, ...]]) -> None:
+    """Persist historical malformed values without using the validated writer."""
+    with closing(sqlite3.connect(library.correctionsdb_file)) as con, con:
+        con.executemany("INSERT INTO correction VALUES (?, ?, ?, ?)", rows)
+
+
+def raw_rows(library: Any) -> list[tuple[Any, ...]]:
+    """Read exact persisted values through an independent SQLite connection."""
+    with closing(sqlite3.connect(library.correctionsdb_file)) as con:
+        return con.execute("SELECT rowid, * FROM correction ORDER BY rowid").fetchall()

--- a/tests/test_correction_data.py
+++ b/tests/test_correction_data.py
@@ -1,0 +1,655 @@
+"""Exercise the correction data contract without importing KiCad or wx."""
+
+import csv
+from dataclasses import FrozenInstanceError, replace
+import importlib.util
+from io import StringIO
+import math
+from pathlib import Path
+import sqlite3
+import sys
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def data(monkeypatch):
+    """Load the production validator with a scoped module registration."""
+    name = "correction_data_validation_tests"
+    spec = importlib.util.spec_from_file_location(name, _ROOT / "correction_data.py")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("rotation", "expected"),
+    [
+        (0, 0),
+        (-90, -90),
+        (450, 450),
+        (90.0, 90),
+        ("90.0", 90),
+        (" +90.000 ", 90),
+        ("-0", 0),
+        ("9e1", 90),
+        (".0", 0),
+        (str(-(2**63)), -(2**63)),
+        (str(2**63 - 1), 2**63 - 1),
+        (-(2**63), -(2**63)),
+        (2**63 - 1, 2**63 - 1),
+    ],
+)
+def test_rotation_parses_exact_whole_signed_degrees(data, rotation, expected):
+    """Keep supported whole-degree syntax, signs, and exact storage limits."""
+    correction = data.validate_correction("SOT-23", rotation, (0, 0))
+    assert correction.rotation == expected
+    assert isinstance(correction.rotation, int)
+    assert correction.offset == (0.0, 0.0)
+    assert all(isinstance(value, float) for value in correction.offset)
+
+
+@pytest.mark.parametrize(
+    "rotation",
+    [
+        "47u",
+        "",
+        "   ",
+        None,
+        True,
+        False,
+        b"90",
+        [],
+        {},
+        complex(90, 0),
+        90.5,
+        "90.5",
+        "90.0000000000000000001",
+        "1e-9999",
+        "1e99999999999999999999999",
+        "1e999999999",
+        2**63,
+        -(2**63) - 1,
+        str(2**63),
+        str(-(2**63) - 1),
+        float(2**63 - 1),
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        "NaN",
+        "Infinity",
+        "-inf",
+        "1_0",
+        "0x5a",
+    ],
+)
+def test_invalid_rotations_report_original_value_and_location(data, rotation):
+    """Reject coercion, truncation, overflow, and issue 531's exact value."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.validate_correction(
+            "Capacitor_SMD:C_0805",
+            rotation,
+            (0, 0),
+            source="parts.csv",
+            line=7,
+            rowid=3,
+        )
+    (issue,) = raised.value.issues
+    assert issue.field == "rotation"
+    assert issue.value is rotation
+    assert issue.source == "parts.csv"
+    assert issue.line == 7
+    assert issue.rowid == 3
+    assert issue.pattern == "Capacitor_SMD:C_0805"
+    assert "whole degrees" in issue.message
+    assert "parts.csv, line 7, row 3" in str(raised.value)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, 0.0),
+        ("-0", -0.0),
+        ("-.125", -0.125),
+        (2.75, 2.75),
+        (" +2.5e-3 ", 0.0025),
+        ("-5e-324", -5e-324),
+        (str(sys.float_info.max), sys.float_info.max),
+    ],
+)
+def test_offsets_accept_finite_signed_floats(data, axis, value, expected):
+    """Validate both axes with fractions and representable finite extremes."""
+    offsets = [0, 0]
+    offsets[axis] = value
+    correction = data.validate_correction("SOT-23", 90, offsets)
+    assert correction.offset[axis] == expected
+    assert math.copysign(1, correction.offset[axis]) == math.copysign(1, expected)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "47u",
+        "",
+        " ",
+        None,
+        True,
+        False,
+        b"1.5",
+        [],
+        {},
+        complex(1, 0),
+        "NaN",
+        "nan",
+        "inf",
+        "+Infinity",
+        "-inf",
+        float("nan"),
+        float("inf"),
+        "1e309",
+        "-1e309",
+        10**400,
+        "1_0",
+    ],
+)
+def test_invalid_offsets_identify_each_axis(data, axis, value):
+    """Reject explicit invalid offsets instead of silently replacing them."""
+    offsets = [0, 0]
+    offsets[axis] = value
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.validate_correction("SOT-23", 90, offsets)
+    (issue,) = raised.value.issues
+    assert issue.field == ("offset_x", "offset_y")[axis]
+    assert issue.value is value
+
+
+@pytest.mark.parametrize(
+    "offset", [None, (), (0,), (0, 0, 0), "00", b"00", {0: 0, 1: 0}]
+)
+def test_invalid_offset_containers_report_a_structured_error(data, offset):
+    """Unexpected database or caller values cannot escape as type errors."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.validate_correction("SOT-23", 0, offset)
+    assert raised.value.issues[0].field == "offset"
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "SOT-23|SOT-23-5",
+        "^SOT-23$",
+        "(?i:SOT-23)",
+        r"(?P<prefix>SOT)-(?P=prefix)",
+        r"(SOT)-\1",
+        " space at both ends ",
+        "L'électronique,µF",
+        'A"B',
+        "SOT\n23",
+    ],
+)
+def test_patterns_preserve_supported_regex_text(data, pattern):
+    """Accept expressions compatible with both matcher passes unchanged."""
+    assert data.validate_correction(pattern, 0, (0, 0)).pattern == pattern
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        None,
+        True,
+        123,
+        b"SOT",
+        "",
+        " \t\n",
+        "[",
+        "(?i)SOT",
+        "a{999999999999999999999}",
+        "(" * 1000,
+    ],
+)
+def test_invalid_patterns_include_anchored_matcher_failures(data, pattern):
+    """Reject invalid regexes, including raw-valid global flag expressions."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.validate_correction(pattern, 0, (0, 0))
+    assert raised.value.issues[0].field == "pattern"
+
+
+def test_validation_aggregates_all_fields(data):
+    """Report each invalid field in one repair attempt."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.validate_correction("[", "47u", ("", "NaN"))
+    assert [issue.field for issue in raised.value.issues] == [
+        "pattern",
+        "rotation",
+        "offset_x",
+        "offset_y",
+    ]
+
+
+def test_correction_and_issue_records_are_immutable(data):
+    """Validated snapshots and diagnostics cannot be changed accidentally."""
+    correction = data.validate_correction("SOT", 90, (0, 0))
+    issue = data.CorrectionIssue("rotation", "47u", "whole degrees required")
+    with pytest.raises(FrozenInstanceError):
+        correction.rotation = 47
+    with pytest.raises(FrozenInstanceError):
+        issue.field = "pattern"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Pattern,Rotation,Offset X,Offset Y\nSOT,90,1.5,-2\n",
+        '"Pattern","Rotation","Offset X","Offset Y"\r\n"SOT","90","1.5","-2"\r\n',
+        '"Pattern","Rotation", "Offset X","Offset Y"\nSOT,90,1.5,-2\n',
+        "Offset Y, Rotation, Pattern, Offset X\n-2,90,SOT,1.5\n",
+        "\ufeff\n\npattern,ROTATION,Offset   X,offset y\r\nSOT,90,1.5,-2\r\n",
+    ],
+)
+def test_current_remote_and_reordered_headers(data, text):
+    """Recognize exporter and remote syntax with safe header mapping."""
+    assert data.parse_corrections_csv(text) == (
+        data.Correction("SOT", 90, (1.5, -2.0)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Footprint pattern,Correction\nSOT,-90\n", ("SOT", -90, (0.0, 0.0))),
+        ("Correction,Footprint pattern\n90,SOT\n", ("SOT", 90, (0.0, 0.0))),
+        ("Pattern,Rotation,Offset X,Offset Y\nSOT,90\n", ("SOT", 90, (0.0, 0.0))),
+        ("Pattern,Rotation,Offset X,Offset Y\nSOT,90,1.5\n", ("SOT", 90, (1.5, 0.0))),
+        ("Pattern,Rotation,Offset Y,Offset X\nSOT,90,1.5\n", ("SOT", 90, (0.0, 1.5))),
+        ("Offset X,Pattern,Rotation,Offset Y\n1.5,SOT,90\n", ("SOT", 90, (1.5, 0.0))),
+    ],
+)
+def test_legacy_rows_default_only_omitted_trailing_offsets(data, text, expected):
+    """Support historical records without defaulting missing required fields."""
+    assert data.parse_corrections_csv(text) == (data.Correction(*expected),)
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Pattern,Rotation",
+        "Footprint pattern,Correction",
+        "Pattern,Rotation,Offset X,Offset Y",
+    ],
+)
+def test_header_only_file_is_a_noop(data, header):
+    """A recognized empty export is a valid empty batch."""
+    assert data.parse_corrections_csv(header + "\n\n  \n") == ()
+
+
+@pytest.mark.parametrize("text", ["", "\n\r\n \t\n", "\ufeff", "\ufeff\n"])
+def test_empty_file_requires_a_header(data, text):
+    """Distinguish an absent file format from a valid empty export."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv(text, "empty.csv")
+    assert raised.value.issues[0].field == "header"
+    assert raised.value.issues[0].source == "empty.csv"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Pattern,Rotatoin",
+        "Pattern,Rotation,Unknown",
+        "Pattern,Pattern,Rotation",
+        "Footprint pattern,Pattern,Correction",
+        "Pattern,Rotation,Correction",
+        "Pattern,Rotation,Offset X,offset x",
+        "Rotation,Offset X,Offset Y",
+        "Pattern,Offset X,Offset Y",
+        "Pattern,Rotation,",
+        ",,,",
+        "SOT,90",
+    ],
+)
+def test_invalid_headers_reject_input_before_records(data, header):
+    """Reject unknown, duplicated, missing, and accidental data headers."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv(header + "\nSOT,90\n", "bad.csv")
+    assert all(issue.field == "header" for issue in raised.value.issues)
+    assert all(issue.line == 1 for issue in raised.value.issues)
+
+
+@pytest.mark.parametrize(
+    ("row", "fields"),
+    [
+        ("SOT", ["rotation"]),
+        ("SOT,", ["rotation"]),
+        ("SOT,90,", ["offset_x"]),
+        ("SOT,90,1,", ["offset_y"]),
+        ("SOT,90,,1", ["offset_x"]),
+        (",90,0,0", ["pattern"]),
+        (",,,", ["pattern", "rotation", "offset_x", "offset_y"]),
+        ('""', ["pattern", "rotation"]),
+        ("SOT,90,0,0,extra", ["csv"]),
+    ],
+)
+def test_explicit_blank_and_malformed_rows_never_become_defaults(data, row, fields):
+    """Differentiate omitted legacy offsets from corrupt or incomplete data."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv("Pattern,Rotation,Offset X,Offset Y\n" + row)
+    assert [issue.field for issue in raised.value.issues] == fields
+
+
+@pytest.mark.parametrize(
+    ("text", "field"),
+    [
+        ("Pattern,Offset X,Rotation\nSOT,0", "rotation"),
+        ("Rotation,Offset X,Pattern\n90,0", "pattern"),
+    ],
+)
+def test_reordered_header_does_not_default_missing_required_values(data, text, field):
+    """Missing physical trailing columns are resolved by their header names."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv(text)
+    assert [issue.field for issue in raised.value.issues] == [field]
+
+
+def test_blank_lines_preserve_physical_line_diagnostics(data):
+    """Locate bad rows correctly after blanks and quoted multiline records."""
+    text = '\nPattern,Rotation\n\n"SOT\n23",90\n \nCAP,47u\n'
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv(text, "corrections.csv")
+    (issue,) = raised.value.issues
+    assert issue.line == 7
+    assert issue.pattern == "CAP"
+    assert issue.value == "47u"
+    assert "corrections.csv, line 7, pattern 'CAP'" in str(raised.value)
+
+
+@pytest.mark.parametrize("invalid_row", ['"SOT,90', '"SOT"bad,90'])
+def test_malformed_quoting_rejects_whole_input(data, invalid_row):
+    """A late CSV syntax error must not return earlier valid corrections."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv("Pattern,Rotation\nVALID,90\n" + invalid_row)
+    (issue,) = raised.value.issues
+    assert issue.field == "csv"
+    assert issue.line == 3
+
+
+def test_malformed_header_quoting_is_a_structured_error(data):
+    """Header parsing failures use the same error type as data failures."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv('"Pattern,Rotation\nSOT,90')
+    assert raised.value.issues[0].field == "csv"
+
+
+@pytest.mark.parametrize("invalid_position", [0, 1, 2])
+def test_entire_batch_validates_regardless_of_invalid_row_position(
+    data, invalid_position
+):
+    """Issue 531 fails before callers receive any records to persist."""
+    rows = ["FIRST,90", "MIDDLE,-90", "LAST,180"]
+    rows[invalid_position] = "CAP,47u"
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv("Pattern,Rotation\n" + "\n".join(rows))
+    assert raised.value.issues[0].line == invalid_position + 2
+
+
+def test_all_invalid_records_are_reported_in_input_order(data):
+    """Give one complete validation result, including a later syntax failure."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv('Pattern,Rotation\nA,47u\nB,90.1\n"unclosed')
+    assert [(issue.line, issue.field) for issue in raised.value.issues] == [
+        (2, "rotation"),
+        (3, "rotation"),
+        (4, "csv"),
+    ]
+
+
+def test_valid_duplicates_remain_in_input_order(data):
+    """Leave overwrite or add-missing policy to the atomic storage boundary."""
+    corrections = data.parse_corrections_csv("Pattern,Rotation\nSOT,90\nSOT,-90")
+    assert corrections == (
+        data.Correction("SOT", 90, (0.0, 0.0)),
+        data.Correction("SOT", -90, (0.0, 0.0)),
+    )
+
+
+@pytest.mark.parametrize("rows", ["SOT,47u\nSOT,90", "SOT,90\nSOT,47u"])
+def test_duplicate_resolution_cannot_hide_invalid_values(data, rows):
+    """Validate even rows that an overwrite or remote update might skip."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv("Pattern,Rotation\n" + rows)
+    assert raised.value.issues[0].value == "47u"
+
+
+def test_csv_roundtrip_preserves_patterns_and_typed_values(data):
+    """Read the actual export format with quotes, Unicode, and backslashes."""
+    stream = StringIO(newline="")
+    writer = csv.writer(stream, quoting=csv.QUOTE_ALL)
+    writer.writerow(["Pattern", "Rotation", "Offset X", "Offset Y"])
+    expected = (
+        data.Correction("  SOT-23  ", -450, (-1.25, 0.125)),
+        data.Correction('L\'électronique,"µF"', 90, (0.0, -0.0)),
+        data.Correction(r"Package:C_\d+", 180, (1.5, -2.25)),
+        data.Correction("SOT\n23", 0, (0.0, 0.0)),
+    )
+    for correction in expected:
+        writer.writerow([correction.pattern, correction.rotation, *correction.offset])
+    assert data.parse_corrections_csv(stream.getvalue()) == expected
+
+
+def test_unquoted_pattern_whitespace_is_preserved(data):
+    """Header whitespace compatibility cannot change a matching expression."""
+    text = 'Pattern, Rotation, "Offset X", "Offset Y"\n  SOT  ,90\n'
+    assert data.parse_corrections_csv(text)[0].pattern == "  SOT  "
+
+
+def test_mixed_legacy_and_current_rows(data):
+    """The remote feed can mix two-field and four-field records."""
+    text = '"Pattern","Rotation", "Offset X","Offset Y"\nA,90\nB,180,1.5\nC,-90,-1,2\n'
+    assert data.parse_corrections_csv(text) == (
+        data.Correction("A", 90, (0.0, 0.0)),
+        data.Correction("B", 180, (1.5, 0.0)),
+        data.Correction("C", -90, (-1.0, 2.0)),
+    )
+
+
+@pytest.mark.parametrize("value", [None, b"Pattern,Rotation\nSOT,90", []])
+def test_parser_requires_decoded_text(data, value):
+    """Unexpected caller values produce structured input errors."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.parse_corrections_csv(value)
+    assert raised.value.issues[0].field == "csv"
+
+
+@pytest.mark.parametrize(
+    ("pattern", "rotation", "offset", "field"),
+    [
+        ("C1", "47u", (0, 0), "rotation"),
+        ("C1", "90.5", (0, 0), "rotation"),
+        ("C1", 2**63, (0, 0), "rotation"),
+        ("C1", -(2**63) - 1, (0, 0), "rotation"),
+        ("C1", float("inf"), (0, 0), "rotation"),
+        ("C1", True, (0, 0), "rotation"),
+        ("[", 0, (0, 0), "pattern"),
+        ("(?i)C1", 0, (0, 0), "pattern"),
+        (" ", 0, (0, 0), "pattern"),
+        (123, 0, (0, 0), "pattern"),
+        ("C1", 0, (float("nan"), 0), "offset_x"),
+        ("C1", 0, (0, "47u"), "offset_y"),
+        ("C1", 0, [0], "offset"),
+    ],
+)
+def test_direct_constructor_rejects_invalid_values(
+    data: ModuleType, pattern: object, rotation: object, offset: object, field: str
+) -> None:
+    """Every constructed value must satisfy the correction contract."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.Correction(pattern, rotation, offset)
+    assert raised.value.issues[0].field == field
+
+
+def test_direct_constructor_aggregates_field_issues(data: ModuleType) -> None:
+    """Raw constructor diagnostics retain all values for contextual repair."""
+    with pytest.raises(data.CorrectionDataError) as raised:
+        data.Correction("[", "47u", ("", "NaN"))
+    assert [(issue.field, issue.value) for issue in raised.value.issues] == [
+        ("pattern", "["),
+        ("rotation", "47u"),
+        ("offset_x", ""),
+        ("offset_y", "NaN"),
+    ]
+
+
+def test_direct_constructor_normalizes_and_detaches_offsets(data: ModuleType) -> None:
+    """Caller mutation cannot invalidate a correction or a stored snapshot."""
+    offsets = ["-0", "0.125"]
+    correction = data.Correction("  C1  ", "9e1", offsets)
+    offsets[0] = "47u"
+    offsets.append("NaN")
+    assert correction.pattern == "  C1  "
+    assert correction.rotation == 90
+    assert type(correction.rotation) is int
+    assert type(correction.offset) is tuple
+    assert correction.offset == (-0.0, 0.125)
+    assert all(type(value) is float for value in correction.offset)
+    assert math.copysign(1, correction.offset[0]) == -1
+    assert hash(correction) == hash(data.Correction("  C1  ", 90, (-0.0, 0.125)))
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"rotation": "47u"},
+        {"rotation": 90.5},
+        {"pattern": "["},
+        {"offset": (0, float("inf"))},
+    ],
+)
+def test_dataclass_replace_cannot_bypass_validation(
+    data: ModuleType, changes: dict[str, object]
+) -> None:
+    """Replacing a field invokes the same invariant as initial construction."""
+    correction = data.Correction("C1", 90, (1.0, 2.0))
+    with pytest.raises(data.CorrectionDataError):
+        replace(correction, **changes)
+    assert correction == data.Correction("C1", 90, (1.0, 2.0))
+
+
+def test_dataclass_replace_normalizes_valid_inputs(data: ModuleType) -> None:
+    """Replacing fields produces another independent immutable value."""
+    offsets = ["-1.25", "2.5"]
+    correction = replace(
+        data.Correction("C1", 90, (0.0, 0.0)), rotation="-9e1", offset=offsets
+    )
+    offsets[0] = "47u"
+    assert correction == data.Correction("C1", -90, (-1.25, 2.5))
+
+
+def test_dataclass_replace_pattern_updates_both_matching_passes(
+    data: ModuleType,
+) -> None:
+    """A replacement uses its new pattern while the original remains usable."""
+    original = data.Correction("OLD", 90, (1.25, -2.5))
+    replacement = replace(original, pattern="NEW")
+    fallback = data.Correction("prefix", -90, (0, 0))
+
+    assert data.find_correction((fallback, replacement), "prefix-NEW") is replacement
+    assert data.find_correction((replacement,), "prefix-NEW-suffix") is replacement
+    assert data.find_correction((replacement,), "prefix-OLD") is None
+    assert data.find_correction((replacement,), "prefix-OLD-suffix") is None
+    assert data.find_correction((original,), "prefix-OLD") is original
+    assert data.find_correction((original,), "prefix-OLD-suffix") is original
+    assert data.find_correction((original,), "NEW") is None
+
+
+def test_replaced_correction_preserves_public_value_contract(data: ModuleType) -> None:
+    """Matching state does not enter equality, hashing, display or persistence."""
+    correction = replace(data.Correction("OLD", 90, (1.25, -2.5)), pattern="NEW")
+    equivalent = data.Correction("NEW", "9e1", ["1.25", "-2.5"])
+
+    assert correction is not equivalent
+    assert correction == equivalent
+    assert correction != replace(correction, pattern="OLD")
+    assert correction != replace(correction, rotation=0)
+    assert correction != replace(correction, offset=(0, 0))
+    assert hash(correction) == hash(equivalent) == hash(("NEW", 90, (1.25, -2.5)))
+    assert {correction: "selected"}[equivalent] == "selected"
+    assert (
+        repr(correction)
+        == "Correction(pattern='NEW', rotation=90, offset=(1.25, -2.5))"
+    )
+    assert str(correction) == "90°, 1.25/-2.5"
+    assert correction.db_row() == ("NEW", 90, 1.25, -2.5)
+    assert correction.csv_row() == ("NEW", 90, 1.25, -2.5)
+    assert correction.editor_values() == ("NEW", "90", "1.25", "-2.5")
+    with pytest.raises(FrozenInstanceError):
+        correction.pattern = "OLD"
+
+
+def test_parse_returns_optional_without_exposing_invalid_corrections(
+    data: ModuleType,
+) -> None:
+    """Expected invalid input is represented by absence, never a partial value."""
+    assert data.Correction.parse("C1", "47u", (0, 0)) is None
+    assert data.Correction.parse("[", 90, (0, 0)) is None
+    assert data.Correction.parse("C1", 90, (0, "NaN")) is None
+    assert data.Correction.parse("C1", "-9e1", ["1.25", "-0"]) == data.Correction(
+        "C1", -90, (1.25, -0.0)
+    )
+
+
+def test_parse_does_not_hide_unexpected_programming_errors(
+    data: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Programming failures must escape the optional input parsing boundary."""
+
+    def fail_validation(pattern: object, rotation: object, offset: object) -> None:
+        raise RuntimeError("unexpected constructor failure")
+
+    monkeypatch.setattr(data, "_validated_values", fail_validation)
+    with pytest.raises(RuntimeError, match="unexpected constructor failure"):
+        data.Correction.parse("C1", 90, (0, 0))
+
+
+@pytest.mark.parametrize("rotation", [-(2**63), 2**63 - 1, 9007199254740993, -450, 0])
+@pytest.mark.parametrize(
+    "offset",
+    [(-0.0, 0.0), (0.12345678901234566, -5e-324), (sys.float_info.max, -1.25)],
+)
+def test_serialization_roundtrips_exact_values(
+    data: ModuleType, rotation: int, offset: tuple[float, float]
+) -> None:
+    """Database, CSV and editor boundaries share lossless canonical values."""
+    pattern = '  L\'électronique,"µF"\\d+\n  '
+    correction = data.Correction(pattern, rotation, offset)
+    assert correction.db_row() == (pattern, rotation, *offset)
+    assert correction.csv_row() == correction.db_row()
+    assert correction.editor_values() == (
+        pattern,
+        str(rotation),
+        str(offset[0]),
+        str(offset[1]),
+    )
+    assert str(correction) == f"{rotation}°, {offset[0]}/{offset[1]}"
+    with sqlite3.connect(":memory:") as connection:
+        connection.execute(
+            "CREATE TABLE corrections(regex, rotation, offset_x, offset_y)"
+        )
+        connection.execute(
+            "INSERT INTO corrections VALUES (?, ?, ?, ?)", correction.db_row()
+        )
+        row = connection.execute("SELECT * FROM corrections").fetchone()
+    assert data.Correction(row[0], row[1], row[2:]) == correction
+    stream = StringIO(newline="")
+    writer = csv.writer(stream)
+    writer.writerow(("Pattern", "Rotation", "Offset X", "Offset Y"))
+    writer.writerow(correction.csv_row())
+    (csv_correction,) = data.parse_corrections_csv(stream.getvalue())
+    assert csv_correction == correction
+    assert math.copysign(1, csv_correction.offset[0]) == math.copysign(1, offset[0])
+    editor = correction.editor_values()
+    assert data.Correction.parse(editor[0], editor[1], editor[2:]) == correction

--- a/tests/test_correction_matching.py
+++ b/tests/test_correction_matching.py
@@ -1,0 +1,171 @@
+"""Keep display and fabrication selection on the established CPL policy."""
+
+from dataclasses import FrozenInstanceError
+import importlib.util
+from pathlib import Path
+import re
+import sys
+from types import ModuleType
+from typing import Optional
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def data(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load the pure production matcher without GUI or database imports."""
+    name = "correction_data_matching_tests"
+    spec = importlib.util.spec_from_file_location(name, _ROOT / "correction_data.py")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("patterns", "value", "expected"),
+    [
+        (("SOT-23", "SOT-23-3"), "SOT-23-3", 1),
+        (("SOT-23-3", "SOT-23"), "SOT-23-3", 0),
+        (("SOT-23",), "Package:SOT-23", 0),
+        (("SOT-23",), "Package:SOT-23-extra", 0),
+        (("23", "SOT-23"), "SOT-23", 0),
+        (("SOT-23", "23"), "SOT-23", 0),
+        ((".+", "SOT-23"), "SOT-23", 0),
+        (("SOT", "SOT-23"), "SOT-23-extra", 0),
+        (("SOT-23", "SOT"), "SOT-23-extra", 0),
+        (("SOT|QFN", "SOT-23"), "SOT-23", 1),
+        (("SOT|QFN",), "Package:QFN", 0),
+        (("(?i:sot-23)",), "Package:SOT-23", 0),
+        (("^SOT-23$",), "Package:SOT-23", None),
+        (("SOT-23",), "sot-23", None),
+        (("SOT-23",), "QFN-32", None),
+        (("SOT-23", "23\\n"), "SOT-23\n", 0),
+        ((), "QFN-32", None),
+    ],
+)
+def test_find_correction_preserves_cpl_match_precedence(
+    data: ModuleType,
+    patterns: tuple[str, ...],
+    value: str,
+    expected: Optional[int],  # noqa: UP045
+) -> None:
+    """Suffix preference and stable ties must not become a new ranking policy."""
+    corrections = tuple(
+        data.Correction(pattern, index * 90, (index, -index))
+        for index, pattern in enumerate(patterns)
+    )
+    selected = data.find_correction(corrections, value)
+    assert selected is (None if expected is None else corrections[expected])
+
+
+@pytest.mark.parametrize("container", [tuple, list])
+@pytest.mark.parametrize(
+    ("patterns", "reference", "value", "footprint", "expected", "source"),
+    [
+        (("SOT-23-3", "VALUE", "R"), "R1", "VALUE", "SOT-23-3", 2, "ref"),
+        (("SOT-23-3", "VAL"), "R1", "VALUE", "SOT-23-3", 1, "val"),
+        (("SOT-23", "SOT-23-3"), "R1", "VALUE", "SOT-23-3", 1, "fpt"),
+        (("R", "R12", "VALUE"), "R12", "VALUE", "SOT-23-3", 1, "ref"),
+        (("VAL", "VALUE"), "R12", "VALUE", "SOT-23-3", 1, "val"),
+        (("1", "R1", "VALUE"), "R1", "VALUE", "SOT-23-3", 0, "ref"),
+        (("R1", "VALUE", "SOT-23"), "R1", "VALUE", "SOT-23-3", 0, "ref"),
+        (("SOT-23",), "R1", "VALUE", "Package:SOT-23-extra", 0, "fpt"),
+    ],
+)
+def test_match_correction_resolves_one_winner_and_source(
+    data: ModuleType,
+    container: type,
+    patterns: tuple[str, ...],
+    reference: str,
+    value: str,
+    footprint: str,
+    expected: int,
+    source: str,
+) -> None:
+    """Complete each target's passes before trying the next footprint field."""
+    corrections = container(
+        data.Correction(pattern, index * 90, (index, -index))
+        for index, pattern in enumerate(patterns)
+    )
+    match = data.match_correction(corrections, reference, value, footprint)
+    assert match.correction is corrections[expected]
+    assert match.source == source
+
+
+def test_zero_valued_match_still_suppresses_lower_priority_corrections(
+    data: ModuleType,
+) -> None:
+    """Zero is an explicit correction and not the absence of a matching record."""
+    zero = data.Correction("R", 0, (0, 0))
+    nonzero = data.Correction("VALUE", 90, (1, 2))
+    match = data.match_correction((nonzero, zero), "R1", "VALUE", "SOT-23")
+    assert match.correction is zero
+    assert match.source == "ref"
+
+
+@pytest.mark.parametrize("patterns", [(), ("QFN", "U1")])
+def test_no_match_has_no_correction_or_source(
+    data: ModuleType, patterns: tuple[str, ...]
+) -> None:
+    """Missing corrections remain distinct from an explicit zero correction."""
+    corrections = tuple(data.Correction(pattern, 90, (1, 2)) for pattern in patterns)
+    assert data.match_correction(corrections, "R1", "VALUE", "SOT-23") is None
+
+
+def test_match_result_cannot_change_the_selected_value_or_source(
+    data: ModuleType,
+) -> None:
+    """Consumers share an immutable description of the selected correction."""
+    correction = data.Correction("R1", 90, (1, 2))
+    match = data.match_correction((correction,), "R1", "VALUE", "SOT-23")
+    with pytest.raises(FrozenInstanceError):
+        match.correction = data.Correction("VALUE", 180, (3, 4))
+    with pytest.raises(FrozenInstanceError):
+        match.source = "val"
+
+
+@pytest.mark.parametrize(
+    ("reference", "value", "footprint", "expected", "source"),
+    [
+        ("R1", "value", "Package:REVIEW_0599", 599, "fpt"),
+        ("R1", "beforeREVIEW_0599after", "package", 599, "val"),
+        ("R1", "value", "package", None, None),
+    ],
+)
+def test_large_correction_set_never_recompiles_during_matching(
+    data: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    reference: str,
+    value: str,
+    footprint: str,
+    expected: Optional[int],  # noqa: UP045
+    source: Optional[str],  # noqa: UP045
+) -> None:
+    """Retained expressions survive cache eviction for suffix, fallback and misses."""
+    corrections = tuple(
+        data.Correction(f"REVIEW_{index:04d}", index, (0, 0)) for index in range(600)
+    )
+    # CPython renamed the compiler module in 3.11. Count actual compilation,
+    # including the path used by re.search(), rather than only re.compile().
+    compiler = re._compiler if hasattr(re, "_compiler") else re.sre_compile
+    original_compile = compiler.compile
+    compile_requests: list[object] = []
+
+    def record_compile(pattern: object, flags: int = 0) -> re.Pattern[str]:
+        compile_requests.append(pattern)
+        return original_compile(pattern, flags)
+
+    re.purge()
+    with monkeypatch.context() as scoped:
+        scoped.setattr(compiler, "compile", record_compile)
+        for _ in range(2):
+            match = data.match_correction(corrections, reference, value, footprint)
+            if expected is None:
+                assert match is None
+            else:
+                assert match.correction is corrections[expected]
+                assert match.source == source
+    assert len(compile_requests) == 0

--- a/tests/test_corrections_import_export.py
+++ b/tests/test_corrections_import_export.py
@@ -1,0 +1,1554 @@
+"""Regression tests for correction CSV import, persistence, and reopening."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import closing
+from pathlib import Path
+import sqlite3
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.correction_test_support import (
+    fresh_library,
+    make_library,
+    raw_rows,
+    seed_raw,
+)
+from tests.wx_harness import load_correction_modules
+
+
+@pytest.fixture
+def modules() -> Iterator[SimpleNamespace]:
+    """Keep production siblings under one package for the full test lifecycle."""
+    with load_correction_modules() as loaded:
+        yield loaded
+
+
+def reopened_rows(library: Any) -> list[tuple[str, int, tuple[float, float]]]:
+    """Read the complete reopened set and expose its values for legacy fixtures."""
+    corrections = fresh_library(library).get_all_correction_data()
+    assert corrections is not None
+    return [(item.pattern, item.rotation, item.offset) for item in corrections]
+
+
+@pytest.mark.parametrize("overwrite", [False, True], ids=["insert", "overwrite"])
+def test_issue531_rejected_import_preserves_database(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    overwrite: bool,
+) -> None:
+    """The reported 47u value cannot persist or replace an existing rotation."""
+    existing = [("R1", 90, 0.0, 0.0)] if overwrite else []
+    library = make_library(modules.library, tmp_path, existing)
+    original = raw_rows(library)
+    path = tmp_path / "issue531.csv"
+    path.write_text("Pattern,Rotation,Offset X,Offset Y\nR1,47u,0,0\n")
+
+    dialog = manager(modules, library, monkeypatch)
+    dialog.populate_corrections_list = MagicMock(
+        side_effect=library.get_all_correction_data
+    )
+
+    assert dialog._import_corrections(str(path)) is False
+    assert raw_rows(library) == original
+    assert reopened_rows(library) == ([("R1", 90, (0.0, 0.0))] if overwrite else [])
+    dialog.populate_corrections_list.assert_not_called()
+    modules.wx.PostEvent.assert_not_called()
+    message = str(modules.wx.MessageBox.call_args)
+    assert "47u" in message
+    assert "rotation" in message.lower()
+    assert "2" in message
+
+
+class TextControl:
+    """Capture original text and button/label state without native wx."""
+
+    def __init__(self, value: Any = "") -> None:
+        self.value = value
+        self.enabled = True
+        self.tooltip = ""
+        self.bindings = {}
+
+    def Bind(self, event: object, callback: Any) -> None:
+        """Retain bound handlers so tests can exercise the constructor's wiring."""
+        self.bindings[event] = callback
+
+    def SetBitmap(self, _bitmap: object) -> None:
+        """Accept a button bitmap without simulating rendering."""
+
+    def SetBitmapMargins(self, _margins: tuple[int, int]) -> None:
+        """Accept bitmap spacing without simulating rendering."""
+
+    def GetValue(self) -> Any:
+        """Return the exact control value."""
+        return self.value
+
+    def SetValue(self, value: Any) -> None:
+        """Retain the exact supplied control value."""
+        self.value = value
+
+    def SetLabel(self, value: Any) -> None:
+        """Capture a visible diagnostic."""
+        self.value = value
+
+    def SetToolTip(self, value: Any) -> None:
+        """Capture the full diagnostic details."""
+        self.tooltip = value
+
+    def Wrap(self, _width: int) -> None:
+        """Accept the native label wrapping request."""
+
+    def Enable(self, enabled: bool) -> None:
+        """Capture toolbar availability."""
+        self.enabled = enabled
+
+
+class CorrectionList:
+    """Exercise list rebuilding and selection using wx-compatible row methods."""
+
+    def __init__(self) -> None:
+        self.rows = []
+        self.selected = -1
+        self.on_change = None
+        self.columns = []
+
+    def Bind(self, _event: object, callback: Any) -> None:
+        """Exercise the selection handler registered by the real constructor."""
+        self.on_change = lambda: callback(
+            SimpleNamespace(GetItem=lambda: self.selected)
+        )
+
+    def AppendTextColumn(self, label: str, **_kwargs: object) -> None:
+        """Keep the visible column order for constructor assertions."""
+        self.columns.append(label)
+
+    def SetMinSize(self, _size: tuple[int, int]) -> None:
+        """Accept sizing without claiming native layout verification."""
+
+    def DeleteAllItems(self) -> None:
+        """Clear rows and optionally simulate synchronous wx selection events."""
+        self.rows = []
+        self.selected = -1
+        if self.on_change:
+            self.on_change()
+
+    def AppendItem(self, values: list[str]) -> None:
+        """Capture a displayed original correction row."""
+        self.rows.append(values)
+
+    def SelectRow(self, index: int) -> None:
+        """Select a row, optionally dispatching synchronous wx events."""
+        if self.selected != index:
+            self.selected = index
+            if self.on_change:
+                self.on_change()
+
+    def GetSelectedRow(self) -> int:
+        """Return the selected row index or wx.NOT_FOUND."""
+        return self.selected
+
+
+def install_manager_controls(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Provide stateful controls without constructing or replacing the real dialog."""
+    wx = modules.wx
+    for name in ("Bind", "SetAcceleratorTable", "SetSizer", "Layout", "Centre"):
+        monkeypatch.setattr(wx.Dialog, name, MagicMock(), raising=False)
+
+    def init_dialog(_self: Any, *_args: object, **_kwargs: object) -> None:
+        """Allow the real subclass constructor to initialize its own state."""
+
+    def control(*args: object, **kwargs: Any) -> TextControl:
+        """Retain the value supplied to native text, button, and checkbox constructors."""
+        return TextControl(args[2] if len(args) > 2 else kwargs.get("label", ""))
+
+    monkeypatch.setattr(wx.Dialog, "__init__", init_dialog)
+    for name in ("DefaultPosition", "DefaultSize"):
+        monkeypatch.setattr(wx, name, (-1, -1), raising=False)
+    for name in ("StaticText", "TextCtrl", "Button", "CheckBox"):
+        monkeypatch.setattr(wx, name, control, raising=False)
+    for name in (
+        "NewId",
+        "AcceleratorEntry",
+        "AcceleratorTable",
+        "BoxSizer",
+        "StaticBoxSizer",
+    ):
+        monkeypatch.setattr(wx, name, MagicMock(), raising=False)
+    monkeypatch.setattr(wx, "ToolTip", lambda text: text, raising=False)
+    monkeypatch.setattr(wx, "Size", lambda *args: args, raising=False)
+    monkeypatch.setattr(
+        wx.dataview,
+        "DataViewListCtrl",
+        MagicMock(side_effect=lambda *_args, **_kwargs: CorrectionList()),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        modules.corrections, "HighResWxSize", lambda _window, size: size
+    )
+    monkeypatch.setattr(modules.corrections, "loadBitmapScaled", MagicMock())
+    # Prevent automatic CSV detection from reading any real user's plugin data.
+    monkeypatch.setattr(modules.corrections, "PLUGIN_PATH", library.datadir)
+
+
+def manager(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> Any:
+    """Run the real constructor with stateful controls and real event bindings."""
+    install_manager_controls(modules, library, monkeypatch)
+    parent = SimpleNamespace(library=library, scale_factor=1, window=object())
+    return modules.corrections.CorrectionManagerDialog(parent, "")
+
+
+@pytest.fixture
+def setup_manager(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[SimpleNamespace, Any, Any]:
+    """Provide isolated real production imports, SQLite, and captured controls."""
+    library = make_library(modules.library, tmp_path)
+    return modules, library, manager(modules, library, monkeypatch)
+
+
+def set_inputs(
+    dialog: Any,
+    pattern: str = "R1",
+    rotation: str = "90",
+    offset_x: str = "0",
+    offset_y: str = "0",
+) -> None:
+    """Fill fields while preserving the exact caller-provided strings."""
+    for control, value in zip(
+        (dialog.regex, dialog.rotation, dialog.offset_x, dialog.offset_y),
+        (pattern, rotation, offset_x, offset_y),
+    ):
+        control.SetValue(value)
+
+
+def select(dialog: Any, index: int) -> None:
+    """Select through the production handler rather than fabricating identity."""
+    dialog.corrections_list.SelectRow(index)
+
+
+def field_values(dialog: Any) -> tuple[str, str, str, str]:
+    """Read exact editable values for preservation assertions."""
+    return tuple(
+        control.GetValue()
+        for control in (dialog.regex, dialog.rotation, dialog.offset_x, dialog.offset_y)
+    )
+
+
+@pytest.mark.parametrize("position", [0, 1, 2])
+def test_invalid_batch_never_applies_inserts_or_replacements(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path, position: int
+) -> None:
+    """Every invalid-row position leaves the complete database and UI intact."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0.25, -0.5))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    set_inputs(dialog, rotation="unsaved input")
+    original = raw_rows(library)
+    selection = (dialog.selection_db_path, dialog.selected_record.rowid)
+    contents = ["R1,180,1,2", "R2,-90,3,4"]
+    contents.insert(position, "C1,47u,0,0")
+    path = tmp_path / "mixed.csv"
+    path.write_text("Pattern,Rotation,Offset X,Offset Y\n" + "\n".join(contents))
+    assert dialog._import_corrections(path) is False
+    assert raw_rows(library) == original
+    assert (dialog.selection_db_path, dialog.selected_record.rowid) == selection
+    assert field_values(dialog) == ("R1", "unsaved input", "0", "0")
+    assert reopened_rows(library) == [("R1", 90, (0.25, -0.5))]
+    modules.wx.PostEvent.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "contents, expected",
+    [
+        (
+            "Pattern,Rotation,Offset X,Offset Y\nR1,-90,0.125,-0.75\n",
+            [("R1", -90, (0.125, -0.75))],
+        ),
+        ("Footprint pattern,Correction\nR1,90.0\n", [("R1", 90, (0.0, 0.0))]),
+        (
+            '"Footprint pattern", "Correction", "Offset X", "Offset Y"\nR1,90\nR2,180,1.5\n',
+            [("R1", 90, (0.0, 0.0)), ("R2", 180, (1.5, 0.0))],
+        ),
+        (
+            "Offset Y,Rotation,Pattern,Offset X\n-0.4,90,R1,0.12345678901234568\n",
+            [("R1", 90, (0.12345678901234568, -0.4))],
+        ),
+        ('\ufeffPattern,Rotation\r\n"Ω,\\d+",90\r\n', [("Ω,\\d+", 90, (0.0, 0.0))]),
+        ("Pattern,Rotation\nR1,90\nR1,180\n", [("R1", 180, (0.0, 0.0))]),
+    ],
+)
+def test_valid_formats_commit_and_reopen(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    contents: str,
+    expected: list[tuple[str, int, tuple[float, float]]],
+) -> None:
+    """Compatible formats and duplicate policy survive the real import boundary."""
+    modules, library, dialog = setup_manager
+    path = tmp_path / "valid.csv"
+    path.write_text(contents, encoding="utf-8")
+    assert dialog._import_corrections(path) is True
+    assert reopened_rows(library) == expected
+    assert len(dialog.corrections_list.rows) == len(expected)
+    modules.wx.PostEvent.assert_called_once()
+    modules.wx.MessageBox.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        b"",
+        b"Pattern,Rotation\nR1\n",
+        b"Pattern,Rotation\nR1,47u\nR1,90\n",
+        b"Pattern,Rotation\nR1,90,0\n",
+        b"Value,Rotation\nR1,90\n",
+        b"Pattern,Rotation,Correction\nR1,90,90\n",
+        b"Pattern,Rotation,Offset X,Offset Y\nR1,90,,0\n",
+        b"Pattern,Rotation,Offset X,Offset Y\nR1,90,0,NaN\n",
+        b'Pattern,Rotation\n"unterminated,90\n',
+        b"Pattern,Rotation\n\xff,90\n",
+    ],
+)
+def test_malformed_import_is_handled_without_side_effects(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path, contents: bytes
+) -> None:
+    """Formatting, decoding, and field failures preserve storage and UI."""
+    modules, library, dialog = setup_manager
+    path = tmp_path / "invalid.csv"
+    path.write_bytes(contents)
+    assert dialog._import_corrections(path) is False
+    assert raw_rows(library) == []
+    modules.wx.PostEvent.assert_not_called()
+    assert str(path) in str(modules.wx.MessageBox.call_args)
+
+
+@pytest.mark.parametrize("kind", ["missing", "directory"])
+def test_import_read_errors_are_handled(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path, kind: str
+) -> None:
+    """Missing and inaccessible input types receive a useful file error."""
+    modules, library, dialog = setup_manager
+    path = tmp_path / "missing.csv" if kind == "missing" else tmp_path
+    assert dialog._import_corrections(path) is False
+    assert raw_rows(library) == []
+    assert str(path) in str(modules.wx.MessageBox.call_args)
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_header_only_import_preserves_selection(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """A valid empty batch is a successful no-op, preserving active edits."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    before = (raw_rows(library), dialog.selected_record.rowid)
+    path = tmp_path / "header.csv"
+    path.write_text("Pattern,Rotation\n")
+    assert dialog._import_corrections(path) is True
+    assert (raw_rows(library), dialog.selected_record.rowid) == before
+    modules.wx.PostEvent.assert_not_called()
+
+
+def abort_writes(library: Any, trigger: str) -> None:
+    """Install a real SQLite trigger to exercise rollback after preceding writes."""
+    with closing(sqlite3.connect(library.correctionsdb_file)) as connection, connection:
+        connection.execute(trigger)
+
+
+def test_import_database_failure_rolls_back_previous_write(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """A storage failure after a replacement cannot leave a partially imported file."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    original = raw_rows(library)
+    abort_writes(
+        library,
+        "CREATE TRIGGER reject_insert BEFORE INSERT ON correction BEGIN SELECT RAISE(ABORT, 'test failure'); END",
+    )
+    path = tmp_path / "failure.csv"
+    path.write_text("Pattern,Rotation\nR1,180\nR2,90\n")
+    assert dialog._import_corrections(path) is False
+    assert raw_rows(library) == original
+    modules.wx.PostEvent.assert_not_called()
+    assert "test failure" in str(modules.wx.MessageBox.call_args)
+
+
+@pytest.mark.parametrize(
+    "method", ["import_corrections_dialog", "export_corrections_dialog"]
+)
+def test_file_dialog_cancellation_changes_nothing(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+) -> None:
+    """Canceling either file picker cannot touch storage or emit completion."""
+    modules, library, dialog = setup_manager
+    picker = MagicMock()
+    picker.__enter__.return_value = picker
+    picker.ShowModal.return_value = modules.wx.ID_CANCEL
+    monkeypatch.setattr(
+        modules.wx, "FileDialog", MagicMock(return_value=picker), raising=False
+    )
+    assert getattr(dialog, method)() is False
+    picker.GetPath.assert_not_called()
+    assert raw_rows(library) == []
+    modules.wx.PostEvent.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [("R1", "47u", 0, 0)],
+        [("R1", 90, "NaN", 0)],
+        [("[", 90, 0, 0)],
+        [(None, None, None, None)],
+        [("R1", 90, 0, 0), ("R1", 180, 0, 0)],
+    ],
+)
+def test_recovery_displays_every_original_row(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rows: list[tuple[Any, ...]],
+) -> None:
+    """Invalid and conflicting rows remain visible, selectable, and diagnosed."""
+    library = make_library(modules.library, tmp_path, rows)
+    dialog = manager(modules, library, monkeypatch)
+    for index, record in enumerate(library.read_correction_data().rows):
+        expected = tuple(map(str, (record.pattern, record.rotation, *record.offset)))
+        if rows == [("R1", 90, 0, 0), ("R1", 180, 0, 0)]:
+            expected = ("R1", "90" if index == 0 else "180", "0.0", "0.0")
+        assert dialog.corrections_list.rows[index][:4] == list(expected)
+        assert dialog.corrections_list.rows[index][4]
+        select(dialog, index)
+        assert field_values(dialog) == expected
+        assert dialog.selected_record.rowid == record.rowid
+        assert dialog.selection_db_path == library.correctionsdb_file
+    assert "need repair" in dialog.correction_status.value
+    assert "blocked" in dialog.correction_status.value
+    assert dialog.correction_status.tooltip
+    modules.wx.MessageBox.assert_not_called()
+
+
+def test_missing_schema_is_visible_and_accessible(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Storage errors appear in the manager even without any readable rows."""
+    modules, library, dialog = setup_manager
+    abort_writes(library, "DROP TABLE correction")
+    dialog.populate_corrections_list()
+    assert dialog.corrections_list.rows == []
+    assert "database" in dialog.correction_status.value
+    assert library.correctionsdb_file in dialog.correction_status.value
+    assert "Select a row" not in dialog.correction_status.value
+    assert dialog.selected_record is None
+    assert dialog.delete_button.enabled is False
+    modules.wx.MessageBox.assert_not_called()
+
+
+def write_rotation_archive(path: str, pattern: str = "ARCHIVED") -> None:
+    """Create a legacy archive independently of the migration implementation."""
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute("CREATE TABLE rotation (regex, rotation)")
+        connection.execute("INSERT INTO rotation VALUES (?, 180)", (pattern,))
+
+
+def test_manager_open_retries_global_archive_once_and_refresh_only_reads(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opening the real manager imports a waiting archive without refresh retries."""
+    library = make_library(modules.library, tmp_path, [("EXISTING", 90, 0, 0)])
+    write_rotation_archive(library.rotationsdb_file)
+    inspect_archive = MagicMock(wraps=library._legacy_rotation_rows)
+    retry_migrations = MagicMock(wraps=library.retry_correction_migrations)
+    monkeypatch.setattr(library, "_legacy_rotation_rows", inspect_archive)
+    monkeypatch.setattr(library, "retry_correction_migrations", retry_migrations)
+
+    dialog = manager(modules, library, monkeypatch)
+
+    assert {row[1] for row in raw_rows(library)} == {"EXISTING", "ARCHIVED"}
+    assert dialog.correction_snapshot.corrections is not None
+    retry_migrations.assert_called_once_with()
+    archive_reads = inspect_archive.call_count
+    assert archive_reads > 0
+    for _ in range(3):
+        dialog.populate_corrections_list()
+    assert inspect_archive.call_count == archive_reads
+    retry_migrations.assert_called_once_with()
+    assert reopened_rows(library) == [
+        ("ARCHIVED", 180, (0.0, 0.0)),
+        ("EXISTING", 90, (0.0, 0.0)),
+    ]
+    modules.wx.MessageBox.assert_not_called()
+
+
+def test_manager_open_keeps_local_scope_isolated_from_archives(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An active local editor never attempts migration of inactive global archives."""
+    library = make_library(modules.library, tmp_path, [("LOCAL", 90, 0, 0)], local=True)
+    Path(library.rotationsdb_file).write_bytes(b"unreadable archive")
+    inspect_archive = MagicMock(wraps=library._legacy_rotation_rows)
+    retry_migrations = MagicMock(wraps=library.retry_correction_migrations)
+    monkeypatch.setattr(library, "_legacy_rotation_rows", inspect_archive)
+    monkeypatch.setattr(library, "retry_correction_migrations", retry_migrations)
+
+    dialog = manager(modules, library, monkeypatch)
+    dialog.populate_corrections_list()
+
+    inspect_archive.assert_not_called()
+    retry_migrations.assert_not_called()
+    assert dialog.global_corrections.GetValue() is False
+    assert dialog.correction_snapshot.scope == "local"
+    assert dialog.correction_snapshot.corrections is not None
+    assert "archive" not in dialog.correction_status.value
+    assert raw_rows(library)[0][1:] == ("LOCAL", 90, 0.0, 0.0)
+
+
+def test_unknown_archive_warnings_allow_export_and_reopening_retries(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warnings identify every unknown file and the advertised reopen action works."""
+    library = make_library(modules.library, tmp_path, [("EXISTING", 90, 0, 0)])
+    for path in (library.rotationsdb_file, library.partsdb_file):
+        Path(path).write_bytes(b"not an SQLite archive")
+
+    dialog = manager(modules, library, monkeypatch)
+
+    assert dialog.correction_snapshot.corrections is not None
+    assert dialog.correction_snapshot.issues == ()
+    assert len(dialog.correction_snapshot.warnings) == 2
+    for path in (library.rotationsdb_file, library.partsdb_file):
+        assert path in dialog.correction_status.value
+        assert path in dialog.correction_status.tooltip
+    assert "reopen Corrections Manager to retry" in dialog.correction_status.value
+    assert "Select a row" not in dialog.correction_status.value
+    assert "blocked" not in dialog.correction_status.value
+    export_path = tmp_path / "healthy.csv"
+    assert dialog._export_corrections(export_path) is True
+    assert "EXISTING" in export_path.read_text()
+
+    for path, pattern in (
+        (library.rotationsdb_file, "ROTATIONS"),
+        (library.partsdb_file, "PARTS"),
+    ):
+        Path(path).unlink()
+        write_rotation_archive(path, pattern)
+    dialog.populate_corrections_list()
+    assert len(dialog.correction_snapshot.warnings) == 2
+    assert [row[1] for row in raw_rows(library)] == ["EXISTING"]
+
+    reopened = manager(modules, fresh_library(library), monkeypatch)
+
+    assert reopened.correction_snapshot.warnings == ()
+    assert reopened.correction_snapshot.corrections is not None
+    assert {row.pattern for row in reopened.correction_snapshot.rows} == {
+        "EXISTING",
+        "ROTATIONS",
+        "PARTS",
+    }
+    modules.wx.MessageBox.assert_not_called()
+
+
+def test_known_failed_transfer_has_file_retry_help_without_row_repair(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed copy remains blocking until the stated reopen action succeeds."""
+    library = make_library(modules.library, tmp_path, [("EXISTING", 90, 0, 0)])
+    write_rotation_archive(library.rotationsdb_file)
+    abort_writes(
+        library,
+        "CREATE TRIGGER reject_insert BEFORE INSERT ON correction "
+        "BEGIN SELECT RAISE(ABORT, 'storage failure'); END",
+    )
+
+    dialog = manager(modules, library, monkeypatch)
+
+    assert dialog.correction_snapshot.corrections is None
+    assert "blocked" in dialog.correction_status.value
+    assert library.rotationsdb_file in dialog.correction_status.value
+    for details in (dialog.correction_status.value, dialog.correction_status.tooltip):
+        assert library.globalcorrectionsdb_file in details
+        assert "storage failure" in details
+    assert "reopen Corrections Manager to retry" in dialog.correction_status.value
+    assert "Select a row" not in dialog.correction_status.value
+    assert [row[1] for row in raw_rows(library)] == ["EXISTING"]
+    export_path = tmp_path / "previous.csv"
+    export_path.write_text("previous valid export")
+    assert dialog._export_corrections(export_path) is False
+    assert export_path.read_text() == "previous valid export"
+
+    abort_writes(library, "DROP TRIGGER reject_insert")
+    dialog.populate_corrections_list()
+    assert dialog.correction_snapshot.corrections is None
+    reopened = manager(modules, fresh_library(library), monkeypatch)
+    assert reopened.correction_snapshot.corrections is not None
+    assert reopened.correction_snapshot.issues == ()
+    assert {row[1] for row in raw_rows(library)} == {"EXISTING", "ARCHIVED"}
+
+
+def test_manager_stays_accessible_after_initial_download_preparation_read_fails(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Storage failing after the migration step cannot prevent opening recovery."""
+    library = make_library(modules.library, tmp_path)
+    monkeypatch.setattr(
+        library,
+        "_initial_seed_is_eligible",
+        MagicMock(side_effect=sqlite3.OperationalError("seed-state unavailable")),
+    )
+
+    dialog = manager(modules, library, monkeypatch)
+
+    assert library.globalcorrectionsdb_file in dialog.correction_status.value
+    assert "seed-state unavailable" in dialog.correction_status.value
+    assert "reopen Corrections Manager to retry" in dialog.correction_status.value
+    assert "Select a row" not in dialog.correction_status.value
+    assert dialog.global_corrections.GetValue() is True
+    assert dialog.correction_snapshot.corrections == ()
+    assert "blocked" not in dialog.correction_status.value
+    modules.wx.MessageBox.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("rotation", "47u"),
+        ("rotation", "90.5"),
+        ("offset_x", "NaN"),
+        ("offset_y", "wrong"),
+        ("regex", "["),
+    ],
+)
+def test_invalid_manual_save_preserves_inputs_and_record(
+    setup_manager: tuple[SimpleNamespace, Any, Any], field: str, value: Any
+) -> None:
+    """Manual entry shares strict validation and never defaults or truncates input."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    getattr(dialog, field).SetValue(value)
+    original = raw_rows(library)
+    inputs = field_values(dialog)
+    assert dialog.save_correction() is False
+    assert raw_rows(library) == original
+    assert field_values(dialog) == inputs
+    assert value in str(modules.wx.MessageBox.call_args)
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_repair_invalid_row_clears_warning_and_survives_reopening(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful precise repair restores a completely valid correction set."""
+    library = make_library(modules.library, tmp_path, [("R1", "47u", 0, 0)])
+    dialog = manager(modules, library, monkeypatch)
+    select(dialog, 0)
+    rowid = dialog.selected_record.rowid
+    dialog.rotation.SetValue("-90.0")
+    assert dialog.save_correction() is True
+    assert raw_rows(library) == [(rowid, "R1", -90, 0.0, 0.0)]
+    assert reopened_rows(library) == [("R1", -90, (0, 0))]
+    assert "need repair" not in dialog.correction_status.value
+    assert dialog.selected_record.rowid == rowid
+    reopened = manager(modules, fresh_library(library), monkeypatch)
+    select(reopened, 0)
+    assert field_values(reopened) == ("R1", "-90", "0.0", "0.0")
+    assert "need repair" not in reopened.correction_status.value
+    modules.wx.PostEvent.assert_called_once()
+
+
+def test_repair_one_of_multiple_invalid_rows_retains_warning(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repairing one bad row does not hide another unresolved row."""
+    library = make_library(
+        modules.library, tmp_path, [("R1", "47u", 0, 0), ("R2", "bad", 0, 0)]
+    )
+    dialog = manager(modules, library, monkeypatch)
+    select(dialog, 0)
+    dialog.rotation.SetValue("90")
+    assert dialog.save_correction() is True
+    assert "need repair" in dialog.correction_status.value
+    assert len(fresh_library(library).read_correction_data().issues) == 1
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [(None, "47u", 0, 0), (None, "bad", 0, 0)],
+        [("R1", "47u", 0, 0), ("R1", 90, 0, 0)],
+    ],
+)
+def test_deletion_targets_exact_null_or_duplicate_row(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rows: list[tuple[Any, ...]],
+) -> None:
+    """Deletion uses stored identity rather than a null or duplicated pattern."""
+    library = make_library(modules.library, tmp_path, rows)
+    dialog = manager(modules, library, monkeypatch)
+    select(dialog, 0)
+    rowid = dialog.selected_record.rowid
+    expected = [row for row in raw_rows(library) if row[0] != rowid]
+    assert dialog.delete_correction() is True
+    assert raw_rows(library) == expected
+    assert dialog.selected_record is None
+    modules.wx.PostEvent.assert_called_once()
+
+
+def test_list_refresh_keeps_selection_despite_native_events(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """A dirty refresh retains the record, leaving a fresh row selectable by click."""
+    _modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    rowid = dialog.selected_record.rowid
+    set_inputs(dialog, rotation="unsaved")
+    dialog.populate_corrections_list()
+    assert dialog.selected_record.rowid == rowid
+    assert dialog.rotation.GetValue() == "unsaved"
+    assert dialog.corrections_list.GetSelectedRow() == -1
+    assert dialog.delete_button.enabled is False
+
+
+@pytest.mark.parametrize("operation", ["save_correction", "delete_correction"])
+def test_stale_selection_cannot_modify_different_active_database(
+    setup_manager: tuple[SimpleNamespace, Any, Any], operation: str
+) -> None:
+    """A rowid must never be reused after the active database path changes."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    original = raw_rows(library)
+    library.create_correction_table(library.localcorrectionsdb_file)
+    library.insert_correction_data(
+        "UNRELATED", 180, (0, 0), db_path=library.localcorrectionsdb_file
+    )
+    library.correctionsdb_file = library.localcorrectionsdb_file
+    other = raw_rows(library)
+    assert getattr(dialog, operation)() is False
+    assert raw_rows(library) == other
+    modules.wx.PostEvent.assert_not_called()
+    assert "database changed" in str(modules.wx.MessageBox.call_args)
+    select(dialog, 0)
+    assert field_values(dialog) == ("UNRELATED", "180", "0.0", "0.0")
+    assert getattr(dialog, operation)() is True
+    library.correctionsdb_file = library.globalcorrectionsdb_file
+    assert raw_rows(library) == original
+
+
+@pytest.mark.parametrize("operation", ["save_correction", "delete_correction"])
+@pytest.mark.parametrize("change", ["deleted", "reused", "edited"])
+@pytest.mark.parametrize(
+    "dirty, refresh", [(False, False), (True, False), (True, True)]
+)
+def test_stale_selection_preserves_concurrent_data_and_unsaved_inputs(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    operation: str,
+    change: str,
+    dirty: bool,
+    refresh: bool,
+) -> None:
+    """A stale editor cannot modify another writer's row, even after list refresh."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    if dirty:
+        set_inputs(dialog, rotation="270", offset_x="1.25")
+    if change == "edited":
+        library.update_correction_data("R1", 180, (3, 4))
+    else:
+        library.delete_correction_row(dialog.selected_record.rowid)
+        if change == "reused":
+            library.insert_correction_data("UNRELATED", 180, (3, 4))
+    before = raw_rows(library)
+    entered = field_values(dialog)
+    if refresh:
+        dialog.populate_corrections_list()
+
+    assert getattr(dialog, operation)() is False
+    assert raw_rows(library) == before
+    assert field_values(dialog) == entered
+    assert modules.wx.MessageBox.call_args.args[0]
+    modules.wx.PostEvent.assert_not_called()
+    if before:
+        assert dialog.corrections_list.GetSelectedRow() == -1
+        select(dialog, 0)
+        assert field_values(dialog) == (before[0][1], "180", "3.0", "4.0")
+        assert getattr(dialog, operation)() is True
+
+
+@pytest.mark.parametrize("selected", [False, True])
+@pytest.mark.parametrize("change", ["edited", "deleted", "reused", "added"])
+def test_replacement_confirmation_cannot_approve_concurrent_changes(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    selected: bool,
+    change: str,
+) -> None:
+    """Confirmation authorizes exactly the raw records displayed in the prompt."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("A", 90, (0, 0))
+    library.insert_correction_data("B", 180, (1, 2))
+    dialog.populate_corrections_list()
+    if selected:
+        select(dialog, 0)
+    set_inputs(dialog, "B", "270", "3", "4")
+    before = []
+
+    def confirm(_correction: Any, conflicts: Any) -> bool:
+        assert [(row.pattern, row.rotation) for row in conflicts] == [("B", 180)]
+        if change == "edited":
+            library.update_correction_data("B", -90, (1, 2))
+        elif change == "added":
+            seed_raw(library, [("B", 0, 0, 0)])
+        else:
+            library.delete_correction_row(conflicts[0].rowid)
+            if change == "reused":
+                library.insert_correction_data("B", -90, (1, 2))
+        before.extend(raw_rows(library))
+        return True
+
+    monkeypatch.setattr(dialog, "_confirm_replacement", confirm)
+    assert dialog.save_correction() is False
+    assert raw_rows(library) == before
+    assert field_values(dialog) == ("B", "270", "3", "4")
+    modules.wx.PostEvent.assert_not_called()
+    assert modules.wx.MessageBox.call_args.args[0]
+
+
+def test_duplicate_replacement_cancel_preserves_every_value(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Declining replacement leaves the selected row and target untouched."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("A", 90, (0, 0))
+    library.insert_correction_data("B", 180, (1, 2))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    set_inputs(dialog, "B", "270.0", "1.25", "-3")
+    original = raw_rows(library)
+    inputs = field_values(dialog)
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_NO
+    assert dialog.save_correction() is False
+    assert raw_rows(library) == original
+    assert field_values(dialog) == inputs
+    assert "180°" in modules.wx.MessageDialog.return_value.ExtendedMessage
+    modules.wx.PostEvent.assert_not_called()
+    modules.wx.MessageDialog.return_value.Destroy.assert_called_once()
+
+
+def test_confirmed_replacement_commits_exact_selected_row(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Confirmed rename/replacement preserves row identity and replaces its collision."""
+    modules, library, dialog = setup_manager
+    for pattern, rotation in (("A", 90), ("B", 180), ("Z", 270)):
+        library.insert_correction_data(pattern, rotation, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    rowid = dialog.selected_record.rowid
+    set_inputs(dialog, "B", "-90", "0.125", "-0.75")
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    assert dialog.save_correction() is True
+    assert raw_rows(library) == [
+        (rowid, "B", -90, 0.125, -0.75),
+        (3, "Z", 270, 0.0, 0.0),
+    ]
+    assert "180°" in modules.wx.MessageDialog.return_value.ExtendedMessage
+    assert "270°" not in modules.wx.MessageDialog.return_value.ExtendedMessage
+    assert dialog.selected_record.rowid == rowid
+    modules.wx.PostEvent.assert_called_once()
+
+
+def test_replacement_failure_restores_both_records(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """A failed update rolls back the confirmed deletion of a conflicting row."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("A", 90, (0, 0))
+    library.insert_correction_data("B", 180, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    set_inputs(dialog, "B", "-90")
+    original = raw_rows(library)
+    abort_writes(
+        library,
+        "CREATE TRIGGER reject_update BEFORE UPDATE ON correction BEGIN SELECT RAISE(ABORT, 'test failure'); END",
+    )
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    assert dialog.save_correction() is False
+    assert raw_rows(library) == original
+    assert field_values(dialog) == ("B", "-90", "0", "0")
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_identical_existing_manual_rule_selects_without_writing(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Entering an identical existing correction keeps the historical selection behavior."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    set_inputs(dialog)
+    before = raw_rows(library)
+    assert dialog.save_correction() is True
+    assert raw_rows(library) == before
+    assert dialog.selected_record.rowid == before[0][0]
+    modules.wx.MessageDialog.assert_not_called()
+    modules.wx.PostEvent.assert_not_called()
+
+
+def legacy_csv(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    contents: str = "Pattern,Rotation\nR1,90\n",
+) -> Path:
+    """Place a legacy source only in this test's plugin directory."""
+    plugin = tmp_path / "plugin"
+    directory = plugin / "corrections"
+    directory.mkdir(parents=True)
+    path = directory / "cpl_rotations_db.csv"
+    path.write_text(contents)
+    monkeypatch.setattr(modules.corrections, "PLUGIN_PATH", str(plugin))
+    return path
+
+
+def test_legacy_success_marks_and_archives_after_commit(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Archival follows successful persistence and refresh waits for constructed controls."""
+    modules, library, dialog = setup_manager
+    path = legacy_csv(modules, tmp_path, monkeypatch)
+    original = path.read_bytes()
+    key = library.correction_csv_migration_key(path, original)
+    assert dialog.import_legacy_corrections() is True
+    assert fresh_library(library).has_correction_migration(key) is True
+    assert reopened_rows(library) == [("R1", 90, (0, 0))]
+    assert not path.exists()
+    assert path.with_suffix(".csv.backup").read_bytes() == original
+    assert dialog.corrections_list.rows == []
+    modules.wx.PostEvent.assert_called_once()
+    modules.wx.MessageBox.assert_not_called()
+
+
+@pytest.mark.parametrize("archive_problem", ["collision", "link_error", "unlink_error"])
+def test_archive_failure_never_replays_over_repairs(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_problem: Any,
+) -> None:
+    """Committed content provenance suppresses replay when the source remains in place."""
+    modules, library, dialog = setup_manager
+    path = legacy_csv(modules, tmp_path, monkeypatch)
+    backup = path.with_suffix(".csv.backup")
+    if archive_problem == "collision":
+        backup.write_bytes(b"existing archive")
+    else:
+        operation = "link" if archive_problem == "link_error" else "unlink"
+        monkeypatch.setattr(
+            modules.corrections.os,
+            operation,
+            MagicMock(side_effect=PermissionError("archive denied")),
+        )
+    assert dialog.import_legacy_corrections() is True
+    assert path.exists()
+    if archive_problem == "collision":
+        assert backup.read_bytes() == b"existing archive"
+    library.update_correction_data("R1", 180, (1, 2))
+    repaired = raw_rows(library)
+    modules.wx.PostEvent.reset_mock()
+    dialog.parent.library = fresh_library(library)
+    assert dialog.import_legacy_corrections() is True
+    assert raw_rows(library) == repaired
+    modules.wx.PostEvent.assert_not_called()
+    assert "imported successfully" in str(modules.wx.MessageBox.call_args)
+    assert "will not be imported again" in str(modules.wx.MessageBox.call_args)
+
+
+def test_legacy_completion_survives_scope_switch(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A remaining global legacy CSV cannot replay over subsequent local repairs."""
+    modules, library, dialog = setup_manager
+    path = legacy_csv(modules, tmp_path, monkeypatch)
+    path.with_suffix(".csv.backup").write_bytes(b"old archive")
+    assert dialog.import_legacy_corrections() is True
+    library.switch_to_global_correction_database(False)
+    library.update_correction_data("R1", 180, (1, 2))
+    repaired = raw_rows(library)
+    dialog.parent.library = fresh_library(library)
+    assert dialog.import_legacy_corrections() is True
+    assert raw_rows(library) == repaired
+
+
+def test_changed_legacy_contents_can_be_imported_once(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Content changes distinguish corrected/new automatic inputs from completed ones."""
+    modules, library, dialog = setup_manager
+    path = legacy_csv(modules, tmp_path, monkeypatch)
+    path.with_suffix(".csv.backup").write_bytes(b"old archive")
+    assert dialog.import_legacy_corrections() is True
+    path.write_text("Pattern,Rotation\nR1,180\n")
+    assert dialog.import_legacy_corrections() is True
+    assert reopened_rows(library) == [("R1", 180, (0, 0))]
+
+
+@pytest.mark.parametrize("failure", ["invalid", "decoding", "read", "storage"])
+def test_legacy_failure_preserves_source_for_retry(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    """Failed legacy imports retain exact unmarked input for repair and retry."""
+    modules, library, dialog = setup_manager
+    path = legacy_csv(modules, tmp_path, monkeypatch)
+    if failure == "invalid":
+        path.write_text("Pattern,Rotation\nR1,47u\n")
+    elif failure == "decoding":
+        path.write_bytes(b"\xff")
+    elif failure == "read":
+        monkeypatch.setattr(
+            modules.corrections,
+            "open",
+            MagicMock(side_effect=PermissionError("denied")),
+            raising=False,
+        )
+    else:
+        abort_writes(
+            library,
+            "CREATE TRIGGER reject_insert BEFORE INSERT ON correction BEGIN SELECT RAISE(ABORT, 'storage failure'); END",
+        )
+    before = path.read_bytes()
+    assert dialog.import_legacy_corrections() is False
+    assert path.read_bytes() == before
+    assert not path.with_suffix(".csv.backup").exists()
+    assert raw_rows(library) == []
+    assert not library.has_correction_migration(
+        library.correction_csv_migration_key(path, path.read_bytes())
+    )
+    modules.wx.PostEvent.assert_not_called()
+    if failure == "invalid":
+        path.write_text("Pattern,Rotation\nR1,90\n")
+        assert dialog.import_legacy_corrections() is True
+        assert reopened_rows(library) == [("R1", 90, (0, 0))]
+
+
+def test_manager_constructor_imports_only_after_controls_exist(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real constructor can import legacy input without touching uncreated widgets."""
+    modules, library, _dialog = setup_manager
+    legacy_csv(modules, tmp_path, monkeypatch)
+    parent = SimpleNamespace(library=library, scale_factor=1, window=object())
+    dialog = modules.corrections.CorrectionManagerDialog(parent, "R1")
+    assert len(dialog.corrections_list.rows) == 1
+    assert dialog.corrections_list.rows == [["R1", "90", "0.0", "0.0", ""]]
+    assert (
+        modules.wx.dataview.DataViewListCtrl.call_args.kwargs["style"]
+        == modules.wx.dataview.DV_SINGLE
+    )
+    assert dialog.corrections_list.columns == [
+        "Regex",
+        "Rotation",
+        "Offset X",
+        "Offset Y",
+        "Status",
+    ]
+    assert dialog.global_corrections.GetValue() is True
+    select(dialog, 0)
+    assert field_values(dialog) == ("R1", "90", "0.0", "0.0")
+    assert dialog.delete_button.enabled is True
+    modules.wx.PostEvent.assert_called_once()
+    assert raw_rows(library)[0][1:3] == ("R1", 90)
+
+
+@pytest.mark.parametrize("kind", ["invalid", "conflicting", "schema"])
+def test_export_errors_leave_existing_bytes_unchanged(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path, kind: str
+) -> None:
+    """No correction export opens its destination until the snapshot fully validates."""
+    modules, library, dialog = setup_manager
+    if kind == "invalid":
+        seed_raw(library, [("R1", "47u", 0, 0)])
+    elif kind == "conflicting":
+        seed_raw(library, [("R1", 90, 0, 0), ("R1", 180, 0, 0)])
+    else:
+        abort_writes(library, "DROP TABLE correction")
+    path = tmp_path / "existing.csv"
+    path.write_bytes(b"previous export\x00\xff")
+    assert dialog._export_corrections(path) is False
+    assert path.read_bytes() == b"previous export\x00\xff"
+    assert str(path) in str(modules.wx.MessageBox.call_args)
+
+
+def test_export_and_import_preserve_quoted_unicode_and_precision(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """CSV round trips preserve literal patterns, numeric precision, and whole rotations."""
+    modules, library, dialog = setup_manager
+    pattern = 'Ω,"O\'Brien"\\d+'
+    library.insert_correction_data(pattern, -90, (0.12345678901234568, -1.25))
+    path = tmp_path / "roundtrip.csv"
+    assert dialog._export_corrections(path) is True
+    assert path.read_text().startswith('"Pattern","Rotation","Offset X","Offset Y"')
+    destination = make_library(modules.library, tmp_path / "reimport")
+    dialog.parent.library = destination
+    assert dialog._import_corrections(path) is True
+    assert reopened_rows(destination) == reopened_rows(library)
+
+
+def test_export_open_failure_is_actionable(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """An unwritable destination becomes a handled file-specific error."""
+    modules, _library, dialog = setup_manager
+    assert dialog._export_corrections(tmp_path) is False
+    assert str(tmp_path) in str(modules.wx.MessageBox.call_args)
+
+
+@pytest.mark.parametrize("confirmation", ["ID_NO", "ID_CANCEL"])
+def test_scope_cancellation_restores_checkbox(
+    setup_manager: tuple[SimpleNamespace, Any, Any], confirmation: str
+) -> None:
+    """Any unconfirmed scope change restores the active scope without refresh."""
+    modules, library, dialog = setup_manager
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = getattr(
+        modules.wx, confirmation
+    )
+    dialog.global_corrections.SetValue(False)
+    assert dialog.on_global_corrections_changed() is False
+    assert dialog.global_corrections.GetValue() is True
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_invalid_scope_switch_keeps_active_data_and_selection(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Rejected scope transfers preserve the source and native checkbox state."""
+    modules, library, dialog = setup_manager
+    seed_raw(library, [("R1", "47u", 0, 0)])
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    before = (raw_rows(library), dialog.selected_record.rowid)
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    dialog.global_corrections.SetValue(False)
+    assert dialog.on_global_corrections_changed() is False
+    assert dialog.global_corrections.GetValue() is True
+    assert (raw_rows(library), dialog.selected_record.rowid) == before
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    modules.wx.PostEvent.assert_not_called()
+
+
+def test_scope_checkbox_uses_active_path_even_if_other_database_appears(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Existing inactive tables cannot change the checkbox's interpretation of scope."""
+    modules, library, dialog = setup_manager
+    library.create_correction_table(library.localcorrectionsdb_file)
+    library.insert_correction_data(
+        "UNRELATED", 180, (0, 0), db_path=library.localcorrectionsdb_file
+    )
+    assert library.uses_global_correction_database() is False
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_NO
+    assert dialog.on_global_corrections_changed() is False
+    assert dialog.global_corrections.GetValue() is True
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+
+
+def test_successful_scope_switch_clears_selection_and_refreshes(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """A successful copy clears global row identity before showing local data."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    assert dialog.on_global_corrections_changed() is True
+    assert dialog.selected_record is None
+    assert dialog.selection_db_path is None
+    assert dialog.global_corrections.GetValue() is False
+    assert dialog.correction_snapshot.scope == "local"
+    assert reopened_rows(library) == [("R1", 90, (0, 0))]
+    modules.wx.PostEvent.assert_called_once()
+
+
+@pytest.mark.parametrize("bad", [False, True])
+def test_remote_update_refreshes_only_after_success(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    bad: bool,
+) -> None:
+    """The real HTTP ingestion path controls whether the manager posts a refresh."""
+    modules, library, dialog = setup_manager
+    response = MagicMock()
+    response.text = "Pattern,Rotation\nR1," + ("47u" if bad else "90") + "\n"
+    monkeypatch.setattr(
+        modules.library.requests, "get", MagicMock(return_value=response)
+    )
+    assert dialog.download_correction_data() is not bad
+    events = [call.args[1] for call in modules.wx.PostEvent.call_args_list]
+    refreshes = [
+        event
+        for event in events
+        if isinstance(event, modules.corrections.PopulateFootprintListEvent)
+    ]
+    assert len(refreshes) == (0 if bad else 1)
+    assert len(raw_rows(library)) == (0 if bad else 1)
+    assert len(dialog.corrections_list.rows) == (0 if bad else 1)
+
+
+@pytest.mark.parametrize("dirty", [False, True])
+def test_selected_import_refreshes_clean_inputs_and_preserves_unsaved_edits(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path, dirty: bool
+) -> None:
+    """Import refresh respects edits and never authorizes a stale save of its replacement."""
+    _modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    rowid = dialog.selected_record.rowid
+    if dirty:
+        dialog.rotation.SetValue("270")
+    entered = field_values(dialog)
+    path = tmp_path / "overwrite.csv"
+    path.write_text("Pattern,Rotation,Offset X,Offset Y\nR1,180,1,2\n")
+    assert dialog._import_corrections(path) is True
+    assert dialog.selected_record.rowid == rowid
+    assert reopened_rows(library) == [("R1", 180, (1, 2))]
+    for _ in range(2):
+        assert field_values(dialog) == (
+            entered if dirty else ("R1", "180", "1.0", "2.0")
+        )
+        dialog.populate_corrections_list()
+    assert dialog.save_correction() is not dirty
+    select(dialog, 0)
+    assert field_values(dialog) == ("R1", "180", "1.0", "2.0")
+    assert dialog.save_correction() is True
+    assert reopened_rows(library) == [("R1", 180, (1, 2))]
+
+
+@pytest.mark.parametrize("dirty", [False, True])
+def test_refresh_updates_only_untouched_selected_inputs(
+    setup_manager: tuple[SimpleNamespace, Any, Any], dirty: bool
+) -> None:
+    """Repeated refreshes keep clean fields current and preserve actual unsaved edits."""
+    _modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    original = field_values(dialog)
+    if dirty:
+        dialog.rotation.SetValue("270")
+        original = field_values(dialog)
+    for rotation in (180, -90):
+        library.update_correction_data("R1", rotation, (1, 2))
+        dialog.populate_corrections_list()
+        assert field_values(dialog) == (
+            original if dirty else ("R1", str(rotation), "1.0", "2.0")
+        )
+    assert dialog.save_correction() is not dirty
+    assert reopened_rows(library) == [("R1", -90, (1, 2))]
+    if dirty:
+        select(dialog, 0)
+    library.update_correction_data("R1", 180, (3, 4))
+    dialog.populate_corrections_list()
+    assert field_values(dialog) == ("R1", "180", "3.0", "4.0")
+
+
+def test_remote_refresh_synchronizes_clean_selection_after_external_update(
+    setup_manager: tuple[SimpleNamespace, Any, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Successful remote refresh also shows committed same-path updates in untouched fields."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+
+    # The remote policy keeps existing values. Simulate another writer changing
+    # the selected rule while the HTTP request is in progress.
+    def remote_response(*_args: Any, **_kwargs: Any) -> MagicMock:
+        library.update_correction_data("R1", 180, (1, 2))
+        response = MagicMock()
+        response.text = "Pattern,Rotation\nR2,90\n"
+        return response
+
+    monkeypatch.setattr(modules.library.requests, "get", remote_response)
+    assert dialog.download_correction_data() is True
+    assert field_values(dialog) == ("R1", "180", "1.0", "2.0")
+    assert dialog.save_correction() is True
+    assert reopened_rows(library) == [
+        ("R1", 180, (1, 2)),
+        ("R2", 90, (0, 0)),
+    ]
+
+
+def test_switch_to_global_warns_that_project_corrections_are_discarded(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """A scope change must disclose the loss of project-specific corrections."""
+    modules, library, dialog = setup_manager
+    library.switch_to_global_correction_database(False)
+    dialog.populate_corrections_list()
+    dialog.global_corrections.SetValue(True)
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_NO
+
+    assert dialog.on_global_corrections_changed() is False
+
+    warning = modules.wx.MessageDialog.return_value.ExtendedMessage
+    assert isinstance(warning, str)
+    assert "project-specific corrections" in warning
+    assert "discarded" in warning
+    assert modules.wx.MessageDialog.call_args.args[3] & modules.wx.NO_DEFAULT
+    assert dialog.global_corrections.GetValue() is False
+
+
+@pytest.mark.parametrize("confirmation", ["ID_YES", "ID_NO", "ID_CANCEL"])
+def test_invalid_local_corrections_can_be_discarded_for_healthy_global(
+    setup_manager: tuple[SimpleNamespace, Any, Any], confirmation: str
+) -> None:
+    """Repair remains possible by leaving an invalid local copy after confirmation."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("GLOBAL", 90, (1, 2))
+    library.switch_to_global_correction_database(False)
+    seed_raw(library, [("BROKEN", "47u", 0, 0)])
+    dialog.populate_corrections_list()
+    select(dialog, 1)
+    before = (raw_rows(library), dialog.selected_record.rowid, field_values(dialog))
+    local_path = library.correctionsdb_file
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = getattr(
+        modules.wx, confirmation
+    )
+    dialog.global_corrections.SetValue(True)
+
+    confirmed = confirmation == "ID_YES"
+    handler = dialog.global_corrections.bindings[modules.wx.EVT_CHECKBOX]
+    assert handler() is confirmed
+
+    if confirmed:
+        assert library.correctionsdb_file == library.globalcorrectionsdb_file
+        assert dialog.global_corrections.GetValue() is True
+        assert dialog.selected_record is None
+        assert fresh_library(library).read_correction_data().issues == ()
+        assert [row[1:] for row in raw_rows(library)] == [("GLOBAL", 90, 1.0, 2.0)]
+        with closing(sqlite3.connect(local_path)) as connection:
+            assert (
+                connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='correction'"
+                ).fetchall()
+                == []
+            )
+        modules.wx.PostEvent.assert_called_once()
+    else:
+        assert library.correctionsdb_file == local_path
+        assert dialog.global_corrections.GetValue() is False
+        assert (
+            raw_rows(library),
+            dialog.selected_record.rowid,
+            field_values(dialog),
+        ) == before
+        modules.wx.PostEvent.assert_not_called()
+
+
+@pytest.mark.parametrize("global_problem", ["invalid", "invalid_schema"])
+def test_invalid_local_scope_switch_failure_preserves_editor_and_both_databases(
+    setup_manager: tuple[SimpleNamespace, Any, Any], global_problem: str
+) -> None:
+    """A broken global destination must not discard the local recovery path."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("GLOBAL", 90, (1, 2))
+    library.switch_to_global_correction_database(False)
+    seed_raw(library, [("BROKEN", "47u", 0, 0)])
+    dialog.populate_corrections_list()
+    select(dialog, 1)
+    dialog.rotation.SetValue("unsaved repair")
+    original_local = raw_rows(library)
+    local_path = library.correctionsdb_file
+    selected = dialog.selected_record.rowid
+    editor = field_values(dialog)
+    with (
+        closing(sqlite3.connect(library.globalcorrectionsdb_file)) as connection,
+        connection,
+    ):
+        if global_problem == "invalid":
+            connection.execute("UPDATE correction SET rotation='bad'")
+        else:
+            connection.execute(
+                "ALTER TABLE correction RENAME COLUMN rotation TO broken"
+            )
+    global_bytes = Path(library.globalcorrectionsdb_file).read_bytes()
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    dialog.global_corrections.SetValue(True)
+
+    handler = dialog.global_corrections.bindings[modules.wx.EVT_CHECKBOX]
+    assert handler() is False
+
+    assert library.correctionsdb_file == local_path
+    assert dialog.global_corrections.GetValue() is False
+    assert dialog.selected_record.rowid == selected
+    assert field_values(dialog) == editor
+    assert raw_rows(library) == original_local
+    assert Path(library.globalcorrectionsdb_file).read_bytes() == global_bytes
+    assert [row[1:] for row in raw_rows(fresh_library(library))] == [
+        ("GLOBAL", 90, 1.0, 2.0),
+        ("BROKEN", "47u", 0, 0),
+    ]
+    modules.wx.PostEvent.assert_not_called()
+    modules.wx.MessageBox.assert_called_once()
+
+
+@pytest.mark.parametrize("condition", ["unknown_archive", "known_transfer", "drop"])
+def test_scope_switch_distinguishes_archive_warnings_from_blocking_failures(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    condition: str,
+) -> None:
+    """Confirmed local discard ignores unknown archives but preserves failed transfers."""
+    library = make_library(
+        modules.library, tmp_path, [("LOCAL", "47u", 0, 0)], local=True
+    )
+    library.create_correction_table(library.globalcorrectionsdb_file)
+    with (
+        closing(sqlite3.connect(library.globalcorrectionsdb_file)) as connection,
+        connection,
+    ):
+        connection.execute("INSERT INTO correction VALUES ('GLOBAL', 90, 1, 2)")
+        if condition == "known_transfer":
+            connection.execute(
+                "CREATE TRIGGER reject_insert BEFORE INSERT ON correction "
+                "BEGIN SELECT RAISE(ABORT, 'transfer denied'); END"
+            )
+    if condition == "unknown_archive":
+        Path(library.rotationsdb_file).write_bytes(b"unreadable archive")
+    elif condition == "known_transfer":
+        write_rotation_archive(library.rotationsdb_file)
+    dialog = manager(modules, library, monkeypatch)
+    select(dialog, 0)
+    dialog.rotation.SetValue("unsaved local repair")
+    before = (raw_rows(library), dialog.selected_record.rowid, field_values(dialog))
+    local_path = library.correctionsdb_file
+    if condition == "drop":
+        connect = sqlite3.connect
+
+        def deny_drop(action: int, *_args: object) -> int:
+            """Reject the native SQLite drop while permitting rollback and reads."""
+            return (
+                sqlite3.SQLITE_DENY
+                if action == sqlite3.SQLITE_DROP_TABLE
+                else sqlite3.SQLITE_OK
+            )
+
+        def connect_with_drop_failure(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+            """Apply the failure only to actual connections to the local database."""
+            connection = connect(*args, **kwargs)
+            if connection.execute("PRAGMA database_list").fetchone()[2] == local_path:
+                connection.set_authorizer(deny_drop)
+            return connection
+
+        monkeypatch.setattr(
+            modules.library.sqlite3, "connect", connect_with_drop_failure
+        )
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+    dialog.global_corrections.SetValue(True)
+
+    assert dialog.global_corrections.bindings[modules.wx.EVT_CHECKBOX]() is (
+        condition == "unknown_archive"
+    )
+
+    if condition == "unknown_archive":
+        assert library.correctionsdb_file == library.globalcorrectionsdb_file
+        assert dialog.global_corrections.GetValue() is True
+        assert dialog.selected_record is None
+        assert dialog.correction_snapshot.corrections is not None
+        assert dialog.correction_snapshot.issues == ()
+        assert library.rotationsdb_file in dialog.correction_status.value
+        assert "reopen Corrections Manager to retry" in dialog.correction_status.value
+        assert raw_rows(library)[0][1:] == ("GLOBAL", 90, 1, 2)
+        with closing(sqlite3.connect(local_path)) as connection:
+            assert (
+                connection.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='correction'"
+                ).fetchone()
+                is None
+            )
+        modules.wx.PostEvent.assert_called_once()
+        modules.wx.MessageBox.assert_not_called()
+    else:
+        assert library.correctionsdb_file == local_path
+        assert dialog.global_corrections.GetValue() is False
+        assert (
+            raw_rows(library),
+            dialog.selected_record.rowid,
+            field_values(dialog),
+        ) == before
+        assert fresh_library(library).correctionsdb_file == local_path
+        assert dialog.correction_snapshot.scope == "local"
+        modules.wx.PostEvent.assert_not_called()
+        modules.wx.MessageBox.assert_called_once()
+        relevant_path = (
+            library.globalcorrectionsdb_file
+            if condition == "known_transfer"
+            else local_path
+        )
+        assert relevant_path in modules.wx.MessageBox.call_args.args[0]
+        assert (
+            "try switching databases again" in modules.wx.MessageBox.call_args.args[0]
+        )
+
+
+def test_empty_corrections_export_header_and_remain_ready(
+    setup_manager: tuple[SimpleNamespace, Any, Any], tmp_path: Path
+) -> None:
+    """A healthy empty database is exportable, unlike an unavailable collection."""
+    modules, library, dialog = setup_manager
+    path = tmp_path / "empty.csv"
+
+    assert dialog._export_corrections(path) is True
+
+    assert path.read_text() == '"Pattern","Rotation","Offset X","Offset Y"\n'
+    assert fresh_library(library).get_all_correction_data() == ()
+    modules.wx.MessageBox.assert_not_called()

--- a/tests/test_fabrication_correction_recovery.py
+++ b/tests/test_fabrication_correction_recovery.py
@@ -1,0 +1,558 @@
+"""Protect real CPL output from invalid storage and stale correction snapshots."""
+
+from collections.abc import Iterator
+from contextlib import closing
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+import sqlite3
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.correction_test_support import (
+    fresh_library,
+    make_library,
+    raw_rows,
+    seed_raw,
+)
+from tests.wx_harness import load_correction_modules, module
+
+
+@dataclass
+class Point:
+    """Represent KiCad coordinates without rounding away offset assertions."""
+
+    x: float
+    y: float
+
+    def __sub__(self, other):
+        """Subtract the board auxiliary origin."""
+        return Point(self.x - other.x, self.y - other.y)
+
+
+@pytest.fixture
+def modules() -> Iterator[SimpleNamespace]:
+    """Keep real storage and placement modules registered with one set of doubles."""
+    package = "fabrication_correction_recovery_tests"
+    pcbnew = MagicMock()
+    pcbnew.FromMM = lambda value: value
+    pcbnew.ToMM = lambda value: value
+    pcbnew.wxPoint = Point
+    pcbnew.VECTOR2I = Point
+    with load_correction_modules(
+        package=package,
+        pcbnew=pcbnew,
+        names=("fabrication",),
+        replacements={
+            f"{package}.footprint_helpers": module(
+                f"{package}.footprint_helpers", get_is_dnp=lambda _footprint: False
+            )
+        },
+    ) as loaded:
+        yield loaded
+
+
+@pytest.fixture
+def library(modules, tmp_path):
+    """Create actual SQLite correction storage away from user databases."""
+    return make_library(modules.library, tmp_path)
+
+
+def make_footprint(
+    reference: str, layer: int, rotation: float, position: Point
+) -> SimpleNamespace:
+    """Expose the board data used by the production placement calculations."""
+    return SimpleNamespace(
+        GetReference=lambda: reference,
+        GetValue=lambda: "Device",
+        GetLayer=lambda: layer,
+        GetOrientation=lambda: SimpleNamespace(AsDegrees=lambda: float(rotation)),
+        GetFPID=lambda: SimpleNamespace(GetLibItemName=lambda: "Package:Device"),
+        Pads=lambda: [],
+        GetPosition=lambda: position,
+    )
+
+
+def make_fabrication(modules, library, tmp_path):
+    """Create a real generator for one top and one bottom footprint."""
+    footprints = [
+        make_footprint("U1", 0, 0, Point(10, 20)),
+        make_footprint("U2", 31, 90, Point(30, 40)),
+    ]
+    board = SimpleNamespace(
+        GetFileName=lambda: str(tmp_path / "board.kicad_pcb"),
+        GetDesignSettings=MagicMock(
+            return_value=SimpleNamespace(GetAuxOrigin=lambda: Point(1, 2))
+        ),
+        Footprints=MagicMock(return_value=footprints),
+    )
+    parts = {
+        reference: {
+            "reference": reference,
+            "value": "Device",
+            "footprint": "Package:Device",
+            "exclude_from_pos": 0,
+            "lcsc": "C123",
+        }
+        for reference in ("U1", "U2")
+    }
+    parent = SimpleNamespace(
+        library=library,
+        settings={},
+        store=SimpleNamespace(get_part=parts.get),
+    )
+    return modules.fabrication.Fabrication(parent, board)
+
+
+def read_cpl(fabrication):
+    """Read the actual generated CSV through a fresh file handle."""
+    with Path(fabrication.get_cpl_csv_path()).open(newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+@pytest.mark.parametrize(
+    ("records", "expected"),
+    [
+        (
+            (("Device", 90, (1, 2)),),
+            ((10, -20, 90), (27, -37, 180)),
+        ),
+        (
+            (("Device", 90, (1, 2)), ("U", 0, (0, 0))),
+            ((9, -18, 0), (29, -38, 90)),
+        ),
+        (
+            (("unused", 90, (1, 2)),),
+            ((9, -18, 0), (29, -38, 90)),
+        ),
+    ],
+)
+def test_cpl_resolves_each_footprint_once_for_both_transforms(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    records: tuple[tuple[str, int, tuple[int, int]], ...],
+    expected: tuple[tuple[int, int, int], ...],
+) -> None:
+    """One selected rule, including zero and no match, drives both placement fields."""
+    fabrication = make_fabrication(modules, SimpleNamespace(), tmp_path)
+    matcher = MagicMock(wraps=fabrication._correction_for_footprint)
+    monkeypatch.setattr(fabrication, "_correction_for_footprint", matcher)
+
+    fabrication.generate_cpl(tuple(modules.data.Correction(*row) for row in records))
+
+    assert [
+        tuple(float(row[field]) for field in ("Mid X", "Mid Y", "Rotation"))
+        for row in read_cpl(fabrication)
+    ] == list(expected)
+    assert [call.args[0].GetReference() for call in matcher.call_args_list] == [
+        "U1",
+        "U2",
+    ]
+
+
+def test_cpl_skipped_footprints_do_not_resolve_corrections(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DNP, missing parts, position exclusions and the LCSC filter skip matching."""
+    fabrication = make_fabrication(modules, SimpleNamespace(), tmp_path)
+    fabrication.board.Footprints.return_value = [
+        make_footprint(f"U{index}", 0, 0, Point(10, 20)) for index in range(1, 7)
+    ]
+    parts = {
+        f"U{index}": {
+            "reference": f"U{index}",
+            "value": "Device",
+            "footprint": "Package:Device",
+            "exclude_from_pos": int(index == 4),
+            "lcsc": "" if index == 5 else "C123",
+        }
+        for index in (1, 2, 4, 5, 6)
+    }
+    fabrication.parent.store.get_part = parts.get
+    fabrication.parent.settings = {"gerber": {"lcsc_bom_cpl": False}}
+    monkeypatch.setattr(
+        modules.fabrication, "get_is_dnp", lambda fp: fp.GetReference() == "U2"
+    )
+    matcher = MagicMock(wraps=fabrication._correction_for_footprint)
+    monkeypatch.setattr(fabrication, "_correction_for_footprint", matcher)
+
+    fabrication.generate_cpl(())
+
+    assert [row["Designator"] for row in read_cpl(fabrication)] == ["U1", "U6"]
+    assert [call.args[0].GetReference() for call in matcher.call_args_list] == [
+        "U1",
+        "U6",
+    ]
+
+
+def test_cpl_resolves_new_rules_on_each_export(
+    modules: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reusing the exporter cannot retain a previous match or previous no-match."""
+    fabrication = make_fabrication(modules, SimpleNamespace(), tmp_path)
+    matcher = MagicMock(wraps=fabrication._correction_for_footprint)
+    monkeypatch.setattr(fabrication, "_correction_for_footprint", matcher)
+    snapshots = (
+        (),
+        (modules.data.Correction("Device", 90, (1, 2)),),
+        (modules.data.Correction("Device", 180, (-1, -2)),),
+        (),
+    )
+    expected = (
+        (9, -18, 0),
+        (10, -20, 90),
+        (8, -16, 180),
+        (9, -18, 0),
+    )
+
+    for corrections, placement in zip(snapshots, expected):
+        matcher.reset_mock()
+        fabrication.generate_cpl(corrections)
+        row = read_cpl(fabrication)[0]
+        assert (
+            tuple(float(row[field]) for field in ("Mid X", "Mid Y", "Rotation"))
+            == placement
+        )
+        assert matcher.call_count == 2
+
+
+@pytest.mark.parametrize("existing_output", [False, True])
+@pytest.mark.parametrize(
+    "offset,x,origin,layer,angle",
+    [
+        ((sys.float_info.max, 0), 0, 0, 0, 0),
+        ((1e12, 0), 0, 0, 0, 0),
+        ((1e-6, 0), 2**31 - 1, 0, 0, 0),
+        ((-1e-6, 0), -(2**31), 0, 0, 0),
+        ((0, 0), 2**31 - 1, -1, 0, 0),
+        ((-1e-6, 0), 2**31 - 1, 0, 31, 180),
+        ((2000, 2000), 0, 0, 0, 45),
+    ],
+)
+def test_coordinate_overflow_preserves_complete_cpl(
+    modules: SimpleNamespace,
+    library: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    existing_output: bool,
+    offset: tuple[float, float],
+    x: int,
+    origin: int,
+    layer: int,
+    angle: int,
+) -> None:
+    """A late placement error cannot truncate old output or create a partial file."""
+    library.save_correction_data("U2", 0, offset)
+    fabrication = make_fabrication(modules, library, tmp_path)
+    fabrication.board.Footprints.return_value[1] = make_footprint(
+        "U2", layer, angle, Point(x, 0)
+    )
+    fabrication.board.GetDesignSettings.return_value.GetAuxOrigin = lambda: Point(
+        origin, 0
+    )
+    # KiCad's Python FromMM helper scales then converts to int; wxPoint's C++
+    # coordinates are signed 32-bit. The ordinary Point double does not enforce
+    # that range, so production must check before passing values to native code.
+    monkeypatch.setattr(modules.fabrication, "FromMM", lambda value: int(value * 1e6))
+    destination = Path(fabrication.get_cpl_csv_path())
+    if existing_output:
+        destination.write_bytes(b"previous complete CPL")
+
+    with pytest.raises(ValueError, match="U2.*correction 'U2'"):
+        fabrication.generate_cpl()
+
+    assert (destination.read_bytes() if destination.exists() else None) == (
+        b"previous complete CPL" if existing_output else None
+    )
+
+
+@pytest.mark.parametrize("coordinate", [-(2**31), 2**31 - 1])
+@pytest.mark.parametrize("origin", [0, 100])
+def test_cpl_accepts_coordinate_boundary_and_unused_large_offset(
+    modules: SimpleNamespace,
+    library: Any,
+    tmp_path: Path,
+    coordinate: int,
+    origin: int,
+) -> None:
+    """Only final placements must fit, including after an origin-canceling offset."""
+    library.save_correction_data("unmatched", 0, (sys.float_info.max, 0))
+    library.save_correction_data("U1", 0, (origin, -origin))
+    fabrication = make_fabrication(modules, library, tmp_path)
+    fabrication.board.GetDesignSettings.return_value.GetAuxOrigin = lambda: Point(
+        origin, -origin
+    )
+    fabrication.board.Footprints.return_value = [
+        make_footprint("U1", 0, 0, Point(coordinate, coordinate))
+    ]
+
+    fabrication.generate_cpl()
+
+    row = read_cpl(fabrication)[0]
+    assert float(row["Mid X"]) == coordinate
+    assert float(row["Mid Y"]) == -coordinate
+
+
+@pytest.mark.parametrize("legacy_angle", [False, True])
+@pytest.mark.parametrize("layer", [0, 31])
+@pytest.mark.parametrize("selection", ["applied", "zero", "unmatched"])
+def test_public_correction_wrappers_preserve_top_bottom_and_legacy_angles(
+    modules: SimpleNamespace,
+    tmp_path: Path,
+    legacy_angle: bool,
+    layer: int,
+    selection: str,
+) -> None:
+    """Independent wrapper calls retain both orientation APIs and zero semantics."""
+    fabrication = make_fabrication(modules, SimpleNamespace(), tmp_path)
+    footprint = make_footprint("U1", layer, 30, Point(10, 20))
+    if legacy_angle:
+        footprint.GetOrientation = lambda: 300
+    fabrication.corrections = (
+        modules.data.Correction(
+            "unused" if selection == "unmatched" else "Device",
+            0 if selection == "zero" else 90,
+            (0, 0) if selection == "zero" else (1, 2),
+        ),
+    )
+    position = Point(10, 20)
+
+    rotation = fabrication.fix_rotation(footprint)
+    corrected = fabrication.fix_position(footprint, position)
+
+    if selection == "applied":
+        assert rotation == (120 if layer == 0 else 240)
+        expected = (
+            (11.866025403784, 21.232050807569)
+            if layer == 0
+            else (9.866025403784, 17.767949192431)
+        )
+        assert (corrected.x, corrected.y) == pytest.approx(expected)
+    else:
+        assert rotation == (30 if layer == 0 else 150)
+        assert corrected is position
+
+
+@pytest.mark.parametrize(
+    "row,field",
+    [
+        (("unused", "47u", 0, 0), "rotation"),
+        (("unused", None, 0, 0), "rotation"),
+        (("unused", 90.5, 0, 0), "rotation"),
+        (("unused", 90, "invalid", 0), "offset_x"),
+        (("unused", 90, 0, "invalid"), "offset_y"),
+        (("unused", 90, float("inf"), 0), "offset_x"),
+        (("unused", 90, 0, None), "offset_y"),
+        (("[", 90, 0, 0), "pattern"),
+        ((None, 90, 0, 0), "pattern"),
+        ((b"unused", 90, 0, 0), "pattern"),
+    ],
+)
+@pytest.mark.parametrize("existing_output", [False, True])
+def test_invalid_storage_preserves_output_before_board_work(
+    modules: SimpleNamespace,
+    library: Any,
+    tmp_path: Path,
+    row: tuple[object, ...],
+    field: str,
+    existing_output: bool,
+) -> None:
+    """Even unmatched invalid rows block output without truncation or stale reuse."""
+    seed_raw(library, [("Device", 90, 1, 2), row])
+    before = raw_rows(library)
+    fabrication = make_fabrication(modules, fresh_library(library), tmp_path)
+    fabrication.corrections = (modules.data.Correction("Device", 90, (1, 2)),)
+    destination = Path(fabrication.get_cpl_csv_path())
+    if existing_output:
+        destination.write_bytes(b"previous CPL\r\nuntouched\x00")
+
+    with pytest.raises(ValueError) as error:
+        fabrication.generate_cpl()
+
+    assert "Open Corrections Manager" in str(error.value)
+    assert field not in str(error.value)
+    assert library.correctionsdb_file in str(error.value)
+    assert raw_rows(library) == before
+    fabrication.board.GetDesignSettings.assert_not_called()
+    fabrication.board.Footprints.assert_not_called()
+    if existing_output:
+        assert destination.read_bytes() == b"previous CPL\r\nuntouched\x00"
+    else:
+        assert not destination.exists()
+
+
+@pytest.mark.parametrize("failure", ["missing", "directory", "corrupt", "schema"])
+def test_storage_failure_preserves_existing_cpl(
+    modules: SimpleNamespace, library: Any, tmp_path: Path, failure: str
+) -> None:
+    """Unreadable correction storage never becomes an implicit empty correction set."""
+    database = Path(library.correctionsdb_file)
+    if failure == "schema":
+        with closing(sqlite3.connect(database)) as connection, connection:
+            connection.execute("DROP TABLE correction")
+    else:
+        database.unlink()
+        if failure == "directory":
+            database.mkdir()
+        elif failure == "corrupt":
+            database.write_bytes(b"this is not a SQLite database")
+    fabrication = make_fabrication(modules, fresh_library(library), tmp_path)
+    destination = Path(fabrication.get_cpl_csv_path())
+    destination.write_bytes(b"saved CPL")
+
+    with pytest.raises(ValueError, match="database"):
+        fabrication.generate_cpl()
+
+    assert destination.read_bytes() == b"saved CPL"
+    fabrication.board.GetDesignSettings.assert_not_called()
+    if failure == "missing":
+        assert not database.exists()
+
+
+def test_conflicting_duplicate_corrections_preserve_output(
+    modules: SimpleNamespace, library: Any, tmp_path: Path
+) -> None:
+    """Ambiguous persisted patterns cannot silently select one fabrication result."""
+    seed_raw(library, [("Device", 90, 0, 0), ("Device", 180, 0, 0)])
+    fabrication = make_fabrication(modules, fresh_library(library), tmp_path)
+    destination = Path(fabrication.get_cpl_csv_path())
+    destination.write_bytes(b"previous")
+
+    with pytest.raises(ValueError, match="unresolved"):
+        fabrication.generate_cpl()
+
+    assert destination.read_bytes() == b"previous"
+
+
+def test_repaired_database_reopens_and_generates_correct_top_bottom_cpl(
+    modules: SimpleNamespace, library: Any, tmp_path: Path
+) -> None:
+    """Repair restores actual rotation, mirrored offsets, and origin subtraction."""
+    seed_raw(library, [("Device", "47u", 1, 2)])
+    fabrication = make_fabrication(modules, fresh_library(library), tmp_path)
+    with pytest.raises(ValueError, match="unresolved"):
+        fabrication.generate_cpl()
+    bad_row = library.read_correction_data().rows[0]
+    library.save_correction_data("Device", 90, (1, 2), rowid=bad_row.rowid)
+    fabrication.parent.library = fresh_library(library)
+
+    fabrication.generate_cpl()
+
+    rows = read_cpl(fabrication)
+    assert [row["Designator"] for row in rows] == ["U1", "U2"]
+    assert [row["Layer"] for row in rows] == ["top", "bottom"]
+    assert [row["Package"] for row in rows] == ["Package:Device"] * 2
+    assert [row["Val"] for row in rows] == ["Device"] * 2
+    assert [float(row["Rotation"]) for row in rows] == [90, 180]
+    assert [float(row["Mid X"]) for row in rows] == pytest.approx([10, 27])
+    assert [float(row["Mid Y"]) for row in rows] == pytest.approx([-20, -37])
+
+
+def test_preflight_snapshot_survives_storage_change_and_direct_call_rereads(
+    modules: SimpleNamespace, library: Any, tmp_path: Path
+) -> None:
+    """One operation retains its snapshot while later direct calls validate anew."""
+    seed_raw(library, [("Device", 90, 1, 2)])
+    snapshot = fresh_library(library).read_correction_data().corrections
+    fabrication = make_fabrication(modules, library, tmp_path)
+    with closing(sqlite3.connect(library.correctionsdb_file)) as connection, connection:
+        connection.execute("UPDATE correction SET rotation='47u'")
+
+    fabrication.generate_cpl(corrections=snapshot)
+
+    destination = Path(fabrication.get_cpl_csv_path())
+    before = destination.read_bytes()
+    assert [float(row["Rotation"]) for row in read_cpl(fabrication)] == [90, 180]
+    with pytest.raises(ValueError, match="unresolved"):
+        fabrication.generate_cpl()
+    assert destination.read_bytes() == before
+
+
+def test_direct_calls_refresh_valid_corrections_between_generations(
+    modules, library, tmp_path
+):
+    """A populated matcher cache cannot hide a committed correction change."""
+    library.save_correction_data("Device", 90, (0, 0))
+    fabrication = make_fabrication(modules, library, tmp_path)
+    fabrication.generate_cpl()
+    assert [float(row["Rotation"]) for row in read_cpl(fabrication)] == [90, 180]
+    fresh_library(library).save_correction_data("Device", -90, (0, 0), replace=True)
+
+    fabrication.generate_cpl()
+
+    assert [float(row["Rotation"]) for row in read_cpl(fabrication)] == [270, 0]
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        ("Device", 90, (0, 0)),
+        SimpleNamespace(pattern="Device", rotation="47u", offset=(0, 0)),
+        None,
+        [],
+    ],
+)
+def test_supplied_snapshot_requires_immutable_corrections_before_output(
+    modules: SimpleNamespace, library: Any, tmp_path: Path, invalid: object
+) -> None:
+    """Only immutable collections of validated values can enter the public boundary."""
+    fabrication = make_fabrication(modules, library, tmp_path)
+    destination = Path(fabrication.get_cpl_csv_path())
+    destination.write_bytes(b"previous")
+    valid = modules.data.Correction("valid-first", 90, (0, 0))
+    supplied = [valid] if isinstance(invalid, list) else (valid, invalid)
+
+    with pytest.raises(TypeError, match="Correction"):
+        fabrication.generate_cpl(corrections=supplied)
+
+    assert destination.read_bytes() == b"previous"
+    fabrication.board.GetDesignSettings.assert_not_called()
+
+
+def test_explicit_empty_snapshot_does_not_fall_back_to_storage(
+    modules: SimpleNamespace, library: Any, tmp_path: Path
+) -> None:
+    """An intentionally empty preflight snapshot remains valid after new bad writes."""
+    snapshot = library.read_correction_data().corrections
+    seed_raw(library, [("Device", "47u", 0, 0)])
+    fabrication = make_fabrication(modules, library, tmp_path)
+    fabrication.corrections = (modules.data.Correction("Device", 90, (0, 0)),)
+
+    fabrication.generate_cpl(corrections=snapshot)
+
+    rows = read_cpl(fabrication)
+    assert [float(row["Rotation"]) for row in rows] == [0, 90]
+    assert [float(row["Mid X"]) for row in rows] == [9, 29]
+    assert [float(row["Mid Y"]) for row in rows] == [-18, -38]
+    assert fabrication.corrections == ()
+
+
+@pytest.mark.parametrize("correction", [2**53 + 1, -(2**53 + 1), 2**63 - 1, -(2**63)])
+@pytest.mark.parametrize("orientation", [0.0, 12.5])
+def test_cpl_preserves_exact_large_correction_with_native_float_angle(
+    modules: SimpleNamespace,
+    library: Any,
+    tmp_path: Path,
+    correction: int,
+    orientation: float,
+) -> None:
+    """Whole-degree corrections retain their modulo when KiCad returns a float."""
+    library.save_correction_data("Device", correction, (0, 0))
+    fabrication = make_fabrication(modules, fresh_library(library), tmp_path)
+    fabrication.board.Footprints.return_value = [
+        make_footprint("U1", 0, orientation, Point(10, 20)),
+        make_footprint("U2", 31, orientation, Point(30, 40)),
+    ]
+
+    fabrication.generate_cpl()
+
+    assert [float(row["Rotation"]) for row in read_cpl(fabrication)] == [
+        (orientation + correction % 360) % 360,
+        ((180 - orientation) % 360 + correction % 360) % 360,
+    ]
+    assert raw_rows(library)[0][2] == correction

--- a/tests/test_fabrication_corrections.py
+++ b/tests/test_fabrication_corrections.py
@@ -1,204 +1,184 @@
-"""Tests for the two-pass correction matching logic in Fabrication._find_correction."""
+"""Keep the parts table and actual placement output on one matching policy."""
 
-import importlib.util
 from pathlib import Path
-import sys
-import types
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from typing import Any
 
-_ROOT = Path(__file__).parent.parent
+import pytest
 
-# Mock KiCad modules before importing fabrication
-for _mod in ["pcbnew", "wx", "wx.dataview"]:
-    sys.modules[_mod] = MagicMock()
-
-# fabrication.py uses relative imports, so give it a fake parent package
-_pkg = types.ModuleType("kicadplugin")
-_pkg.__path__ = [str(_ROOT)]
-sys.modules["kicadplugin"] = _pkg
-
-_footprint_helpers = types.ModuleType("kicadplugin.footprint_helpers")
-_footprint_helpers.get_is_dnp = lambda fp: False  # type: ignore[attr-defined]
-sys.modules["kicadplugin.footprint_helpers"] = _footprint_helpers
-
-_spec = importlib.util.spec_from_file_location(
-    "kicadplugin.fabrication", _ROOT / "fabrication.py"
+from tests.test_fabrication_correction_recovery import (
+    Point,
+    make_fabrication,
+    make_footprint,
+    read_cpl,
 )
-assert _spec is not None and _spec.loader is not None
-_fab_mod = importlib.util.module_from_spec(_spec)
-_fab_mod.__package__ = "kicadplugin"
-sys.modules["kicadplugin.fabrication"] = _fab_mod
-_spec.loader.exec_module(_fab_mod)  # type: ignore[union-attr]
+from tests.test_mainwindow_correction_recovery import (
+    _displayed_corrections,
+    _population_window,
+    runtime as correction_runtime,
+)
 
-Fabrication = _fab_mod.Fabrication  # type: ignore[attr-defined]
-
-
-def make_fab(corrections):
-    """Create a bare Fabrication instance with the given corrections list."""
-    fab = object.__new__(Fabrication)
-    fab.corrections = corrections
-    return fab
+runtime = correction_runtime
 
 
-# ---------------------------------------------------------------------------
-# Anchored-first conflict resolution
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "records,reference,value,footprint,rotation,offset,source",
+    [
+        (
+            [("SOT-23", 10, (0, 0)), ("SOT-23-3", 20, (1, 2))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            20,
+            (1, 2),
+            "fpt",
+        ),
+        (
+            [("SOT-23-3", 20, (1, 2)), ("SOT-23", 10, (0, 0))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            20,
+            (1, 2),
+            "fpt",
+        ),
+        (
+            [("U", 10, (1, 2)), ("U1", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            20,
+            (3, 4),
+            "ref",
+        ),
+        (
+            [("U", 10, (1, 2)), ("Device", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            10,
+            (1, 2),
+            "ref",
+        ),
+        (
+            [("Dev", 10, (1, 2)), ("Device", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            20,
+            (3, 4),
+            "val",
+        ),
+        (
+            [("Dev", 10, (1, 2)), ("SOT-23-3", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            10,
+            (1, 2),
+            "val",
+        ),
+        (
+            [("U[0-9]", 10, (1, 2)), ("U.", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            20,
+            (3, 4),
+            "ref",
+        ),
+        (
+            [("SOT-23-3|SOT-23-5", 10, (1, 2)), ("SOT-23-30", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-30",
+            20,
+            (3, 4),
+            "fpt",
+        ),
+        (
+            [("SOT-23-3|SOT-23-5", 10, (1, 2))],
+            "U1",
+            "Device",
+            "Package:SOT-23-5-long",
+            10,
+            (1, 2),
+            "fpt",
+        ),
+        (
+            [("U1", 0, (0, 0)), ("Device", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            0,
+            (0, 0),
+            "ref",
+        ),
+        (
+            [("U1", 0, (1, 2)), ("Device", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            0,
+            (1, 2),
+            "ref",
+        ),
+        (
+            [("U1", -90, (0, 0)), ("Device", 20, (3, 4))],
+            "U1",
+            "Device",
+            "SOT-23-3",
+            -90,
+            (0, 0),
+            "ref",
+        ),
+        ([("QFP", 10, (1, 2))], "U1", "Device", "SOT-23-3", 0, (0, 0), None),
+        ([], "U1", "Device", "SOT-23-3", 0, (0, 0), None),
+    ],
+)
+def test_parts_table_reports_the_correction_used_by_cpl(
+    runtime: SimpleNamespace,
+    tmp_path: Path,
+    records: list[tuple[str, int, tuple[float, float]]],
+    reference: str,
+    value: str,
+    footprint: str,
+    rotation: int,
+    offset: tuple[float, float],
+    source: Any,
+) -> None:
+    """Persisted overlap rules produce matching display, rotation and position."""
+    runtime.library.apply_corrections(records)
+    fabrication = make_fabrication(runtime.modules, runtime.library, tmp_path)
+    fp = make_footprint(reference, 0, 0, Point(10, 20))
+    fp.GetValue = lambda: value
+    fp.GetFPID = lambda: SimpleNamespace(GetLibItemName=lambda: footprint)
+    fabrication.board.Footprints.return_value = [fp]
+    part = {
+        "reference": reference,
+        "value": value,
+        "footprint": footprint,
+        "exclude_from_bom": 0,
+        "exclude_from_pos": 0,
+        "lcsc": "",
+    }
+    fabrication.parent.store.get_part = lambda _reference: part
+    window = _population_window(runtime)
+    window.store.read_all.return_value = [part]
+    window.pcbnew = SimpleNamespace(
+        GetBoard=lambda: SimpleNamespace(FindFootprintByReference=lambda _reference: fp)
+    )
 
+    window.populate_footprint_list()
+    fabrication.generate_cpl()
 
-class TestFindCorrectionConflictResolution:
-    """_find_correction prefers exact-suffix (anchored) matches over substring matches."""
-
-    def test_specific_pattern_wins_over_prefix(self):
-        """SOT-23-3 correction wins over the shorter SOT-23 pattern."""
-        fab = make_fab(
-            [
-                ("SOT-23", 10, (0.0, 0.0)),
-                ("SOT-23-3", 20, (0.0, 0.0)),
-            ]
-        )
-        rotation, _ = fab._find_correction("SOT-23-3")
-        assert rotation == 20
-
-    def test_shorter_pattern_still_matches_its_own_value(self):
-        """SOT-23 correction is used when the value is exactly SOT-23."""
-        fab = make_fab(
-            [
-                ("SOT-23", 10, (0.0, 0.0)),
-                ("SOT-23-3", 20, (0.0, 0.0)),
-            ]
-        )
-        rotation, _ = fab._find_correction("SOT-23")
-        assert rotation == 10
-
-    def test_order_in_list_does_not_matter(self):
-        """Anchored match wins regardless of which pattern is listed first."""
-        fab = make_fab(
-            [
-                ("SOT-23-3", 20, (0.0, 0.0)),
-                ("SOT-23", 10, (0.0, 0.0)),
-            ]
-        )
-        rotation, _ = fab._find_correction("SOT-23-3")
-        assert rotation == 20
-
-    def test_three_way_conflict_most_specific_wins(self):
-        """Most specific (longest exact-suffix) pattern wins in a three-way conflict."""
-        fab = make_fab(
-            [
-                ("SOT", 5, (0.0, 0.0)),
-                ("SOT-23", 10, (0.0, 0.0)),
-                ("SOT-23-3", 20, (0.0, 0.0)),
-            ]
-        )
-        rotation, _ = fab._find_correction("SOT-23-3")
-        assert rotation == 20
-
-
-# ---------------------------------------------------------------------------
-# Unanchored fallback
-# ---------------------------------------------------------------------------
-
-
-class TestFindCorrectionUnanchoredFallback:
-    """When no anchored match exists, the first substring match is used."""
-
-    def test_substring_match_used_when_no_conflict(self):
-        """A substring pattern matches when it is the only candidate."""
-        fab = make_fab([("SOT-23", 10, (0.0, 0.0))])
-        rotation, _ = fab._find_correction("Package_TO_SOT_SMD:SOT-23")
-        assert rotation == 10
-
-    def test_no_match_returns_none(self):
-        """Returns None when no pattern matches the value."""
-        fab = make_fab([("SOT-23", 10, (0.0, 0.0))])
-        assert fab._find_correction("QFP-100") is None
-
-    def test_empty_corrections_returns_none(self):
-        """Returns None when the corrections list is empty."""
-        fab = make_fab([])
-        assert fab._find_correction("SOT-23-3") is None
-
-
-# ---------------------------------------------------------------------------
-# Alternation patterns
-# ---------------------------------------------------------------------------
-
-
-class TestFindCorrectionAlternation:
-    """Alternation patterns (|) are wrapped so $ anchors all branches."""
-
-    def test_alternation_matches_first_branch(self):
-        """An alternation pattern matches the first branch correctly."""
-        fab = make_fab([("SOT-23-3|SOT-23-5", 20, (0.0, 0.0))])
-        rotation, _ = fab._find_correction("SOT-23-3")
-        assert rotation == 20
-
-    def test_alternation_matches_second_branch(self):
-        """An alternation pattern matches the second branch correctly."""
-        fab = make_fab([("SOT-23-3|SOT-23-5", 20, (0.0, 0.0))])
-        rotation, _ = fab._find_correction("SOT-23-5")
-        assert rotation == 20
-
-    def test_alternation_anchored_does_not_match_extended_value(self):
-        """SOT-23-3|SOT-23-5 does not match SOT-23-30 via the first branch."""
-        fab = make_fab(
-            [
-                ("SOT-23-3|SOT-23-5", 20, (0.0, 0.0)),
-                ("SOT-23-30", 30, (0.0, 0.0)),
-            ]
-        )
-        rotation, _ = fab._find_correction("SOT-23-30")
-        assert rotation == 30
-
-    def test_alternation_falls_back_to_unanchored_when_needed(self):
-        """Alternation pattern still matches as substring in the fallback pass."""
-        fab = make_fab([("SOT-23-3|SOT-23-5", 20, (0.0, 0.0))])
-        rotation, _ = fab._find_correction("Package_TO_SOT_SMD:SOT-23-3")
-        assert rotation == 20
-
-
-# ---------------------------------------------------------------------------
-# Patterns that already carry anchors
-# ---------------------------------------------------------------------------
-
-
-class TestFindCorrectionExistingAnchors:
-    """Patterns that already end with $ are wrapped as (?:pattern)$ harmlessly."""
-
-    def test_pre_anchored_pattern_matches_correctly(self):
-        """A pattern ending in $ still matches correctly when wrapped."""
-        fab = make_fab([("SOT-23$", 10, (0.0, 0.0))])
-        rotation, _ = fab._find_correction("SOT-23")
-        assert rotation == 10
-
-    def test_pre_anchored_pattern_does_not_match_longer_value(self):
-        """A pre-anchored SOT-23$ pattern does not match SOT-23-3."""
-        fab = make_fab([("SOT-23$", 10, (0.0, 0.0))])
-        assert fab._find_correction("SOT-23-3") is None
-
-    def test_pre_anchored_and_unanchored_coexist(self):
-        """Pre-anchored SOT-23$ and unanchored SOT-23-3 resolve correctly."""
-        fab = make_fab(
-            [
-                ("SOT-23$", 10, (0.0, 0.0)),
-                ("SOT-23-3", 20, (0.0, 0.0)),
-            ]
-        )
-        assert fab._find_correction("SOT-23")[0] == 10
-        assert fab._find_correction("SOT-23-3")[0] == 20
-
-
-# ---------------------------------------------------------------------------
-# Offset (position correction) passthrough
-# ---------------------------------------------------------------------------
-
-
-class TestFindCorrectionOffset:
-    """_find_correction returns the offset tuple as well as rotation."""
-
-    def test_offset_returned_with_rotation(self):
-        """Both rotation and offset are returned in the result tuple."""
-        fab = make_fab([("SOT-23-3", 45, (1.5, -0.5))])
-        rotation, offset = fab._find_correction("SOT-23-3")
-        assert rotation == 45
-        assert offset == (1.5, -0.5)
+    expected = (
+        f"{rotation}°, {float(offset[0])}/{float(offset[1])} ({source})"
+        if source is not None
+        else "0°, 0.0/0.0"
+    )
+    assert _displayed_corrections(window) == [expected]
+    (row,) = read_cpl(fabrication)
+    assert float(row["Rotation"]) == rotation % 360
+    assert float(row["Mid X"]) == pytest.approx(9 + offset[0])
+    assert float(row["Mid Y"]) == pytest.approx(-18 - offset[1])

--- a/tests/test_fabrication_cpl_format.py
+++ b/tests/test_fabrication_cpl_format.py
@@ -1,5 +1,6 @@
 """Keep CPL coordinates in decimal millimetres."""
 
+from collections.abc import Callable, Iterator
 import csv
 from pathlib import Path
 from types import SimpleNamespace
@@ -7,7 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from .wx_harness import load, module, package_stubs
+from .wx_harness import load_correction_modules, module
 
 
 class Point:
@@ -23,58 +24,72 @@ class Point:
 
 
 @pytest.fixture
-def generate_cpl(tmp_path):
+def generate_cpl(tmp_path: Path) -> Iterator[Callable[..., list[dict[str, str]]]]:
     """Run the real exporter with KiCad substitutes and temporary output."""
     package = "_cpl_format_test"
-    stubs = package_stubs(package)
-    stubs["pcbnew"] = MagicMock(
+    pcbnew = MagicMock(
         ToMM=lambda value: value / 1_000_000,
         FromMM=lambda value: round(value * 1_000_000),
         wxPoint=Point,
         VECTOR2I=Point,
     )
     helpers = f"{package}.footprint_helpers"
-    stubs[helpers] = module(helpers, get_is_dnp=lambda footprint: False)
-    fabrication_module = load(package, "fabrication", stubs)
+    with load_correction_modules(
+        package=package,
+        pcbnew=pcbnew,
+        names=("fabrication",),
+        replacements={helpers: module(helpers, get_is_dnp=lambda _footprint: False)},
+    ) as modules:
 
-    def generate(position, *, layer=0, origin=(0, 0), offset=(0, 0)):
-        """Return the CSV rows after actual origin and correction calculations."""
-        footprint = SimpleNamespace(
-            GetReference=lambda: "R1",
-            GetValue=lambda: "10k",
-            GetFPID=lambda: SimpleNamespace(GetLibItemName=lambda: "R_0603"),
-            GetLayer=lambda: layer,
-            GetOrientation=lambda: SimpleNamespace(AsDegrees=lambda: 0),
-            Pads=lambda: [],
-            GetPosition=lambda: Point(*position),
-        )
-        board = SimpleNamespace(
-            GetFileName=lambda: str(tmp_path / "board.kicad_pcb"),
-            GetDesignSettings=lambda: SimpleNamespace(
-                GetAuxOrigin=lambda: Point(*origin)
-            ),
-            Footprints=lambda: [footprint],
-        )
-        part = {
-            "reference": "R1",
-            "value": "10k",
-            "footprint": "R_0603",
-            "exclude_from_pos": 0,
-            "lcsc": "C123",
-        }
-        parent = SimpleNamespace(
-            settings={},
-            library=SimpleNamespace(
-                get_all_correction_data=lambda: [("R1", 0, offset)]
-            ),
-            store=SimpleNamespace(get_part=lambda reference: part),
-        )
-        fabrication = fabrication_module.Fabrication(parent, board)
-        fabrication.generate_cpl()
-        with Path(fabrication.get_cpl_csv_path()).open(newline="") as stream:
-            return list(csv.DictReader(stream))
+        def generate(
+            position: tuple[int, int],
+            *,
+            layer: int = 0,
+            origin: tuple[int, int] = (0, 0),
+            offset: tuple[float, float] = (0, 0),
+        ) -> list[dict[str, str]]:
+            """Return the CSV rows after actual origin and correction calculations."""
+            footprint = SimpleNamespace(
+                GetReference=lambda: "R1",
+                GetValue=lambda: "10k",
+                GetFPID=lambda: SimpleNamespace(GetLibItemName=lambda: "R_0603"),
+                GetLayer=lambda: layer,
+                GetOrientation=lambda: SimpleNamespace(AsDegrees=lambda: 0),
+                Pads=lambda: [],
+                GetPosition=lambda: Point(*position),
+            )
+            board = SimpleNamespace(
+                GetFileName=lambda: str(tmp_path / "board.kicad_pcb"),
+                GetDesignSettings=lambda: SimpleNamespace(
+                    GetAuxOrigin=lambda: Point(*origin)
+                ),
+                Footprints=lambda: [footprint],
+            )
+            part = {
+                "reference": "R1",
+                "value": "10k",
+                "footprint": "R_0603",
+                "exclude_from_pos": 0,
+                "lcsc": "C123",
+            }
+            snapshot = modules.library.CorrectionSnapshot(
+                db_path=str(tmp_path / "corrections.db"),
+                scope="global",
+                rows=(),
+                corrections=(modules.data.Correction("R1", 0, offset),),
+                issues=(),
+            )
+            parent = SimpleNamespace(
+                settings={},
+                library=SimpleNamespace(read_correction_data=lambda: snapshot),
+                store=SimpleNamespace(get_part=lambda _reference: part),
+            )
+            fabrication = modules.fabrication.Fabrication(parent, board)
+            fabrication.generate_cpl()
+            with Path(fabrication.get_cpl_csv_path()).open(newline="") as stream:
+                return list(csv.DictReader(stream))
 
-    return generate
+        yield generate
 
 
 @pytest.mark.parametrize(

--- a/tests/test_library_corrections.py
+++ b/tests/test_library_corrections.py
@@ -1,0 +1,2483 @@
+"""Exercise correction persistence and recovery against real SQLite files."""
+
+from collections.abc import Callable, Iterator
+from contextlib import closing, contextmanager
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+import sqlite3
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.correction_test_support import (
+    fresh_library,
+    make_library,
+    raw_rows,
+    seed_raw,
+)
+from tests.wx_harness import load_correction_modules
+
+
+@pytest.fixture
+def modules() -> Iterator[SimpleNamespace]:
+    """Import actual correction modules with isolated GUI dependencies."""
+    with load_correction_modules() as loaded:
+        yield loaded
+
+
+@pytest.fixture
+def library(modules, tmp_path):
+    """Create a correction database confined to this test's directory."""
+    return make_library(modules.library, tmp_path)
+
+
+def execute(path, sql, parameters=()):
+    """Execute and commit SQL using an independent connection."""
+    with closing(sqlite3.connect(path)) as connection, connection:
+        return connection.execute(sql, parameters).fetchall()
+
+
+def install_abort_trigger(path, *, operation="INSERT", pattern="explode"):
+    """Abort a genuine later write so tests prove transaction rollback."""
+    assert operation in {"INSERT", "UPDATE", "DELETE"}
+    reference = "OLD" if operation == "DELETE" else "NEW"
+    with closing(sqlite3.connect(path)) as connection, connection:
+        # Trigger syntax cannot bind a WHEN value; quote the fixture value.
+        quoted = pattern.replace("'", "''")
+        connection.execute(
+            f"CREATE TRIGGER fail_write BEFORE {operation} ON correction "
+            f"WHEN {reference}.regex = '{quoted}' "
+            "BEGIN SELECT RAISE(ABORT, 'injected write failure'); END"
+        )
+
+
+def seed_legacy(path, rows):
+    """Create a historical rotation table, retaining raw invalid values."""
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.execute("CREATE TABLE rotation (regex, rotation)")
+        connection.executemany("INSERT INTO rotation VALUES (?, ?)", rows)
+
+
+def migration_rows(library):
+    """Inspect committed migration records from a new connection."""
+    return execute(
+        library.globalcorrectionsdb_file,
+        "SELECT migration_key, source FROM correction_migrations ORDER BY migration_key",
+    )
+
+
+def immediate_thread(
+    *, target: Callable[..., Any], args: tuple[Any, ...], daemon: bool
+) -> SimpleNamespace:
+    """Run requested work synchronously without changing the callback or arguments."""
+    return SimpleNamespace(start=lambda: target(*args))
+
+
+def prepare_constructor_storage(library: Any) -> None:
+    """Start the real constructor with project settings and no correction database."""
+    library.parent.settings = {"library": {"data_path": library.datadir}}
+    library.create_mapping_table()
+    Path(library.globalcorrectionsdb_file).unlink()
+
+
+def correction_values(library: Any, **kwargs: Any) -> Any:
+    """Compare stable field values while checking the public typed-set contract."""
+    corrections = library.get_all_correction_data(**kwargs)
+    if corrections is None:
+        return None
+    assert isinstance(corrections, tuple)
+    return [(item.pattern, item.rotation, item.offset) for item in corrections]
+
+
+def test_ordinary_snapshots_never_probe_legacy_storage(
+    library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unrelated archives cannot change a previously ready active snapshot."""
+    seed_raw(library, [("custom", 270, 1, 2)])
+    library.migrate_corrections()
+    Path(library.partsdb_file).write_bytes(b"download currently replacing parts")
+
+    def forbidden_probe(source: str) -> None:
+        pytest.fail(f"ordinary correction read inspected {source}")
+
+    monkeypatch.setattr(library, "_legacy_rotation_rows", forbidden_probe)
+    assert correction_values(library) == [("custom", 270, (1.0, 2.0))]
+
+
+@pytest.mark.parametrize("kind", ["missing", "zero", "no-table", "empty"])
+def test_examined_empty_sources_and_settled_startup_are_read_only(
+    library: Any, monkeypatch: pytest.MonkeyPatch, kind: str
+) -> None:
+    """No-data archives are terminal without making every startup a writer."""
+    if kind == "zero":
+        Path(library.rotationsdb_file).touch()
+    elif kind == "no-table":
+        execute(library.rotationsdb_file, "CREATE TABLE unrelated (value)")
+    elif kind == "empty":
+        seed_legacy(library.rotationsdb_file, [])
+    seed_raw(library, [("custom", 90, 1, 2)])
+    library.create_mapping_table()
+    assert library.migrate_corrections() == ()
+    reopened = fresh_library(library)
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("settled startup acquired a write lock or inspected an archive")
+
+    monkeypatch.setattr(reopened, "_correction_transaction", forbidden)
+    monkeypatch.setattr(reopened, "_legacy_rotation_rows", forbidden)
+    reopened.check_library()
+    assert correction_values(reopened) == [("custom", 90, (1.0, 2.0))]
+
+
+@pytest.mark.parametrize("rows", [[], [("custom", 90)]])
+def test_aliases_of_captured_legacy_sources_complete_once(
+    modules: SimpleNamespace, library: Any, rows: list[tuple[str, int]]
+) -> None:
+    """Changing directory spelling after interrupted startup preserves canonical identity."""
+    seed_legacy(library.rotationsdb_file, rows)
+    execute(
+        library.globalcorrectionsdb_file,
+        "INSERT INTO correction_migration_state VALUES (?, ?, 'seed-pending', ?)",
+        (
+            modules.library._INITIAL_DEFAULTS_KEY,
+            library.globalcorrectionsdb_file,
+            modules.library.json.dumps(
+                [library.rotationsdb_file, library.partsdb_file]
+            ),
+        ),
+    )
+    alias = Path(library.datadir).parent / "alias"
+    alias.symlink_to(library.datadir, target_is_directory=True)
+    library.rotationsdb_file = str(alias / "rotations.db")
+    library.partsdb_file = str(alias / "parts.db")
+    assert library.migrate_corrections() == ()
+    assert len(migration_rows(library)) == 2
+    assert correction_values(library) == [
+        (pattern, rotation, (0.0, 0.0)) for pattern, rotation in rows
+    ]
+    assert execute(
+        library.globalcorrectionsdb_file,
+        "SELECT status FROM correction_migration_state",
+    ) == [("seed-pending",)]
+
+
+@pytest.mark.parametrize("key", [None, b"unknown"])
+@pytest.mark.parametrize("table", ["completed", "pending", "deferred"])
+def test_unrecognized_metadata_keys_preserve_repair_and_pending_diagnostics(
+    modules: SimpleNamespace, library: Any, key: object, table: str
+) -> None:
+    """SQLite permits non-text keys; unrelated metadata cannot crash repair or hide pending work."""
+    seed_raw(library, [("broken", "47u", 0, 0)])
+    if table == "completed":
+        execute(
+            library.correctionsdb_file,
+            "INSERT INTO correction_migrations VALUES (?, ?)",
+            (key, "old-tool"),
+        )
+    else:
+        execute(
+            library.correctionsdb_file,
+            "INSERT INTO correction_migration_state VALUES (?, ?, ?, ?)",
+            (key, library.rotationsdb_file, table, "restore custom corrections"),
+        )
+    library.migrate_corrections()
+    snapshot = library.read_correction_data()
+    assert snapshot.rows[0].rotation == "47u"
+    assert snapshot.state is (
+        modules.library.CorrectionState.UNAVAILABLE
+        if table == "pending"
+        else modules.library.CorrectionState.NEEDS_REPAIR
+    )
+    assert snapshot.csv_migrations == ()
+    if table != "completed":
+        assert "restore custom corrections" in str(
+            snapshot.issues if table == "pending" else snapshot.warnings
+        )
+
+
+def test_old_completed_legacy_and_csv_markers_stay_settled(
+    library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Adding lifecycle state cannot replay archives completed by an earlier version."""
+    seed_raw(library, [("repaired", 270, 1, 2)])
+    for source in (library.rotationsdb_file, library.partsdb_file):
+        seed_legacy(source, [("repaired", "47u"), ("deleted", 90)])
+        execute(
+            library.globalcorrectionsdb_file,
+            "INSERT INTO correction_migrations VALUES (?, ?)",
+            (library._legacy_migration_key(source), source),
+        )
+    execute(
+        library.globalcorrectionsdb_file,
+        "INSERT INTO correction_migrations VALUES ('csv:preserved', 'legacy.csv')",
+    )
+    execute(library.globalcorrectionsdb_file, "DROP TABLE correction_migration_state")
+    library.create_mapping_table()
+    reopened = fresh_library(library)
+
+    def forbidden(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("completed historical metadata caused a write or legacy probe")
+
+    monkeypatch.setattr(reopened, "_correction_transaction", forbidden)
+    monkeypatch.setattr(reopened, "_legacy_rotation_rows", forbidden)
+    reopened.check_library()
+    assert correction_values(reopened) == [("repaired", 270, (1.0, 2.0))]
+    assert reopened.read_correction_data().csv_migrations == (
+        ("csv:preserved", "legacy.csv"),
+    )
+
+
+def test_unknown_archive_warning_defers_lower_priority_and_retries(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Recovered custom rotations cannot lose to prematurely imported parts values."""
+    seed_raw(library, [("existing", 270, 1, 2)])
+    Path(library.rotationsdb_file).write_bytes(b"temporarily unreadable")
+    seed_legacy(library.partsdb_file, [("priority", 180), ("parts-only", 0)])
+    assert library.migrate_corrections() == ()
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.READY
+    assert any(issue.source == library.rotationsdb_file for issue in snapshot.warnings)
+    assert correction_values(library) == [("existing", 270, (1.0, 2.0))]
+    Path(library.rotationsdb_file).unlink()
+    seed_legacy(library.rotationsdb_file, [("priority", 90)])
+    assert fresh_library(library).retry_correction_migrations() == ()
+    assert correction_values(library) == [
+        ("existing", 270, (1.0, 2.0)),
+        ("parts-only", 0, (0.0, 0.0)),
+        ("priority", 90, (0.0, 0.0)),
+    ]
+    assert fresh_library(library).read_correction_data().warnings == ()
+
+
+def test_failed_known_transfer_remains_blocking_without_source_probes(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rollback retains durable knowledge of missing custom corrections."""
+    seed_legacy(library.rotationsdb_file, [("explode", 90)])
+    install_abort_trigger(library.globalcorrectionsdb_file)
+    assert library.migrate_corrections()
+    reopened = fresh_library(library)
+
+    def forbidden_probe(source: str) -> None:
+        pytest.fail(f"snapshot rediscovered pending source {source}")
+
+    monkeypatch.setattr(reopened, "_legacy_rotation_rows", forbidden_probe)
+    snapshot = reopened.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.UNAVAILABLE
+    assert snapshot.corrections is None
+    assert any(issue.source == library.rotationsdb_file for issue in snapshot.issues)
+    assert raw_rows(library) == []
+
+
+def test_pending_metadata_failure_blocks_captured_target_until_retry(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Failure to persist positive knowledge cannot make the same session ready."""
+    seed_raw(library, [("existing", 270, 1, 2)])
+    seed_legacy(library.rotationsdb_file, [("custom", 90)])
+    execute(
+        library.globalcorrectionsdb_file,
+        "CREATE TRIGGER deny_pending BEFORE INSERT ON correction_migration_state "
+        "WHEN NEW.status='pending' BEGIN SELECT RAISE(ABORT, 'pending metadata denied'); END",
+    )
+    before = raw_rows(library)
+    library.create_mapping_table()
+    library.parent.settings = {"library": {"data_path": library.datadir}}
+    library = modules.library.Library(library.parent)
+    assert library.retry_correction_migrations()
+    snapshot = library.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.UNAVAILABLE
+    assert snapshot.corrections is None
+    assert "pending metadata denied" in str(snapshot.issues)
+    assert raw_rows(library) == before
+    library.create_correction_table(library.localcorrectionsdb_file)
+    library.correctionsdb_file = library.localcorrectionsdb_file
+    assert library.read_correction_data().corrections == ()
+    library.correctionsdb_file = library.globalcorrectionsdb_file
+    execute(library.globalcorrectionsdb_file, "DROP TRIGGER deny_pending")
+    assert library.retry_correction_migrations() == ()
+    assert correction_values(library) == [
+        ("custom", 90, (0.0, 0.0)),
+        ("existing", 270, (1.0, 2.0)),
+    ]
+
+
+@pytest.mark.parametrize("unreadable", [False, True])
+def test_failed_optional_bookkeeping_preserves_ready_corrections(
+    modules: SimpleNamespace, library: Any, unreadable: bool
+) -> None:
+    """A read-only destination does not turn absence or unknown archives into lost data."""
+    seed_raw(library, [("existing", 270, 1, 2)])
+    if unreadable:
+        Path(library.rotationsdb_file).write_bytes(b"unclassified archive")
+    execute(
+        library.globalcorrectionsdb_file,
+        "CREATE TRIGGER deny_state BEFORE INSERT ON "
+        + ("correction_migration_state " if unreadable else "correction_migrations ")
+        + "BEGIN SELECT RAISE(ABORT, 'bookkeeping denied'); END",
+    )
+    assert library.retry_correction_migrations() == ()
+    snapshot = library.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.READY
+    assert snapshot.issues == ()
+    assert snapshot.warnings
+    if unreadable:
+        assert any(
+            issue.source == library.rotationsdb_file for issue in snapshot.warnings
+        )
+    assert correction_values(library) == [("existing", 270, (1.0, 2.0))]
+
+
+@pytest.mark.parametrize("damage", ["missing", "no-table", "unreadable", "empty"])
+def test_known_pending_source_cannot_be_downgraded_after_later_damage(
+    modules: SimpleNamespace, library: Any, damage: str
+) -> None:
+    """Positive knowledge survives later loss of readable source rows."""
+    seed_legacy(library.rotationsdb_file, [("explode", 90)])
+    install_abort_trigger(library.globalcorrectionsdb_file)
+    assert library.migrate_corrections()
+    execute(library.globalcorrectionsdb_file, "DROP TRIGGER fail_write")
+    Path(library.rotationsdb_file).unlink()
+    if damage == "no-table":
+        execute(library.rotationsdb_file, "CREATE TABLE unrelated (value)")
+    elif damage == "unreadable":
+        Path(library.rotationsdb_file).write_bytes(b"unreadable now")
+    elif damage == "empty":
+        seed_legacy(library.rotationsdb_file, [])
+    reopened = fresh_library(library)
+    assert reopened.retry_correction_migrations()
+    snapshot = reopened.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.UNAVAILABLE
+    assert snapshot.corrections is None
+    assert any(issue.source == library.rotationsdb_file for issue in snapshot.issues)
+    assert raw_rows(library) == []
+
+
+def test_changing_parts_library_keeps_unfinished_archive_priority(library: Any) -> None:
+    """A newly selected parts source cannot outrank an earlier deferred archive."""
+    first_parts = Path(library.partsdb_file)
+    first_parts.write_bytes(b"pending old library download")
+    assert library.migrate_corrections() == ()
+    library.partsdb_file = str(first_parts.with_name("other-parts.db"))
+    seed_legacy(library.partsdb_file, [("same", 180)])
+    assert library.migrate_corrections() == ()
+    assert raw_rows(library) == []
+    first_parts.unlink()
+    seed_legacy(first_parts, [("same", 90)])
+    assert fresh_library(library).retry_correction_migrations() == ()
+    assert correction_values(library) == [("same", 90, (0.0, 0.0))]
+
+
+@pytest.mark.parametrize(
+    "condition",
+    ["empty", "valid", "row", "conflict", "migration", "storage", "metadata"],
+)
+def test_snapshot_readiness_distinguishes_empty_repair_and_unavailable(
+    modules: SimpleNamespace, library: Any, condition: str
+) -> None:
+    """Only complete ready sets are usable, including the deliberately empty set."""
+    if condition != "empty":
+        seed_raw(library, [("existing", 90, 1.25, -2.5)])
+    if condition == "row":
+        seed_raw(library, [("broken", "47u", 0, 0)])
+    elif condition == "conflict":
+        seed_raw(library, [("existing", 180, 0, 0)])
+    elif condition == "migration":
+        seed_legacy(library.rotationsdb_file, [("pending", 180)])
+        install_abort_trigger(library.globalcorrectionsdb_file, pattern="pending")
+        assert library.migrate_corrections()
+    elif condition == "storage":
+        Path(library.correctionsdb_file).write_bytes(b"broken destination")
+    elif condition == "metadata":
+        execute(library.correctionsdb_file, "DROP TABLE correction_migrations")
+        execute(
+            library.correctionsdb_file, "CREATE TABLE correction_migrations (wrong)"
+        )
+
+    snapshot = fresh_library(library).read_correction_data()
+
+    if condition in {"empty", "valid"}:
+        assert snapshot.state is modules.library.CorrectionState.READY
+        assert snapshot.corrections == (
+            ()
+            if condition == "empty"
+            else (modules.data.Correction("existing", 90, (1.25, -2.5)),)
+        )
+        assert snapshot.issues == ()
+    else:
+        assert snapshot.corrections is None
+        assert snapshot.issues
+        expected = (
+            modules.library.CorrectionState.NEEDS_REPAIR
+            if condition in {"row", "conflict"}
+            else modules.library.CorrectionState.UNAVAILABLE
+        )
+        assert snapshot.state is expected
+        if condition != "storage":
+            assert any(row.pattern == "existing" for row in snapshot.rows)
+
+
+@pytest.mark.parametrize("legacy_rotation", [0, "47u"])
+@pytest.mark.parametrize("destination_rotation", [270, "47u"])
+def test_pending_legacy_sources_preserve_established_destination(
+    library: Any, legacy_rotation: Any, destination_rotation: Any
+) -> None:
+    """A pre-marker installation keeps repaired offsets and any remaining bad data."""
+    seed_raw(library, [("established", destination_rotation, 1.25, -2.5)])
+    before = raw_rows(library)
+    originals = [("established", legacy_rotation)]
+    seed_legacy(library.rotationsdb_file, originals)
+    seed_legacy(library.partsdb_file, originals)
+
+    assert library.migrate_corrections() == ()
+
+    assert raw_rows(library) == before
+    assert len(migration_rows(library)) == 2
+    for source in (library.rotationsdb_file, library.partsdb_file):
+        assert execute(source, "SELECT * FROM rotation") == originals
+    fresh_library(library).check_library()
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize("failure", ["row", "marker"])
+def test_pending_legacy_batch_failure_rolls_back_every_source(
+    library: Any, failure: str
+) -> None:
+    """A later source failure cannot commit earlier rows or completion markers."""
+    seed_raw(library, [("established", 270, 1.25, -2.5)])
+    before = raw_rows(library)
+    seed_legacy(library.rotationsdb_file, [("first-source", 90)])
+    seed_legacy(library.partsdb_file, [("explode", 180)])
+    if failure == "row":
+        install_abort_trigger(library.globalcorrectionsdb_file)
+    else:
+        execute(
+            library.globalcorrectionsdb_file,
+            "CREATE TRIGGER fail_marker BEFORE INSERT ON correction_migrations "
+            "WHEN NEW.source LIKE '%parts.db' "
+            "BEGIN SELECT RAISE(ABORT, 'injected marker failure'); END",
+        )
+
+    assert library.migrate_corrections()
+    assert raw_rows(library) == before
+    assert migration_rows(library) == []
+    assert fresh_library(library).read_correction_data().issues
+
+    trigger = "fail_write" if failure == "row" else "fail_marker"
+    execute(library.globalcorrectionsdb_file, f"DROP TRIGGER {trigger}")
+    fresh_library(library).check_library()
+    assert [row[1:] for row in raw_rows(library)] == [
+        ("established", 270, 1.25, -2.5),
+        ("first-source", 90, 0, 0),
+        ("explode", 180, 0, 0),
+    ]
+    assert len(migration_rows(library)) == 2
+
+
+def test_new_pending_source_preserves_a_repair_after_partial_migration(
+    library: Any,
+) -> None:
+    """A later archive cannot undo a repair after another source was completed."""
+    seed_legacy(library.rotationsdb_file, [("repaired", 90)])
+    library.migrate_corrections_from_rotation()
+    rowid = raw_rows(library)[0][0]
+    library.save_correction_data("repaired", 270, (1.25, -2.5), rowid=rowid)
+    seed_legacy(library.partsdb_file, [("repaired", "47u"), ("new", 180)])
+    assert fresh_library(library).migrate_corrections() == ()
+    assert correction_values(fresh_library(library)) == [
+        ("new", 180, (0.0, 0.0)),
+        ("repaired", 270, (1.25, -2.5)),
+    ]
+    assert len(migration_rows(library)) == 2
+
+
+@pytest.mark.parametrize("pattern", [None, 17, b"raw", "", "  "])
+def test_unidentifiable_legacy_patterns_are_never_silently_suppressed(
+    library: Any, pattern: Any
+) -> None:
+    """Raw invalid identity values remain repairable in destination and both archives."""
+    seed_raw(library, [(pattern, 270, 1, 2)])
+    seed_legacy(library.rotationsdb_file, [(pattern, 90)])
+    seed_legacy(library.partsdb_file, [(pattern, "47u")])
+    assert library.migrate_corrections() == ()
+    assert [row[1:] for row in raw_rows(library)] == [
+        (pattern, 270, 1, 2),
+        (pattern, 90, 0, 0),
+        (pattern, "47u", 0, 0),
+    ]
+    assert fresh_library(library).get_all_correction_data() is None
+
+
+def test_established_invalid_regex_is_preserved_without_legacy_duplicates(
+    library: Any,
+) -> None:
+    """An identifiable existing row remains the user's repair target even if invalid."""
+    seed_raw(library, [("[", "47u", 1.25, -2.5)])
+    before = raw_rows(library)
+    seed_legacy(library.rotationsdb_file, [("[", 90)])
+    assert library.migrate_corrections() == ()
+    assert raw_rows(library) == before
+    assert fresh_library(library).get_all_correction_data() is None
+
+
+def test_winning_legacy_source_retains_its_internal_conflicts(
+    modules: Any, library: Any
+) -> None:
+    """Rotations beats parts while contradictions within rotations remain repairable."""
+    seed_legacy(library.rotationsdb_file, [("same", 90), ("same", 180)])
+    seed_legacy(library.partsdb_file, [("same", "47u")])
+    assert library.migrate_corrections() == ()
+    snapshot = fresh_library(library).read_correction_data()
+    assert [row.rotation for row in snapshot.rows] == [90, 180]
+    assert all(
+        any("conflicting" in issue.message for issue in row.issues)
+        for row in snapshot.rows
+    )
+    assert snapshot.state is modules.library.CorrectionState.NEEDS_REPAIR
+    assert snapshot.corrections is None
+    assert len(migration_rows(library)) == 2
+    before = raw_rows(library)
+    fresh_library(library).check_library()
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize(
+    "failure", ["invalid-global", "migration", "migration-write", "drop"]
+)
+def test_failed_discard_preserves_invalid_local_records_and_selection(
+    modules: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    """A failed destination check or actual SQL drop cannot discard active repairs."""
+    instance = make_library(
+        modules.library, tmp_path, [("local", "47u", 1, 2)], local=True
+    )
+    instance.create_correction_table(instance.globalcorrectionsdb_file)
+    before = raw_rows(instance)
+    if failure == "invalid-global":
+        execute(
+            instance.globalcorrectionsdb_file,
+            "INSERT INTO correction VALUES ('global','47u',0,0)",
+        )
+    elif failure == "migration":
+        seed_legacy(instance.rotationsdb_file, [("explode", 90)])
+        install_abort_trigger(instance.globalcorrectionsdb_file)
+    elif failure == "migration-write":
+        seed_legacy(instance.rotationsdb_file, [("custom", 90)])
+        execute(instance.globalcorrectionsdb_file, "DROP TABLE correction_migrations")
+        connect = sqlite3.connect
+
+        def deny_metadata(operation: int, table: str, *arguments: Any) -> int:
+            return (
+                sqlite3.SQLITE_DENY
+                if operation == sqlite3.SQLITE_CREATE_TABLE
+                and table == "correction_migrations"
+                else sqlite3.SQLITE_OK
+            )
+
+        def protected_connect(target: Any, **kwargs: Any) -> sqlite3.Connection:
+            connection = connect(target, **kwargs)
+            if target == instance.globalcorrectionsdb_file:
+                connection.set_authorizer(deny_metadata)
+            return connection
+
+        monkeypatch.setattr(sqlite3, "connect", protected_connect)
+    else:
+        transaction = instance._correction_transaction
+
+        def deny_drop(operation: int, *arguments: Any) -> int:
+            return (
+                sqlite3.SQLITE_DENY
+                if operation == sqlite3.SQLITE_DROP_TABLE
+                else sqlite3.SQLITE_OK
+            )
+
+        @contextmanager
+        def protected_transaction(
+            target: Any, **kwargs: Any
+        ) -> Iterator[sqlite3.Connection]:
+            with transaction(target, **kwargs) as connection:
+                if target == instance.localcorrectionsdb_file:
+                    connection.set_authorizer(deny_drop)
+                yield connection
+
+        monkeypatch.setattr(instance, "_correction_transaction", protected_transaction)
+    with pytest.raises(modules.data.CorrectionDataError):
+        instance.switch_to_global_correction_database(True)
+    assert instance.correctionsdb_file == instance.localcorrectionsdb_file
+    assert raw_rows(instance) == before
+    assert fresh_library(instance).uses_global_correction_database() is False
+
+
+@pytest.mark.parametrize(
+    "legacy_row",
+    [
+        (17, 90),
+        (17.5, 90),
+        ("valid-pattern", "-9223372036854775809"),
+        ("valid-pattern", "9007199254740993.0"),
+    ],
+)
+def test_legacy_migration_rejects_affinity_changes_to_original_data(
+    modules: SimpleNamespace, library: Any, legacy_row: tuple[object, object]
+) -> None:
+    """A typed destination cannot turn malformed archived values into usable corrections."""
+    execute(library.correctionsdb_file, "DROP TABLE correction")
+    execute(
+        library.correctionsdb_file,
+        "CREATE TABLE correction (regex TEXT, rotation INTEGER, offset_x REAL, offset_y REAL)",
+    )
+    seed_legacy(library.rotationsdb_file, [("first", 90)])
+    seed_legacy(library.partsdb_file, [legacy_row])
+    assert library.migrate_corrections()
+    assert raw_rows(library) == []
+    assert migration_rows(library) == []
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.UNAVAILABLE
+    assert snapshot.corrections is None
+    assert execute(library.partsdb_file, "SELECT * FROM rotation") == [legacy_row]
+
+
+def test_typed_legacy_destination_allows_safe_normalization_and_raw_repairs(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Safe numeric representations normalize while compatible malformed rows stay raw."""
+    execute(library.correctionsdb_file, "DROP TABLE correction")
+    execute(
+        library.correctionsdb_file,
+        "CREATE TABLE correction (regex TEXT, rotation INTEGER, offset_x REAL, offset_y REAL)",
+    )
+    seed_legacy(library.rotationsdb_file, [("integer", 90), ("numeric-text", "90.0")])
+    seed_legacy(library.partsdb_file, [("bad", "47u"), (None, 180)])
+    assert library.migrate_corrections() == ()
+    assert [row[1:] for row in raw_rows(library)] == [
+        ("integer", 90, 0.0, 0.0),
+        ("numeric-text", 90, 0.0, 0.0),
+        ("bad", "47u", 0.0, 0.0),
+        (None, 180, 0.0, 0.0),
+    ]
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.NEEDS_REPAIR
+    assert snapshot.corrections is None
+    assert len(migration_rows(library)) == 2
+
+
+@pytest.mark.parametrize("affinity", ["", "INTEGER", "NUMERIC", "REAL"])
+def test_supported_offset_schemas_round_trip_float_precision(
+    modules: SimpleNamespace, library: Any, affinity: str
+) -> None:
+    """All supported offset affinities preserve normalized floating-point values."""
+    execute(library.correctionsdb_file, "DROP TABLE correction")
+    execute(
+        library.correctionsdb_file,
+        f"CREATE TABLE correction (regex TEXT, rotation INTEGER, offset_x {affinity}, offset_y {affinity})",
+    )
+    original = modules.data.Correction(
+        "precise", 90, (0.12345678901234567, -0.23456789012345678)
+    )
+    library.apply_corrections([original])
+    assert fresh_library(library).get_all_correction_data() == (original,)
+
+
+@pytest.mark.parametrize("offset_column", ["offset_x", "offset_y"])
+def test_text_offset_schema_cannot_round_validated_values(
+    modules: SimpleNamespace, library: Any, offset_column: str
+) -> None:
+    """SQLite's decimal conversion for TEXT offsets loses significant float digits."""
+    execute(library.correctionsdb_file, "DROP TABLE correction")
+    declarations = [
+        f"{name} {'TEXT' if name == offset_column else 'REAL'}"
+        for name in ("offset_x", "offset_y")
+    ]
+    execute(
+        library.correctionsdb_file,
+        "CREATE TABLE correction (regex TEXT, rotation INTEGER, "
+        + ", ".join(declarations)
+        + ")",
+    )
+    original = modules.data.Correction(
+        "precise", 90, (0.12345678901234567, -0.23456789012345678)
+    )
+    with pytest.raises(modules.data.CorrectionDataError, match="offset"):
+        library.apply_corrections([original])
+    assert raw_rows(library) == []
+
+
+@pytest.mark.parametrize("broken_source", [False, True])
+def test_constructor_waits_for_legacy_batch_before_remote_defaults(
+    modules: SimpleNamespace,
+    library: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    broken_source: bool,
+) -> None:
+    """Default downloads cannot become established corrections ahead of archived custom values."""
+    library.partsdb_file = str(
+        Path(library.datadir)
+        / modules.library.LIBRARY_CONFIGS[modules.library.DEFAULT_LIBRARY].name
+    )
+    prepare_constructor_storage(library)
+    seed_legacy(library.rotationsdb_file, [("custom", 270)])
+    if broken_source:
+        Path(library.partsdb_file).write_bytes(b"unreadable pending archive")
+    else:
+        seed_legacy(library.partsdb_file, [("other", 180)])
+    http_get = MagicMock(
+        return_value=response("Pattern,Rotation\ncustom,90\nremote-only,0\n")
+    )
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+
+    monkeypatch.setattr(modules.library, "Thread", immediate_thread)
+    first = modules.library.Library(library.parent)
+    if broken_source:
+        http_get.assert_not_called()
+        assert (
+            first.read_correction_data().state is modules.library.CorrectionState.READY
+        )
+        assert first.read_correction_data().warnings
+        assert first.get_correction_data("custom") == ("custom", 270, 0, 0)
+        assert len(migration_rows(first)) == 1
+        Path(library.partsdb_file).unlink()
+        seed_legacy(library.partsdb_file, [("other", 180)])
+    else:
+        http_get.assert_called_once()
+    reopened = modules.library.Library(library.parent)
+    assert (
+        reopened.read_correction_data().state is modules.library.CorrectionState.READY
+    )
+    assert reopened.get_correction_data("custom") == ("custom", 270, 0, 0)
+    assert reopened.get_correction_data("other") == ("other", 180, 0, 0)
+    assert reopened.get_correction_data("remote-only") == ("remote-only", 0, 0, 0)
+    http_get.assert_called_once()
+    execute(reopened.globalcorrectionsdb_file, "DELETE FROM correction")
+    assert raw_rows(modules.library.Library(library.parent)) == []
+    http_get.assert_called_once()
+
+
+def test_interrupted_initialization_resumes_defaults_without_replaying_deletions(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Creating storage is not a successful seed; a committed seed is never replayed."""
+    prepare_constructor_storage(library)
+
+    def interrupted_retry(instance: Any) -> tuple[Any, ...]:
+        raise RuntimeError("interrupted after creating destination")
+
+    with monkeypatch.context() as interruption:
+        interruption.setattr(
+            modules.library.Library, "retry_correction_migrations", interrupted_retry
+        )
+        with pytest.raises(RuntimeError, match="interrupted"):
+            modules.library.Library(library.parent)
+    http_get = MagicMock(return_value=response("Pattern,Rotation\nremote-only,90\n"))
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+
+    monkeypatch.setattr(modules.library, "Thread", immediate_thread)
+    reopened = modules.library.Library(library.parent)
+    assert reopened.get_correction_data("remote-only") == ("remote-only", 90, 0, 0)
+    http_get.assert_called_once()
+    execute(reopened.globalcorrectionsdb_file, "DELETE FROM correction")
+    reopened.fetch_remote_corrections(initial=True)
+    assert raw_rows(reopened) == []
+    assert raw_rows(modules.library.Library(library.parent)) == []
+
+
+def test_interrupted_initial_seed_recovers_original_library_before_new_selection(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Captured archives remain discoverable and retain priority after library selection changes."""
+    prepare_constructor_storage(library)
+    original_config = modules.library.LIBRARY_CONFIGS[modules.library.DEFAULT_LIBRARY]
+    original_path = Path(library.datadir) / original_config.name
+    seed_legacy(original_path, [("custom", 270)])
+
+    def interrupted_retry(instance: Any) -> tuple[Any, ...]:
+        raise RuntimeError("interrupted before archive examination")
+
+    with monkeypatch.context() as interruption:
+        interruption.setattr(
+            modules.library.Library, "retry_correction_migrations", interrupted_retry
+        )
+        with pytest.raises(RuntimeError, match="interrupted"):
+            modules.library.Library(library.parent)
+    alternate_key, alternate_config = next(
+        (key, config)
+        for key, config in modules.library.LIBRARY_CONFIGS.items()
+        if config.name != original_config.name
+    )
+    library.parent.settings["library"]["selected_library"] = alternate_key
+    alternate_path = Path(library.datadir) / alternate_config.name
+    seed_legacy(alternate_path, [("custom", 90), ("new-library", 180)])
+    http_get = MagicMock(
+        return_value=response("Pattern,Rotation\ncustom,0\nremote-only,0\n")
+    )
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+
+    monkeypatch.setattr(modules.library, "Thread", immediate_thread)
+    reopened = modules.library.Library(library.parent)
+    assert correction_values(reopened) == [
+        ("custom", 270, (0.0, 0.0)),
+        ("new-library", 180, (0.0, 0.0)),
+        ("remote-only", 0, (0.0, 0.0)),
+    ]
+    http_get.assert_called_once()
+    assert execute(original_path, "SELECT * FROM rotation") == [("custom", 270)]
+
+
+def test_concurrent_constructors_share_initial_download_and_commit_once(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reopening a manager during an in-flight initial seed cannot launch another one."""
+    prepare_constructor_storage(library)
+    scheduled = []
+
+    def queued_thread(
+        *, target: Callable[..., Any], args: tuple[Any, ...], daemon: bool
+    ) -> SimpleNamespace:
+        return SimpleNamespace(start=lambda: scheduled.append((target, args)))
+
+    monkeypatch.setattr(modules.library, "Thread", queued_thread)
+    http_get = MagicMock(return_value=response("Pattern,Rotation\nremote-only,90\n"))
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+    first = modules.library.Library(library.parent)
+    second = modules.library.Library(library.parent)
+    second.retry_correction_migrations()
+    assert len(scheduled) == 1
+    target, args = scheduled.pop()
+    target(*args)
+    assert first.get_correction_data("remote-only") == ("remote-only", 90, 0, 0)
+    execute(first.globalcorrectionsdb_file, "DELETE FROM correction")
+    first.retry_correction_migrations()
+    second.retry_correction_migrations()
+    assert scheduled == []
+    assert raw_rows(second) == []
+    http_get.assert_called_once()
+
+
+def test_failed_unknown_source_bookkeeping_cannot_authorize_initial_defaults(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing durable classification must block seeding even in another instance."""
+    prepare_constructor_storage(library)
+    Path(library.rotationsdb_file).write_bytes(b"unclassified custom archive")
+    retry = modules.library.Library.retry_correction_migrations
+
+    def denied_first_retry(instance: Any) -> tuple[Any, ...]:
+        seed_raw(instance, [("existing", 270, 1, 2)])
+        execute(
+            instance.globalcorrectionsdb_file,
+            "CREATE TRIGGER deny_deferred BEFORE INSERT ON correction_migration_state "
+            "WHEN NEW.status='deferred' BEGIN SELECT RAISE(ABORT, 'deferred bookkeeping denied'); END",
+        )
+        return retry(instance)
+
+    http_get = MagicMock(
+        return_value=response("Pattern,Rotation\ncustom,180\nremote-only,0\n")
+    )
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+
+    monkeypatch.setattr(modules.library, "Thread", immediate_thread)
+    with monkeypatch.context() as first_start:
+        first_start.setattr(
+            modules.library.Library, "retry_correction_migrations", denied_first_retry
+        )
+        first = modules.library.Library(library.parent)
+    assert first.read_correction_data().state is modules.library.CorrectionState.READY
+    assert first.read_correction_data().warnings
+    http_get.assert_not_called()
+    other = fresh_library(first)
+    result = other.apply_corrections(
+        [("custom", 180, (0, 0)), ("remote-only", 0, (0, 0))],
+        migration_key=modules.library._INITIAL_DEFAULTS_KEY,
+        overwrite=False,
+    )
+    assert result.changed == 0
+    assert correction_values(other) == [("existing", 270, (1.0, 2.0))]
+    assert not other.has_correction_migration(modules.library._INITIAL_DEFAULTS_KEY)
+    Path(library.rotationsdb_file).unlink()
+    seed_legacy(library.rotationsdb_file, [("custom", 90)])
+    assert first.retry_correction_migrations() == ()
+    assert correction_values(first) == [
+        ("custom", 90, (0.0, 0.0)),
+        ("existing", 270, (1.0, 2.0)),
+        ("remote-only", 0, (0.0, 0.0)),
+    ]
+    http_get.assert_called_once()
+
+
+def test_initial_seed_marker_failure_rolls_back_and_resumes(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A completion failure rolls back defaults while preserving prior custom migration."""
+    prepare_constructor_storage(library)
+    seed_legacy(library.rotationsdb_file, [("custom", 270)])
+    retry = modules.library.Library.retry_correction_migrations
+
+    def deny_seed_marker(instance: Any) -> tuple[Any, ...]:
+        execute(
+            instance.globalcorrectionsdb_file,
+            "CREATE TRIGGER deny_seed BEFORE INSERT ON correction_migrations "
+            "WHEN NEW.migration_key LIKE 'remote:%' BEGIN SELECT RAISE(ABORT, 'seed marker denied'); END",
+        )
+        return retry(instance)
+
+    http_get = MagicMock(
+        return_value=response("Pattern,Rotation\ncustom,90\nremote-only,0\n")
+    )
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+
+    monkeypatch.setattr(modules.library, "Thread", immediate_thread)
+    with monkeypatch.context() as first_start:
+        first_start.setattr(
+            modules.library.Library, "retry_correction_migrations", deny_seed_marker
+        )
+        first = modules.library.Library(library.parent)
+    assert correction_values(first) == [("custom", 270, (0.0, 0.0))]
+    assert not first.has_correction_migration(modules.library._INITIAL_DEFAULTS_KEY)
+    execute(first.globalcorrectionsdb_file, "DROP TRIGGER deny_seed")
+    reopened = modules.library.Library(library.parent)
+    assert correction_values(reopened) == [
+        ("custom", 270, (0.0, 0.0)),
+        ("remote-only", 0, (0.0, 0.0)),
+    ]
+    assert reopened.has_correction_migration(modules.library._INITIAL_DEFAULTS_KEY)
+    assert http_get.call_count == 2
+
+
+def test_switching_back_to_global_resumes_deferred_initial_defaults(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A local board can recover its global archive and resume pending defaults."""
+    prepare_constructor_storage(library)
+    Path(library.rotationsdb_file).write_bytes(b"temporarily unreadable archive")
+    scheduled = []
+
+    def queued_thread(
+        *, target: Callable[..., Any], args: tuple[Any, ...], daemon: bool
+    ) -> SimpleNamespace:
+        return SimpleNamespace(start=lambda: scheduled.append((target, args)))
+
+    monkeypatch.setattr(modules.library, "Thread", queued_thread)
+    instance = modules.library.Library(library.parent)
+    assert scheduled == []
+    instance.switch_to_global_correction_database(False)
+    instance.apply_corrections([("local", 180, (1, 2))])
+    Path(instance.rotationsdb_file).unlink()
+    seed_legacy(instance.rotationsdb_file, [("custom", 270)])
+    instance.switch_to_global_correction_database(True)
+    assert instance.correctionsdb_file == instance.globalcorrectionsdb_file
+    assert len(scheduled) == 1
+    assert instance.get_correction_data("custom") == ("custom", 270, 0, 0)
+    http_get = MagicMock(
+        return_value=response("Pattern,Rotation\ncustom,90\nremote-only,0\n")
+    )
+    monkeypatch.setattr(modules.library.requests, "get", http_get)
+    target, args = scheduled.pop()
+    target(*args)
+    assert correction_values(instance) == [
+        ("custom", 270, (0.0, 0.0)),
+        ("remote-only", 0, (0.0, 0.0)),
+    ]
+
+
+@pytest.mark.parametrize("entry", ["retry", "startup", "scope"])
+def test_optional_download_start_failure_preserves_healthy_corrections(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch, entry: str
+) -> None:
+    """Every scheduling entry leaves usable data and retryable initial defaults."""
+    seed_raw(library, [("existing", 90, 1, 2)])
+    library.create_mapping_table()
+    library.migrate_corrections()
+    execute(
+        library.globalcorrectionsdb_file,
+        "INSERT INTO correction_migration_state VALUES (?, ?, 'seed-pending', ?)",
+        (
+            modules.library._INITIAL_DEFAULTS_KEY,
+            library.globalcorrectionsdb_file,
+            modules.library.json.dumps(
+                [library.rotationsdb_file, library.partsdb_file]
+            ),
+        ),
+    )
+    thread = MagicMock()
+    thread.return_value.start.side_effect = RuntimeError("thread could not start")
+    monkeypatch.setattr(modules.library, "Thread", thread)
+    if entry == "scope":
+        library.switch_to_global_correction_database(False)
+        library.switch_to_global_correction_database(True)
+        assert library.correctionsdb_file == library.globalcorrectionsdb_file
+        assert (
+            execute(
+                library.localcorrectionsdb_file,
+                "SELECT name FROM sqlite_master WHERE name='correction'",
+            )
+            == []
+        )
+    elif entry == "startup":
+        library.check_library()
+    else:
+        assert library.retry_correction_migrations() == ()
+    snapshot = library.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.READY
+    assert correction_values(library) == [("existing", 90, (1.0, 2.0))]
+    assert "thread could not start" in str(snapshot.warnings)
+    assert not library.has_correction_migration(modules.library._INITIAL_DEFAULTS_KEY)
+    thread.return_value.start.side_effect = None
+    assert library.retry_correction_migrations() == ()
+    assert thread.return_value.start.call_count == 2
+    assert library.read_correction_data().warnings == ()
+    modules.library._INITIAL_DOWNLOAD_TARGETS.clear()
+
+
+def test_late_active_storage_failure_remains_blocking(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A race after migration cannot hide an unreadable active correction set."""
+    seed_raw(library, [("existing", 90, 1, 2)])
+    migrate = library.migrate_corrections
+
+    def damage_after_migration() -> tuple[Any, ...]:
+        result = migrate()
+        Path(library.globalcorrectionsdb_file).write_bytes(b"unreadable active storage")
+        return result
+
+    monkeypatch.setattr(library, "migrate_corrections", damage_after_migration)
+    library.retry_correction_migrations()
+    snapshot = library.read_correction_data()
+    assert snapshot.state is modules.library.CorrectionState.UNAVAILABLE
+    assert snapshot.corrections is None
+    assert any(
+        issue.source == library.globalcorrectionsdb_file for issue in snapshot.issues
+    )
+
+
+@pytest.mark.parametrize("bad_rotation", ["47u", 90])
+def test_discard_invalid_local_corrections_for_healthy_global_and_reopen(
+    modules: Any, tmp_path: Path, bad_rotation: Any
+) -> None:
+    """Global selection drops the local table even when its rows need repair."""
+    rows = [("same", bad_rotation, 0, 0), ("same", 180, 0, 0)]
+    instance = make_library(modules.library, tmp_path, rows, local=True)
+    instance.create_correction_table(instance.globalcorrectionsdb_file)
+    instance.apply_corrections(
+        [("global", 270, (1.25, -2.5))], db_path=instance.globalcorrectionsdb_file
+    )
+    execute(instance.localcorrectionsdb_file, "CREATE TABLE unrelated (value)")
+    execute(instance.localcorrectionsdb_file, "INSERT INTO unrelated VALUES ('keep')")
+    instance.parent.settings = {"library": {"data_path": instance.datadir}}
+
+    instance.switch_to_global_correction_database(True)
+
+    reopened = modules.library.Library(instance.parent)
+    assert reopened.correctionsdb_file == instance.globalcorrectionsdb_file
+    assert correction_values(reopened) == [("global", 270, (1.25, -2.5))]
+    assert execute(instance.localcorrectionsdb_file, "SELECT * FROM unrelated") == [
+        ("keep",)
+    ]
+    assert (
+        execute(
+            instance.localcorrectionsdb_file,
+            "SELECT name FROM sqlite_master WHERE name='correction'",
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_issue_531_invalid_rotation_never_persists(
+    modules: SimpleNamespace, library: Any, existing: bool
+) -> None:
+    """Reject the reported 47u value without destroying an existing rotation."""
+    if existing:
+        seed_raw(library, [("Capacitor.*", 90, 0.25, -0.5)])
+    before = raw_rows(library)
+
+    with pytest.raises(modules.data.CorrectionDataError, match="47u") as error:
+        library.apply_corrections([("Capacitor.*", "47u", (0, 0))])
+
+    assert "rotation" in str(error.value)
+    assert "Capacitor" in str(error.value)
+    assert raw_rows(library) == before
+    assert correction_values(fresh_library(library)) == (
+        [("Capacitor.*", 90, (0.25, -0.5))] if existing else []
+    )
+    library.apply_corrections([("Capacitor.*", "-90", (".125", "-.5"))])
+    assert correction_values(fresh_library(library)) == [
+        ("Capacitor.*", -90, (0.125, -0.5))
+    ]
+
+
+@pytest.mark.parametrize("bad_position", [0, 1, 3])
+@pytest.mark.parametrize("overwrite", [False, True])
+def test_validate_complete_batch_before_any_write(
+    modules: SimpleNamespace, library: Any, bad_position: int, overwrite: bool
+) -> None:
+    """Every bad-row position preserves all prior inserts and replacements."""
+    seed_raw(library, [("existing", 90, 0.25, -0.5), ("untouched", 0, 0, 0)])
+    before = raw_rows(library)
+    batch = [
+        ("insert-before", 180, (0, 0)),
+        ("existing", -90, (1, 2)),
+        ("insert-after", 270, (3, 4)),
+    ]
+    batch.insert(bad_position, ("bad", "47u", (0, 0)))
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.apply_corrections(batch, overwrite=overwrite)
+    assert raw_rows(library) == before
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 90, (0.25, -0.5)),
+        ("untouched", 0, (0.0, 0.0)),
+    ]
+
+
+@pytest.mark.parametrize("overwrite", [False, True])
+@pytest.mark.parametrize("bad_first", [False, True])
+def test_invalid_duplicate_cannot_hide_behind_resolution(
+    modules, library, overwrite, bad_first
+):
+    """Validate duplicates even when last-wins or insert-only would skip them."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    batch = [("existing", 180, (0, 0)), ("existing", "47u", (0, 0))]
+    if bad_first:
+        batch.reverse()
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.apply_corrections(batch, overwrite=overwrite)
+    assert raw_rows(library) == before
+
+
+def test_database_failure_rolls_back_prior_insert_and_update(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A real SQLite abort restores all earlier mutations in the batch."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    install_abort_trigger(library.correctionsdb_file)
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="injected write failure"
+    ):
+        library.apply_corrections(
+            [
+                ("first", 0, (0, 0)),
+                ("existing", 180, (1, 2)),
+                ("explode", 270, (3, 4)),
+            ]
+        )
+    assert raw_rows(library) == before
+    assert correction_values(fresh_library(library)) == [("existing", 90, (0.0, 0.0))]
+
+
+@pytest.mark.parametrize("overwrite", [False, True])
+def test_successful_batch_has_explicit_duplicate_policy(
+    modules: SimpleNamespace, library: Any, overwrite: bool
+) -> None:
+    """User import keeps last input; remote insertion preserves first input."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    result = library.apply_corrections(
+        [
+            modules.data.Correction("new", 180, (0.25, -0.5)),
+            ("existing", "270.0", ("1.5", "-2")),
+            ("new", "-90", ("3", "4")),
+        ],
+        overwrite=overwrite,
+    )
+    assert result.changed
+    assert result.inserted == 1
+    assert result.updated == int(overwrite)
+    assert correction_values(fresh_library(library)) == (
+        [("existing", 270, (1.5, -2.0)), ("new", -90, (3.0, 4.0))]
+        if overwrite
+        else [("existing", 90, (0.0, 0.0)), ("new", 180, (0.25, -0.5))]
+    )
+
+
+def test_empty_batch_is_noop(library):
+    """A valid empty import leaves records and commit result unchanged."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    result = library.apply_corrections([])
+    assert not result.changed
+    assert (result.inserted, result.updated, result.skipped) == (0, 0, 0)
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["insert_correction_data", "update_correction_data", "save_correction_data"],
+)
+def test_single_record_writers_validate_at_storage_boundary(modules, library, method):
+    """Direct callers cannot bypass validation by avoiding the CSV importer."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError, match="47u"):
+        getattr(library, method)("existing", "47u", (0, 0))
+    assert raw_rows(library) == before
+
+
+def test_typed_corrections_persist_their_immutable_normalized_values(
+    modules: Any, library: Any
+) -> None:
+    """Caller changes to mutable inputs cannot alter a validated pending write."""
+    offsets = [".25", "-.5"]
+    record = modules.data.Correction("existing", "90.0", offsets)
+    offsets[0] = "47u"
+    library.apply_corrections([record])
+    saved = modules.data.Correction("saved", "180.0", ["1.25", "-2.5"])
+    library.save_correction_data(saved)
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 90, (0.25, -0.5)),
+        ("saved", 180, (1.25, -2.5)),
+    ]
+
+
+def test_batch_target_is_captured_before_consuming_input_iterator(library: Any) -> None:
+    """Validation cannot redirect writes when another activity changes active scope."""
+    target = library.globalcorrectionsdb_file
+    execute(
+        library.localcorrectionsdb_file,
+        "CREATE TABLE correction (regex, rotation, offset_x, offset_y)",
+    )
+
+    def changing_scope():
+        yield ("first", 90, (0, 0))
+        library.correctionsdb_file = library.localcorrectionsdb_file
+        yield ("second", 180, (1, 2))
+
+    library.apply_corrections(changing_scope())
+    assert raw_rows(library) == []
+    assert correction_values(library, db_path=target) == [
+        ("first", 90, (0.0, 0.0)),
+        ("second", 180, (1.0, 2.0)),
+    ]
+
+
+def test_parameterized_crud_preserves_quotes_and_unrelated_records(
+    library: Any,
+) -> None:
+    """Apostrophes in valid patterns remain data throughout CRUD operations."""
+    pattern = r"O'Brien\:C.*' OR 1=1 --"
+    seed_raw(library, [("untouched", 0, 0, 0)])
+    library.insert_correction_data(pattern, 90, (0.25, -0.5))
+    assert library.get_correction_data(pattern) == (pattern, 90, 0.25, -0.5)
+    library.update_correction_data(pattern, -180, (1.5, 2.5))
+    assert library.get_correction_data(pattern) == (pattern, -180, 1.5, 2.5)
+    library.delete_correction_data(pattern)
+    assert library.get_correction_data(pattern) is None
+    assert correction_values(fresh_library(library)) == [("untouched", 0, (0.0, 0.0))]
+
+
+def test_read_snapshot_preserves_original_invalid_values(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Recoverable reads expose raw data while strict readers reject it."""
+    seed_raw(
+        library,
+        [("good", "90.0", ".25", "-.5"), ("broken", "47u", "0", "0")],
+    )
+    before = raw_rows(library)
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.db_path == library.correctionsdb_file
+    assert snapshot.scope == "global"
+    assert len(snapshot.rows) == 2
+    bad = next(row for row in snapshot.rows if row.pattern == "broken")
+    assert bad.rotation == "47u"
+    assert bad.offset == ("0", "0")
+    assert bad.correction is None
+    assert bad.issues[0].rowid == bad.rowid
+    assert bad.issues[0].source == library.correctionsdb_file
+    assert snapshot.corrections is None
+    assert snapshot.state is modules.library.CorrectionState.NEEDS_REPAIR
+    assert fresh_library(library).get_all_correction_data() is None
+    good = next(row for row in snapshot.rows if row.pattern == "good")
+    assert good.correction == modules.data.Correction("good", 90, (0.25, -0.5))
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize(
+    "row, field",
+    [
+        ((None, 90, 0, 0), "pattern"),
+        (("[", 90, 0, 0), "pattern"),
+        (("bad", None, 0, 0), "rotation"),
+        (("bad", b"90", 0, 0), "rotation"),
+        (("bad", 90.5, 0, 0), "rotation"),
+        (("bad", 90, "NaN", 0), "offset_x"),
+        (("bad", 90, 0, float("inf")), "offset_y"),
+        (("bad", 90, None, 0), "offset_x"),
+    ],
+)
+def test_all_invalid_database_remains_inspectable(
+    modules: SimpleNamespace, library: Any, row: tuple[object, ...], field: str
+) -> None:
+    """Unexpected historical SQLite values produce repairable field errors."""
+    seed_raw(library, [row])
+    before = raw_rows(library)
+    snapshot = fresh_library(library).read_correction_data()
+    assert len(snapshot.rows) == 1
+    assert snapshot.corrections is None
+    assert field in {issue.field for issue in snapshot.issues}
+    assert snapshot.corrections is None
+    assert raw_rows(library) == before
+
+
+def test_snapshot_and_values_are_immutable(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """A validated operation snapshot cannot change through ordinary mutation."""
+    library.apply_corrections([("good", 90, (0.25, -0.5))])
+    snapshot = library.read_correction_data()
+    assert isinstance(snapshot.rows, tuple)
+    assert isinstance(snapshot.corrections, tuple)
+    assert isinstance(snapshot.issues, tuple)
+    with pytest.raises(FrozenInstanceError):
+        snapshot.db_path = "another.db"
+    with pytest.raises(FrozenInstanceError):
+        snapshot.corrections[0].rotation = 180
+    library.update_correction_data("good", 180, (1, 2))
+    assert snapshot.corrections == (modules.data.Correction("good", 90, (0.25, -0.5)),)
+    assert correction_values(library) == [("good", 180, (1.0, 2.0))]
+
+
+def test_snapshot_reads_rows_and_migration_markers_in_same_transaction(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A concurrent legacy import cannot make an incomplete snapshot look valid."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    seed_legacy(library.rotationsdb_file, [("legacy", 180)])
+    install_abort_trigger(library.globalcorrectionsdb_file, pattern="legacy")
+    assert library.migrate_corrections()
+    execute(library.globalcorrectionsdb_file, "DROP TRIGGER fail_write")
+    assert execute(library.globalcorrectionsdb_file, "PRAGMA journal_mode=WAL") == [
+        ("wal",)
+    ]
+    read_metadata = library._correction_metadata
+    migrated = False
+
+    def migrate_between_reads(connection: sqlite3.Connection) -> tuple[Any, ...]:
+        nonlocal migrated
+        if not migrated:
+            migrated = True
+            fresh_library(library).migrate_corrections_from_rotation()
+        return read_metadata(connection)
+
+    monkeypatch.setattr(library, "_correction_metadata", migrate_between_reads)
+    snapshot = library.read_correction_data()
+    assert migrated
+    assert [row.pattern for row in snapshot.rows] == ["existing"]
+    assert any(issue.field == "migration" for issue in snapshot.issues)
+    assert snapshot.corrections is None
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 90, (0.0, 0.0)),
+        ("legacy", 180, (0.0, 0.0)),
+    ]
+
+
+def test_equal_duplicate_rows_collapse_without_losing_raw_records(library: Any) -> None:
+    """Historical numerically equivalent duplicates have one unambiguous value."""
+    seed_raw(library, [("same", "90", "0", "0"), ("same", 90.0, 0.0, 0.0)])
+    snapshot = library.read_correction_data()
+    assert len(snapshot.rows) == 2
+    assert snapshot.issues == ()
+    assert correction_values(library) == [("same", 90, (0.0, 0.0))]
+
+
+def test_conflicting_duplicates_are_visible_and_block_strict_reads(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Conflicting historical rows require an explicit repair decision."""
+    seed_raw(library, [("same", 90, 0, 0), ("same", 180, 0, 0)])
+    snapshot = library.read_correction_data()
+    assert len(snapshot.rows) == 2
+    assert snapshot.issues
+    assert snapshot.corrections is None
+    assert {issue.rowid for issue in snapshot.issues} == {
+        row.rowid for row in snapshot.rows
+    }
+
+
+@pytest.mark.parametrize(
+    "storage_kind", ["missing", "no-table", "malformed", "directory"]
+)
+def test_storage_errors_are_not_presented_as_empty_healthy_data(
+    modules: SimpleNamespace, library: Any, tmp_path: Path, storage_kind: str
+) -> None:
+    """Read failures are recoverable diagnostics and cannot create source files."""
+    target = tmp_path / f"{storage_kind}.db"
+    if storage_kind == "no-table":
+        execute(target, "CREATE TABLE unrelated (value)")
+    elif storage_kind == "malformed":
+        target.write_bytes(b"not a sqlite database")
+    elif storage_kind == "directory":
+        target.mkdir()
+    snapshot = library.read_correction_data(db_path=str(target))
+    assert snapshot.issues
+    assert snapshot.corrections is None
+    if storage_kind == "missing":
+        assert not target.exists()
+
+
+def test_row_repair_preserves_bad_row_until_validation_succeeds(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """The original reported value remains repairable after a rejected save."""
+    seed_raw(library, [("bad", "47u", "0", "0"), ("other", 90, 1, 2)])
+    rowid = next(row[0] for row in raw_rows(library) if row[1] == "bad")
+    before = raw_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.save_correction_data("bad", "still bad", (0, 0), rowid=rowid)
+    assert raw_rows(library) == before
+    library.save_correction_data("repaired", 180, (0.25, -0.5), rowid=rowid)
+    assert correction_values(fresh_library(library)) == [
+        ("other", 90, (1.0, 2.0)),
+        ("repaired", 180, (0.25, -0.5)),
+    ]
+    assert next(row[0] for row in raw_rows(library) if row[1] == "repaired") == rowid
+
+
+def test_repair_and_delete_target_only_the_selected_duplicate(library: Any) -> None:
+    """Row identity distinguishes duplicate or NULL patterns during recovery."""
+    seed_raw(
+        library,
+        [
+            (None, "47u", 0, 0),
+            (None, "bad", 0, 0),
+            ("same", 90, 0, 0),
+            ("same", 180, 0, 0),
+        ],
+    )
+    rows = raw_rows(library)
+    library.save_correction_data("fixed", 270, (0, 0), rowid=rows[0][0])
+    library.delete_correction_row(rows[1][0])
+    library.delete_correction_row(rows[2][0])
+    assert raw_rows(library) == [
+        (rows[0][0], "fixed", 270, 0.0, 0.0),
+        rows[3],
+    ]
+    assert correction_values(fresh_library(library)) == [
+        ("fixed", 270, (0.0, 0.0)),
+        ("same", 180, (0.0, 0.0)),
+    ]
+
+
+def test_row_rename_requires_explicit_collision_replacement(modules, library):
+    """A selected-row rename cannot silently overwrite another correction."""
+    seed_raw(library, [("old", 90, 0, 0), ("target", 180, 1, 2)])
+    before = raw_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.save_correction_data("target", 270, (3, 4), rowid=before[0][0])
+    assert raw_rows(library) == before
+    library.save_correction_data(
+        "target", 270, (3, 4), rowid=before[0][0], replace=True
+    )
+    assert raw_rows(library) == [(before[0][0], "target", 270, 3.0, 4.0)]
+
+
+def test_failed_replacement_restores_deleted_collision_and_selected_row(
+    modules, library
+):
+    """A trigger abort after collision deletion rolls back the complete rename."""
+    seed_raw(library, [("old", 90, 0, 0), ("target", 180, 1, 2)])
+    before = raw_rows(library)
+    install_abort_trigger(
+        library.correctionsdb_file, operation="UPDATE", pattern="target"
+    )
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="injected write failure"
+    ):
+        library.save_correction_data(
+            "target", 270, (3, 4), rowid=before[0][0], replace=True
+        )
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize("action", ["save", "delete"])
+@pytest.mark.parametrize("change", ["missing", "reused", "edited", "type"])
+def test_stale_selected_record_cannot_change_storage(
+    modules: SimpleNamespace, library: Any, action: str, change: str
+) -> None:
+    """Raw selected values, including their types, are checked under the write lock."""
+    seed_raw(library, [(None, "47u", 0, 0)])
+    selected = library.read_correction_data().rows[0]
+    if change in {"missing", "reused"}:
+        execute(library.correctionsdb_file, "DELETE FROM correction")
+        if change == "reused":
+            seed_raw(library, [("unrelated", 90, 1, 2)])
+            assert raw_rows(library)[0][0] == selected.rowid
+    else:
+        execute(
+            library.correctionsdb_file,
+            "UPDATE correction SET offset_x=?",
+            (1 if change == "edited" else 0.0,),
+        )
+    before = raw_rows(library)
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="changed|no longer exists"
+    ):
+        if action == "save":
+            library.save_correction_data(
+                "repaired", 180, (0, 0), rowid=selected.rowid, expected_record=selected
+            )
+        else:
+            library.delete_correction_row(selected.rowid, expected_record=selected)
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize("change", ["edited", "removed", "added", "reused"])
+def test_replacement_checks_the_exact_confirmed_records(
+    modules: SimpleNamespace, library: Any, change: str
+) -> None:
+    """Replacement confirmation never grants permission to modify changed collisions."""
+    seed_raw(library, [("selected", 90, 0, 0), ("target", "bad", 1, 2)])
+    selected, conflict = library.read_correction_data().rows
+    if change in {"removed", "reused"}:
+        execute(
+            library.correctionsdb_file,
+            "DELETE FROM correction WHERE rowid=?",
+            (conflict.rowid,),
+        )
+    if change in {"added", "reused"}:
+        seed_raw(library, [("target", 270, 0, 0)])
+    elif change == "edited":
+        execute(
+            library.correctionsdb_file,
+            "UPDATE correction SET rotation=180 WHERE rowid=?",
+            (conflict.rowid,),
+        )
+    before = raw_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError, match="changed"):
+        library.save_correction_data(
+            "target",
+            180,
+            (3, 4),
+            rowid=selected.rowid,
+            replace=True,
+            expected_record=selected,
+            expected_conflicts=(conflict,),
+        )
+    assert raw_rows(library) == before
+
+
+def test_migration_key_is_stable_and_distinguishes_source_and_content(
+    library, tmp_path
+):
+    """Legacy CSV completion identifies both the source path and its contents."""
+    first = tmp_path / "legacy.csv"
+    second = tmp_path / "other.csv"
+    contents = "Pattern,Rotation\npart,90\n"
+    key = library.correction_csv_migration_key(first, contents)
+    assert key == library.correction_csv_migration_key(first, contents.encode())
+    assert key != library.correction_csv_migration_key(second, contents)
+    assert key != library.correction_csv_migration_key(first, contents + "next,180\n")
+
+
+def test_completion_marker_commits_with_data_and_prevents_replay(library: Any) -> None:
+    """A completed automatic import cannot overwrite later user repairs."""
+    key = "legacy-csv:fixture"
+    assert not library.has_correction_migration(key)
+    library.apply_corrections([("existing", 90, (0, 0))], migration_key=key)
+    assert fresh_library(library).has_correction_migration(key)
+    library.update_correction_data("existing", 270, (0.25, -0.5))
+    result = fresh_library(library).apply_corrections(
+        [("existing", 90, (0, 0))], migration_key=key
+    )
+    assert not result.changed
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 270, (0.25, -0.5))
+    ]
+
+
+def test_cloning_global_corrections_preserves_csv_completion_and_user_repairs(
+    library: Any, tmp_path: Path
+) -> None:
+    """A legacy CSV left after archive failure cannot replay after changing scope."""
+    key = library.correction_csv_migration_key(
+        tmp_path / "legacy.csv", "Pattern,Rotation\nexisting,90\n"
+    )
+    original = [("existing", 90, (0, 0))]
+    library.apply_corrections(original, migration_key=key)
+    library.update_correction_data("existing", 270, (0.25, -0.5))
+    library.switch_to_global_correction_database(False)
+    assert library.has_correction_migration(key, library.localcorrectionsdb_file)
+    result = library.apply_corrections(original, migration_key=key)
+    assert not result.changed
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 270, (0.25, -0.5))
+    ]
+
+
+def test_marker_write_failure_rolls_back_all_imported_data(modules, library):
+    """Failure in the final bookkeeping write also rolls back successful records."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    execute(
+        library.correctionsdb_file,
+        "CREATE TRIGGER fail_marker BEFORE INSERT ON correction_migrations "
+        "BEGIN SELECT RAISE(ABORT, 'marker write failed'); END",
+    )
+    with pytest.raises(modules.data.CorrectionDataError, match="marker write failed"):
+        library.apply_corrections(
+            [("existing", 180, (1, 2)), ("new", 270, (3, 4))],
+            migration_key="csv:marker-failure",
+        )
+    assert raw_rows(library) == before
+    assert not fresh_library(library).has_correction_migration("csv:marker-failure")
+
+
+def test_failed_batch_cannot_commit_completion_marker(modules, library):
+    """Migration bookkeeping rolls back with earlier successful writes."""
+    key = "legacy-csv:failed"
+    install_abort_trigger(library.correctionsdb_file)
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="injected write failure"
+    ):
+        library.apply_corrections(
+            [("first", 90, (0, 0)), ("explode", 180, (0, 0))], migration_key=key
+        )
+    assert raw_rows(library) == []
+    assert not fresh_library(library).has_correction_migration(key)
+
+
+@pytest.mark.parametrize("source", ["rotation", "parts"])
+def test_legacy_migration_preserves_invalid_data_and_source(
+    modules: SimpleNamespace, library: Any, source: str
+) -> None:
+    """Historical invalid values migrate into recovery without destroying archives."""
+    path = library.rotationsdb_file if source == "rotation" else library.partsdb_file
+    original = [("good", 90), ("bad", "47u"), (None, 180)]
+    seed_legacy(path, original)
+    getattr(library, f"migrate_corrections_from_{source}")()
+    assert execute(path, "SELECT * FROM rotation ORDER BY rowid") == original
+    assert [row[1:] for row in raw_rows(library)] == [
+        ("good", 90, 0, 0),
+        ("bad", "47u", 0, 0),
+        (None, 180, 0, 0),
+    ]
+    assert len(migration_rows(library)) == 1
+    snapshot = fresh_library(library).read_correction_data()
+    assert len(snapshot.rows) == 3
+    assert snapshot.corrections is None
+    before = raw_rows(library)
+    getattr(fresh_library(library), f"migrate_corrections_from_{source}")()
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize("source", ["rotation", "parts"])
+def test_legacy_write_failure_rolls_back_and_retries_existing_destination(
+    modules: SimpleNamespace, library: Any, source: str
+) -> None:
+    """Failed migration remains visible and check_library retries on a later start."""
+    path = library.rotationsdb_file if source == "rotation" else library.partsdb_file
+    original = [("first", 90), ("explode", 180)]
+    seed_legacy(path, original)
+    seed_raw(library, [("existing", 270, 0.25, -0.5)])
+    before = raw_rows(library)
+    install_abort_trigger(library.globalcorrectionsdb_file)
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="injected write failure"
+    ):
+        getattr(library, f"migrate_corrections_from_{source}")()
+    assert raw_rows(library) == before
+    assert migration_rows(library) == []
+    assert execute(path, "SELECT * FROM rotation ORDER BY rowid") == original
+    assert fresh_library(library).read_correction_data().issues
+    execute(library.globalcorrectionsdb_file, "DROP TRIGGER fail_write")
+    fresh_library(library).check_library()
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 270, (0.25, -0.5)),
+        ("explode", 180, (0.0, 0.0)),
+        ("first", 90, (0.0, 0.0)),
+    ]
+    assert len(migration_rows(library)) == 2
+
+
+def test_two_legacy_sources_migrate_once_without_overwriting_repairs(
+    library: Any,
+) -> None:
+    """Both historical sources are archived and completed independently."""
+    seed_legacy(library.rotationsdb_file, [("rotation-source", 90)])
+    seed_legacy(library.partsdb_file, [("parts-source", 180)])
+    library.migrate_corrections()
+    assert len(migration_rows(library)) == 2
+    row = next(row for row in raw_rows(library) if row[1] == "rotation-source")
+    library.save_correction_data("repaired", 270, (0.25, 0.5), rowid=row[0])
+    before = raw_rows(library)
+    fresh_library(library).check_library()
+    fresh_library(library).check_library()
+    assert raw_rows(library) == before
+    assert correction_values(fresh_library(library)) == [
+        ("parts-source", 180, (0.0, 0.0)),
+        ("repaired", 270, (0.25, 0.5)),
+    ]
+
+
+def test_migration_preserves_established_source_and_destination_records(
+    library: Any,
+) -> None:
+    """Existing corrected destination data wins while the legacy archive stays intact."""
+    seed_raw(library, [("same", 90, 1, 2)])
+    seed_legacy(library.rotationsdb_file, [("same", 180)])
+    library.migrate_corrections()
+    assert [row[1:] for row in raw_rows(library)] == [
+        ("same", 90, 1, 2),
+    ]
+    assert correction_values(fresh_library(library)) == [("same", 90, (1.0, 2.0))]
+    assert execute(library.rotationsdb_file, "SELECT * FROM rotation") == [
+        ("same", 180)
+    ]
+
+
+@pytest.mark.parametrize("source", ["rotation", "parts"])
+def test_missing_legacy_source_is_not_created_by_migration(library, source):
+    """Checking for historical data must not create empty legacy databases."""
+    path = Path(
+        library.rotationsdb_file if source == "rotation" else library.partsdb_file
+    )
+    assert not path.exists()
+    getattr(library, f"migrate_corrections_from_{source}")()
+    assert not path.exists()
+    assert not library.read_correction_data().issues
+
+
+@pytest.mark.parametrize("source", ["rotation", "parts"])
+def test_empty_legacy_table_is_completed_and_retained(
+    library: Any, source: str
+) -> None:
+    """Empty archives share completion markers and cannot become pending again."""
+    path = library.rotationsdb_file if source == "rotation" else library.partsdb_file
+    seed_legacy(path, [])
+    library.migrate_corrections()
+    assert execute(path, "SELECT * FROM rotation") == []
+    assert raw_rows(library) == []
+    assert library.has_correction_migration(library._legacy_migration_key(path))
+    assert (
+        execute(
+            library.globalcorrectionsdb_file, "SELECT * FROM correction_migration_state"
+        )
+        == []
+    )
+    reopened = fresh_library(library)
+    reopened.migrate_corrections()
+    assert reopened.read_correction_data().issues == ()
+    assert migration_rows(reopened) == migration_rows(library)
+
+
+def test_modern_parts_database_without_rotation_is_not_a_failed_migration(
+    library: Any,
+) -> None:
+    """Ordinary parts storage lacking a historical rotation table is valid."""
+    execute(library.partsdb_file, "CREATE TABLE parts (part_number)")
+    execute(library.partsdb_file, "INSERT INTO parts VALUES ('C123')")
+    library.migrate_corrections()
+    assert fresh_library(library).read_correction_data().issues == ()
+    assert execute(library.partsdb_file, "SELECT * FROM parts") == [("C123",)]
+    assert len(migration_rows(library)) == 2
+
+
+def test_dedicated_rotation_database_without_rotation_is_examined(
+    library: Any,
+) -> None:
+    """A successfully inspected no-table archive cannot block valid corrections."""
+    execute(library.rotationsdb_file, "CREATE TABLE unrelated (value)")
+    library.migrate_corrections_from_rotation()
+    assert fresh_library(library).read_correction_data().issues == ()
+    assert library.has_correction_migration(
+        library._legacy_migration_key(library.rotationsdb_file)
+    )
+    assert execute(
+        library.rotationsdb_file,
+        "SELECT name FROM sqlite_master WHERE name='unrelated'",
+    ) == [("unrelated",)]
+
+
+@pytest.mark.parametrize("source", ["rotation", "parts"])
+def test_malformed_legacy_source_is_preserved_and_reported(
+    library: Any, source: str
+) -> None:
+    """Unrecoverable legacy storage cannot become a false completed migration."""
+    path = Path(
+        library.rotationsdb_file if source == "rotation" else library.partsdb_file
+    )
+    original = b"not a SQLite database; preserve this source"
+    path.write_bytes(original)
+    getattr(library, f"migrate_corrections_from_{source}")()
+    assert path.read_bytes() == original
+    assert raw_rows(library) == []
+    assert migration_rows(library) == []
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.issues == ()
+    assert any(issue.source == str(path) for issue in snapshot.warnings)
+
+
+def test_legacy_migration_targets_global_while_local_scope_is_active(
+    modules: SimpleNamespace, tmp_path: Path
+) -> None:
+    """Global archives never pollute the active board's correction table."""
+    library = make_library(modules.library, tmp_path, [("board", 90, 1, 2)], local=True)
+    local_before = raw_rows(library)
+    seed_legacy(library.rotationsdb_file, [("legacy-global", 180)])
+    library.migrate_corrections()
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert raw_rows(library) == local_before
+    assert correction_values(library, db_path=library.globalcorrectionsdb_file) == [
+        ("legacy-global", 180, (0.0, 0.0))
+    ]
+    fresh_library(library).migrate_corrections()
+    assert raw_rows(library) == local_before
+
+
+def response(text):
+    """Construct an HTTP response substitute without bypassing actual parsing."""
+    return SimpleNamespace(text=text, raise_for_status=MagicMock())
+
+
+def test_remote_import_preserves_existing_and_accepts_short_rows(
+    modules: SimpleNamespace, library: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The production remote format keeps stored edits and first new duplicates."""
+    seed_raw(library, [("existing", 90, 0.25, -0.5)])
+    monkeypatch.setattr(
+        modules.library.requests,
+        "get",
+        MagicMock(
+            return_value=response(
+                '"Footprint pattern", "Correction","Offset X","Offset Y"\n'
+                '"existing",180\n"new",270\n"new",90\n"offset",-90,.125,-.5\n'
+            )
+        ),
+    )
+    library.fetch_remote_corrections()
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 90, (0.25, -0.5)),
+        ("new", 270, (0.0, 0.0)),
+        ("offset", -90, (0.125, -0.5)),
+    ]
+
+
+@pytest.mark.parametrize("bad_pattern", ["new-bad", "existing"])
+def test_remote_invalid_batch_including_skipped_rows_preserves_database(
+    modules, library, monkeypatch, caplog, bad_pattern
+):
+    """Remote rows are all validated, even records insert-only policy would skip."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    monkeypatch.setattr(
+        modules.library.requests,
+        "get",
+        MagicMock(
+            return_value=response(
+                f"Pattern,Rotation\nfirst,180\n{bad_pattern},47u\nlast,270\n"
+            )
+        ),
+    )
+    library.fetch_remote_corrections()
+    assert raw_rows(library) == before
+    assert "47u" in caplog.text
+    assert any(record.levelname == "WARNING" for record in caplog.records)
+    modules.wx.PostEvent.assert_called()
+
+
+def test_remote_network_failure_keeps_storage_and_reports_error(
+    modules, library, monkeypatch, caplog
+):
+    """A remote request failure leaves local corrections usable."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    monkeypatch.setattr(
+        modules.library.requests,
+        "get",
+        MagicMock(
+            side_effect=modules.library.requests.RequestException("network failed")
+        ),
+    )
+    library.fetch_remote_corrections()
+    assert raw_rows(library) == before
+    assert "network failed" in caplog.text
+    modules.wx.PostEvent.assert_called()
+
+
+def test_remote_write_failure_rolls_back_earlier_records_and_reports(
+    modules, library, monkeypatch, caplog
+):
+    """The downloaded-record workflow uses the same atomic transaction boundary."""
+    seed_raw(library, [("existing", 90, 0, 0)])
+    before = raw_rows(library)
+    install_abort_trigger(library.correctionsdb_file)
+    monkeypatch.setattr(
+        modules.library.requests,
+        "get",
+        MagicMock(return_value=response("Pattern,Rotation\nfirst,90\nexplode,180\n")),
+    )
+    library.fetch_remote_corrections()
+    assert raw_rows(library) == before
+    assert "injected write failure" in caplog.text
+    modules.wx.PostEvent.assert_called()
+
+
+@pytest.mark.parametrize("explicit_target", [False, True])
+def test_remote_target_is_captured_before_scope_changes(
+    modules: SimpleNamespace,
+    library: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    explicit_target: bool,
+) -> None:
+    """A download finishing after scope changes writes only its original target."""
+    global_path = library.globalcorrectionsdb_file
+    execute(
+        library.localcorrectionsdb_file,
+        "CREATE TABLE correction (regex, rotation, offset_x, offset_y)",
+    )
+
+    def download(*_args, **_kwargs):
+        library.correctionsdb_file = library.localcorrectionsdb_file
+        return response("Pattern,Rotation\nremote,90\n")
+
+    monkeypatch.setattr(modules.library.requests, "get", download)
+    library.fetch_remote_corrections(
+        **({"db_path": global_path} if explicit_target else {})
+    )
+    assert raw_rows(library) == []
+    assert correction_values(library, db_path=global_path) == [
+        ("remote", 90, (0.0, 0.0))
+    ]
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+
+
+def test_scope_switch_preserves_unrelated_project_tables_and_correct_data(
+    library: Any,
+) -> None:
+    """Global-local-global switching changes corrections without dropping project data."""
+    seed_raw(library, [("global", 90, 0.25, -0.5)])
+    execute(library.localcorrectionsdb_file, "CREATE TABLE unrelated (value)")
+    execute(library.localcorrectionsdb_file, "INSERT INTO unrelated VALUES ('keep')")
+    global_before = raw_rows(library)
+    library.switch_to_global_correction_database(False)
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert correction_values(fresh_library(library)) == [("global", 90, (0.25, -0.5))]
+    library.update_correction_data("global", 180, (1, 2))
+    library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert raw_rows(library) == global_before
+    assert execute(library.localcorrectionsdb_file, "SELECT * FROM unrelated") == [
+        ("keep",)
+    ]
+    assert (
+        execute(
+            library.localcorrectionsdb_file,
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='correction'",
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_scope,use_global", [("global", False), ("local", False), ("global", True)]
+)
+def test_scope_switch_rejects_invalid_active_or_destination_without_mutation(
+    modules: SimpleNamespace, library: Any, invalid_scope: str, use_global: bool
+) -> None:
+    """Copying requires a valid source and both directions require a valid destination."""
+    seed_raw(library, [("global", 90, 0, 0)])
+    execute(
+        library.localcorrectionsdb_file,
+        "CREATE TABLE correction (regex, rotation, offset_x, offset_y)",
+    )
+    execute(
+        library.localcorrectionsdb_file,
+        "INSERT INTO correction VALUES ('local',180,0,0)",
+    )
+    paths = {
+        "global": library.globalcorrectionsdb_file,
+        "local": library.localcorrectionsdb_file,
+    }
+    execute(paths[invalid_scope], "UPDATE correction SET rotation='47u'")
+    library.correctionsdb_file = paths["local" if use_global else "global"]
+    active_before = library.correctionsdb_file
+    before = {
+        scope: execute(path, "SELECT rowid, * FROM correction ORDER BY rowid")
+        for scope, path in paths.items()
+    }
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.switch_to_global_correction_database(use_global)
+    assert library.correctionsdb_file == active_before
+    for scope, path in paths.items():
+        assert (
+            execute(path, "SELECT rowid, * FROM correction ORDER BY rowid")
+            == before[scope]
+        )
+
+
+def test_failed_scope_copy_restores_destination_and_active_selection(modules, library):
+    """A later copy write failure rolls back destination changes and selection."""
+    seed_raw(library, [("first", 90, 0, 0), ("explode", 180, 0, 0)])
+    execute(
+        library.localcorrectionsdb_file,
+        "CREATE TABLE correction (regex, rotation, offset_x, offset_y)",
+    )
+    execute(
+        library.localcorrectionsdb_file,
+        "INSERT INTO correction VALUES ('local',270,1,2)",
+    )
+    before = execute(library.localcorrectionsdb_file, "SELECT rowid, * FROM correction")
+    global_before = raw_rows(library)
+    install_abort_trigger(library.localcorrectionsdb_file)
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="injected write failure"
+    ):
+        library.switch_to_global_correction_database(False)
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert raw_rows(library) == global_before
+    assert (
+        execute(library.localcorrectionsdb_file, "SELECT rowid, * FROM correction")
+        == before
+    )
+
+
+def test_invalid_inactive_database_does_not_block_active_reads(library: Any) -> None:
+    """Healthy active corrections remain usable despite a separate invalid scope."""
+    seed_raw(library, [("good", 90, 0, 0)])
+    execute(
+        library.localcorrectionsdb_file,
+        "CREATE TABLE correction (regex, rotation, offset_x, offset_y)",
+    )
+    execute(
+        library.localcorrectionsdb_file,
+        "INSERT INTO correction VALUES ('bad','47u',0,0)",
+    )
+    assert correction_values(fresh_library(library)) == [("good", 90, (0.0, 0.0))]
+
+
+def test_local_csv_provenance_survives_switch_to_global_without_replaying(
+    modules: SimpleNamespace, tmp_path: Path
+) -> None:
+    """An archived local import cannot overwrite repaired global values later."""
+    library = make_library(modules.library, tmp_path, local=True)
+    library.create_correction_table(library.globalcorrectionsdb_file)
+    library.apply_corrections(
+        [("existing", 270, (0.25, -0.5))], db_path=library.globalcorrectionsdb_file
+    )
+    key = library.correction_csv_migration_key(
+        tmp_path / "legacy.csv", "Pattern,Rotation\nexisting,90\n"
+    )
+    original = [("existing", 90, (0, 0))]
+    library.apply_corrections(original, migration_key=key)
+    library.update_correction_data("existing", 180, (1, 2))
+    library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert fresh_library(library).has_correction_migration(key)
+    result = fresh_library(library).apply_corrections(original, migration_key=key)
+    assert not result.changed
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 270, (0.25, -0.5))
+    ]
+    assert (
+        execute(
+            library.localcorrectionsdb_file,
+            "SELECT name FROM sqlite_master WHERE name='correction'",
+        )
+        == []
+    )
+    assert execute(
+        library.localcorrectionsdb_file,
+        "SELECT migration_key FROM correction_migrations",
+    ) == [(key,)]
+
+
+def test_corrupt_alternate_csv_provenance_blocks_replay_but_not_active_reads(
+    modules: SimpleNamespace, library: Any, tmp_path: Path
+) -> None:
+    """Uncertain archived provenance is surfaced without invalidating active corrections."""
+    seed_raw(library, [("existing", 270, 0.25, -0.5)])
+    Path(library.localcorrectionsdb_file).write_bytes(b"unreadable archive")
+    key = library.correction_csv_migration_key(
+        tmp_path / "legacy.csv", "Pattern,Rotation\nexisting,90\n"
+    )
+    before = raw_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.has_correction_migration(key)
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.apply_corrections([("existing", 90, (0, 0))], migration_key=key)
+    assert raw_rows(library) == before
+    assert correction_values(fresh_library(library)) == [
+        ("existing", 270, (0.25, -0.5))
+    ]
+
+
+def test_switching_from_local_initializes_missing_global_before_drop(
+    modules: SimpleNamespace, tmp_path: Path
+) -> None:
+    """A board with local data can select a newly configured global data directory."""
+    library = make_library(modules.library, tmp_path, [("local", 90, 0, 0)], local=True)
+    assert not Path(library.globalcorrectionsdb_file).exists()
+    execute(library.localcorrectionsdb_file, "CREATE TABLE unrelated (value)")
+    execute(library.localcorrectionsdb_file, "INSERT INTO unrelated VALUES ('keep')")
+    library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert correction_values(fresh_library(library)) == []
+    assert execute(library.localcorrectionsdb_file, "SELECT * FROM unrelated") == [
+        ("keep",)
+    ]
+    assert (
+        execute(
+            library.localcorrectionsdb_file,
+            "SELECT name FROM sqlite_master WHERE name='correction'",
+        )
+        == []
+    )
+
+
+def test_switching_to_missing_global_migrates_legacy_before_validating(
+    modules: SimpleNamespace, tmp_path: Path
+) -> None:
+    """Selecting new global storage uses its valid archived corrections."""
+    library = make_library(modules.library, tmp_path, [("local", 90, 0, 0)], local=True)
+    seed_legacy(library.rotationsdb_file, [("legacy-global", 180)])
+    library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.globalcorrectionsdb_file
+    assert correction_values(fresh_library(library)) == [
+        ("legacy-global", 180, (0.0, 0.0))
+    ]
+    assert execute(library.rotationsdb_file, "SELECT * FROM rotation") == [
+        ("legacy-global", 180)
+    ]
+
+
+def test_invalid_legacy_in_new_global_preserves_active_local_scope(
+    modules: SimpleNamespace, tmp_path: Path
+) -> None:
+    """Discovering invalid legacy data during a switch cannot discard local records."""
+    library = make_library(modules.library, tmp_path, [("local", 90, 0, 0)], local=True)
+    seed_legacy(library.rotationsdb_file, [("legacy-bad", "47u")])
+    before = raw_rows(library)
+    with pytest.raises(modules.data.CorrectionDataError, match="47u"):
+        library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert raw_rows(library) == before
+    assert correction_values(fresh_library(library)) == [("local", 90, (0.0, 0.0))]
+    invalid_global = library.read_correction_data(library.globalcorrectionsdb_file)
+    assert any(row.rotation == "47u" for row in invalid_global.rows)
+    assert invalid_global.corrections is None
+
+
+@pytest.mark.parametrize("source", ["rotation", "parts"])
+def test_switching_to_existing_global_retries_failed_migration(
+    modules: SimpleNamespace, tmp_path: Path, source: str
+) -> None:
+    """A resolved transient migration failure cannot trap the board in local scope."""
+    library = make_library(modules.library, tmp_path, [("local", 90, 0, 0)], local=True)
+    library.create_correction_table(library.globalcorrectionsdb_file)
+    library.apply_corrections(
+        [("existing-global", 270, (0, 0))], db_path=library.globalcorrectionsdb_file
+    )
+    path = library.rotationsdb_file if source == "rotation" else library.partsdb_file
+    seed_legacy(path, [("first", 90), ("explode", 180)])
+    install_abort_trigger(library.globalcorrectionsdb_file)
+    local_before = raw_rows(library)
+    global_before = execute(
+        library.globalcorrectionsdb_file, "SELECT rowid, * FROM correction"
+    )
+
+    with pytest.raises(
+        modules.data.CorrectionDataError, match="injected write failure"
+    ):
+        library.switch_to_global_correction_database(True)
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert raw_rows(library) == local_before
+    assert (
+        execute(library.globalcorrectionsdb_file, "SELECT rowid, * FROM correction")
+        == global_before
+    )
+    assert not library.has_correction_migration(library._legacy_migration_key(path))
+
+    execute(library.globalcorrectionsdb_file, "DROP TRIGGER fail_write")
+    fresh = fresh_library(library)
+    fresh.check_library()
+    fresh.switch_to_global_correction_database(True)
+    assert fresh.correctionsdb_file == fresh.globalcorrectionsdb_file
+    assert correction_values(fresh_library(fresh)) == [
+        ("existing-global", 270, (0.0, 0.0)),
+        ("explode", 180, (0.0, 0.0)),
+        ("first", 90, (0.0, 0.0)),
+    ]
+    assert len(migration_rows(fresh)) == 2
+    assert execute(path, "SELECT * FROM rotation") == [("first", 90), ("explode", 180)]
+
+
+def test_malformed_migration_metadata_preserves_repairable_raw_rows(
+    modules: SimpleNamespace, library: Any
+) -> None:
+    """Metadata failures do not hide the original data required for recovery."""
+    seed_raw(library, [("good", 90, 0, 0), ("bad", "47u", 0, 0)])
+    execute(library.correctionsdb_file, "DROP TABLE correction_migrations")
+    execute(
+        library.correctionsdb_file, "CREATE TABLE correction_migrations (wrong_column)"
+    )
+    before = raw_rows(library)
+    snapshot = fresh_library(library).read_correction_data()
+    assert {row.pattern for row in snapshot.rows} == {"good", "bad"}
+    assert next(row for row in snapshot.rows if row.pattern == "bad").rotation == "47u"
+    assert snapshot.corrections is None
+    assert raw_rows(library) == before
+
+
+@pytest.mark.parametrize("mixed_case", [False, True])
+@pytest.mark.parametrize("writer", ["batch", "save", "insert", "rotation", "parts"])
+def test_reordered_storage_columns_are_written_by_name(
+    library: Any, mixed_case: bool, writer: str
+) -> None:
+    """Every insert path respects schema names instead of corrupting reordered tables."""
+    execute(library.correctionsdb_file, "DROP TABLE correction")
+    columns = (
+        "RoTaTiOn, ReGeX, OfFsEt_Y, OfFsEt_X"
+        if mixed_case
+        else "rotation, regex, offset_y, offset_x"
+    )
+    execute(library.correctionsdb_file, f"CREATE TABLE correction ({columns})")
+    if writer == "batch":
+        library.apply_corrections([("part", "90", (".25", "-.5"))])
+    elif writer == "save":
+        library.save_correction_data("part", "90", (".25", "-.5"))
+    elif writer == "insert":
+        library.insert_correction_data("part", "90", (".25", "-.5"))
+    else:
+        source = (
+            library.rotationsdb_file if writer == "rotation" else library.partsdb_file
+        )
+        seed_legacy(source, [("part", 90)])
+        getattr(library, f"migrate_corrections_from_{writer}")()
+    offsets = (0.0, 0.0) if writer in {"rotation", "parts"} else (0.25, -0.5)
+    stored = execute(
+        library.correctionsdb_file,
+        "SELECT regex, rotation, offset_x, offset_y FROM correction",
+    )
+    assert stored == [("part", 90, *offsets)]
+    assert isinstance(stored[0][0], str)
+    assert isinstance(stored[0][1], int)
+    assert correction_values(fresh_library(library)) == [("part", 90, offsets)]
+
+
+@pytest.mark.parametrize("mixed_case", [False, True])
+def test_scope_copy_writes_reordered_destination_columns_by_name(
+    library: Any, mixed_case: bool
+) -> None:
+    """Copying global corrections into an existing local schema preserves meaning."""
+    seed_raw(library, [("global", 90, 0.25, -0.5)])
+    columns = (
+        "RoTaTiOn, ReGeX, OfFsEt_Y, OfFsEt_X"
+        if mixed_case
+        else "rotation, regex, offset_y, offset_x"
+    )
+    execute(library.localcorrectionsdb_file, f"CREATE TABLE correction ({columns})")
+    execute(
+        library.localcorrectionsdb_file,
+        "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES ('local',180,1,2)",
+    )
+    library.switch_to_global_correction_database(False)
+    assert library.correctionsdb_file == library.localcorrectionsdb_file
+    assert execute(
+        library.localcorrectionsdb_file,
+        "SELECT regex, rotation, offset_x, offset_y FROM correction",
+    ) == [("global", 90, 0.25, -0.5)]
+    assert correction_values(fresh_library(library)) == [("global", 90, (0.25, -0.5))]
+
+
+_UNSUPPORTED_SCHEMAS = (
+    "shadowed-rowid",
+    "view",
+    "without-rowid",
+    "missing-column",
+    "extra-column",
+)
+
+
+def replace_with_unsupported_schema(library, schema):
+    """Seed malformed storage without relying on the compromised row identities."""
+    target = library.correctionsdb_file
+    execute(target, "DROP TABLE correction")
+    if schema == "view":
+        execute(target, "CREATE TABLE backing (regex, rotation, offset_x, offset_y)")
+        execute(
+            target, "INSERT INTO backing VALUES ('existing',90,1,2), ('other',180,3,4)"
+        )
+        execute(target, "CREATE VIEW correction AS SELECT * FROM backing")
+        execute(
+            target,
+            "CREATE TRIGGER insert_view INSTEAD OF INSERT ON correction BEGIN "
+            "INSERT INTO backing VALUES (NEW.regex,NEW.rotation,NEW.offset_x,NEW.offset_y); END",
+        )
+        execute(
+            target,
+            "CREATE TRIGGER update_view INSTEAD OF UPDATE ON correction BEGIN "
+            "UPDATE backing SET regex=NEW.regex,rotation=NEW.rotation,"
+            "offset_x=NEW.offset_x,offset_y=NEW.offset_y WHERE regex=OLD.regex; END",
+        )
+        execute(
+            target,
+            "CREATE TRIGGER delete_view INSTEAD OF DELETE ON correction BEGIN "
+            "DELETE FROM backing WHERE regex=OLD.regex; END",
+        )
+    elif schema == "shadowed-rowid":
+        execute(
+            target,
+            "CREATE TABLE correction (regex, rotation, offset_x, offset_y, rowid)",
+        )
+        execute(
+            target,
+            "INSERT INTO correction VALUES ('existing',90,1,2,7), ('other',180,3,4,7)",
+        )
+    elif schema == "without-rowid":
+        execute(
+            target,
+            "CREATE TABLE correction (regex TEXT PRIMARY KEY, rotation, offset_x, offset_y) WITHOUT ROWID",
+        )
+        execute(
+            target,
+            "INSERT INTO correction VALUES ('existing',90,1,2), ('other',180,3,4)",
+        )
+    elif schema == "missing-column":
+        execute(target, "CREATE TABLE correction (regex, rotation, offset_x)")
+        execute(
+            target, "INSERT INTO correction VALUES ('existing',90,1), ('other',180,3)"
+        )
+    else:
+        assert schema == "extra-column"
+        execute(
+            target,
+            "CREATE TABLE correction (regex, rotation, offset_x, offset_y, extra)",
+        )
+        execute(
+            target,
+            "INSERT INTO correction VALUES ('existing',90,1,2,'keep'), ('other',180,3,4,'also keep')",
+        )
+    return execute(target, "SELECT * FROM correction ORDER BY regex")
+
+
+@pytest.mark.parametrize("schema", _UNSUPPORTED_SCHEMAS)
+def test_unsupported_schema_has_no_guessed_repair_rowids(
+    modules: SimpleNamespace, library: Any, schema: str
+) -> None:
+    """Unknown row identity cannot be presented as a safe target for user repair."""
+    before = replace_with_unsupported_schema(library, schema)
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.rows == ()
+    assert snapshot.issues
+    assert snapshot.db_path == library.correctionsdb_file
+    assert snapshot.corrections is None
+    assert correction_values(fresh_library(library)) is None
+    assert (
+        execute(library.correctionsdb_file, "SELECT * FROM correction ORDER BY regex")
+        == before
+    )
+
+
+@pytest.mark.parametrize("schema", _UNSUPPORTED_SCHEMAS)
+@pytest.mark.parametrize(
+    "operation",
+    ["batch", "save", "repair", "delete-row", "delete-pattern", "update", "insert"],
+)
+def test_unsupported_schema_blocks_all_correction_mutations(
+    modules, library, schema, operation
+):
+    """Unsupported storage is rejected before a trigger or ambiguous ID can change data."""
+    before = replace_with_unsupported_schema(library, schema)
+    mutation = {
+        "batch": lambda: library.apply_corrections([("new", 270, (5, 6))]),
+        "save": lambda: library.save_correction_data("new", 270, (5, 6)),
+        "repair": lambda: library.save_correction_data(
+            "repaired", 270, (5, 6), rowid=7
+        ),
+        "delete-row": lambda: library.delete_correction_row(7),
+        "delete-pattern": lambda: library.delete_correction_data("existing"),
+        "update": lambda: library.update_correction_data("existing", 270, (5, 6)),
+        "insert": lambda: library.insert_correction_data("new", 270, (5, 6)),
+    }[operation]
+    with pytest.raises(modules.data.CorrectionDataError):
+        mutation()
+    assert (
+        execute(library.correctionsdb_file, "SELECT * FROM correction ORDER BY regex")
+        == before
+    )
+    if schema == "view":
+        assert (
+            execute(library.correctionsdb_file, "SELECT * FROM backing ORDER BY regex")
+            == before
+        )
+
+
+@pytest.mark.parametrize(
+    "pattern_type, rotation_type",
+    [
+        ("INTEGER", "INTEGER"),
+        ("FLOATING POINT", "INTEGER"),
+        ("STRING", "INTEGER"),
+        ("TEXT", "REAL"),
+        ("TEXT", "DOUBLE"),
+    ],
+)
+@pytest.mark.parametrize("operation", ["read", "apply", "save", "update"])
+def test_lossy_sqlite_affinity_is_rejected_before_data_changes(
+    modules: SimpleNamespace,
+    library: Any,
+    pattern_type: str,
+    rotation_type: str,
+    operation: str,
+) -> None:
+    """Storage affinity cannot coerce a numeric pattern or round exact whole degrees."""
+    target = library.correctionsdb_file
+    execute(target, "DROP TABLE correction")
+    execute(
+        target,
+        f"CREATE TABLE correction (regex {pattern_type}, rotation {rotation_type}, "
+        "offset_x REAL, offset_y REAL)",
+    )
+    execute(
+        target,
+        "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES ('456',90,.25,-.5)",
+    )
+    before = execute(target, "SELECT * FROM correction")
+    if operation == "read":
+        snapshot = fresh_library(library).read_correction_data()
+        assert snapshot.rows == ()
+        assert snapshot.issues
+        assert snapshot.corrections is None
+    else:
+        exact_rotation = 9007199254740993
+        mutation = {
+            "apply": lambda: library.apply_corrections(
+                [("123", exact_rotation, (0.125, -0.5))]
+            ),
+            "save": lambda: library.save_correction_data(
+                "123", exact_rotation, (0.125, -0.5)
+            ),
+            "update": lambda: library.update_correction_data(
+                "456", exact_rotation, (0.125, -0.5)
+            ),
+        }[operation]
+        with pytest.raises(modules.data.CorrectionDataError):
+            mutation()
+    assert execute(target, "SELECT * FROM correction") == before
+
+
+@pytest.mark.parametrize("rotation_type", ["INTEGER", "FLOATING POINT"])
+def test_safe_typed_schema_preserves_numeric_patterns_and_large_rotations(
+    library: Any, rotation_type: str
+) -> None:
+    """SQLite integer affinity takes priority over FLOAT in a declared type name."""
+    target = library.correctionsdb_file
+    execute(target, "DROP TABLE correction")
+    execute(
+        target,
+        f"CREATE TABLE correction (regex TEXT, rotation {rotation_type}, "
+        "offset_x REAL, offset_y REAL)",
+    )
+    exact_rotation = 9007199254740993
+    library.apply_corrections([("123", exact_rotation, (0.125, -0.5))])
+    assert execute(
+        target, "SELECT regex, rotation, offset_x, offset_y FROM correction"
+    ) == [("123", exact_rotation, 0.125, -0.5)]
+    assert execute(
+        target, "SELECT typeof(regex), typeof(rotation) FROM correction"
+    ) == [("text", "integer")]
+    assert correction_values(fresh_library(library)) == [
+        ("123", exact_rotation, (0.125, -0.5))
+    ]

--- a/tests/test_library_paths.py
+++ b/tests/test_library_paths.py
@@ -1,0 +1,283 @@
+"""Check portable SQLite paths and real existing-file connection guarantees."""
+
+from collections.abc import Iterator
+from contextlib import closing
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
+import sqlite3
+import sys
+from types import ModuleType
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+import pytest
+
+from tests.wx_harness import load_correction_modules
+
+
+@pytest.fixture
+def library_module() -> Iterator[ModuleType]:
+    """Import the production storage code with isolated GUI dependencies."""
+    with load_correction_modules() as loaded:
+        yield loaded.library
+
+
+class ResolvedPath:
+    """Supply only the Windows filesystem facts needed before SQLite opens."""
+
+    def __init__(self, path: PurePath) -> None:
+        self.path = path
+
+    def resolve(self) -> PurePath:
+        """Expose a Windows absolute path without requiring Windows I/O."""
+        return self.path
+
+    def is_file(self) -> bool:
+        """Represent an existing database for the transaction precondition."""
+        return True
+
+
+@pytest.mark.parametrize("read_only", [True, False], ids=["read", "transaction"])
+@pytest.mark.parametrize("host", ["nas", "localhost"])
+def test_unc_connection_boundaries_preserve_host_and_mode(
+    library_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    read_only: bool,
+    host: str,
+) -> None:
+    """Both production opens must avoid URI authorities, including localhost.
+
+    Only path resolution and disk access are replaced: the original connection
+    string still traverses SQLite's URI parser in memory mode. Separate real-file
+    tests below verify the original read-only and existing-only open modes.
+    """
+    target = PureWindowsPath(f"//{host}/share/corrections.db")
+    expected = f"file:////{host}/share/corrections.db"
+    original_connect = sqlite3.connect
+    observed = []
+
+    def resolve_path(value: str) -> ResolvedPath:
+        assert value == str(target)
+        return ResolvedPath(target)
+
+    def connect_in_memory(database: str, *, uri: bool = False) -> sqlite3.Connection:
+        observed.append((database, uri))
+        connection = original_connect(
+            database.rsplit("?", 1)[0] + "?mode=memory", uri=uri
+        )
+        try:
+            assert database == expected + ("?mode=ro" if read_only else "?mode=rw")
+            assert uri is True
+            connection.execute(
+                "CREATE TABLE correction (regex, rotation, offset_x, offset_y)"
+            )
+            return connection
+        except BaseException:
+            connection.close()
+            raise
+
+    monkeypatch.setattr(library_module, "Path", resolve_path)
+    monkeypatch.setattr(sqlite3, "connect", connect_in_memory)
+    library = library_module.Library.__new__(library_module.Library)
+    if read_only:
+        with closing(library._read_database(str(target))) as connection:
+            assert connection.execute("SELECT COUNT(*) FROM correction").fetchone() == (
+                0,
+            )
+    else:
+        with library._correction_transaction(str(target)) as connection:
+            connection.execute("INSERT INTO correction VALUES ('R1', 90, 0, 0)")
+    assert len(observed) == 1
+
+
+@pytest.mark.parametrize(
+    ("path", "expected", "decoded"),
+    [
+        (
+            PureWindowsPath("//nas/share/corrections.db"),
+            "file:////nas/share/corrections.db",
+            "//nas/share/corrections.db",
+        ),
+        (
+            PureWindowsPath("//localhost/share/corrections.db"),
+            "file:////localhost/share/corrections.db",
+            "//localhost/share/corrections.db",
+        ),
+        (
+            PureWindowsPath("//nas/share/"),
+            "file:////nas/share/",
+            "//nas/share/",
+        ),
+        (
+            PureWindowsPath("//nas/shared folder/nested/café #100%23.db"),
+            "file:////nas/shared%20folder/nested/caf%C3%A9%20%23100%2523.db",
+            "//nas/shared folder/nested/café #100%23.db",
+        ),
+        (
+            PureWindowsPath("//nás/share/corrections.db"),
+            "file:////n%C3%A1s/share/corrections.db",
+            "//nás/share/corrections.db",
+        ),
+        (
+            PureWindowsPath("C:/data/corrections.db"),
+            "file:///C:/data/corrections.db",
+            "/C:/data/corrections.db",
+        ),
+        (
+            PureWindowsPath("d:/café #100%23/corrections.db"),
+            "file:///d:/caf%C3%A9%20%23100%2523/corrections.db",
+            "/d:/café #100%23/corrections.db",
+        ),
+        (
+            PurePosixPath("/data/corrections.db"),
+            "file:///data/corrections.db",
+            "/data/corrections.db",
+        ),
+        (
+            PurePosixPath("/data/café #100%?mode=rwc.db"),
+            "file:///data/caf%C3%A9%20%23100%25%3Fmode%3Drwc.db",
+            "/data/café #100%?mode=rwc.db",
+        ),
+        (
+            PurePosixPath("/data/%23%3F%25.db"),
+            "file:///data/%2523%253F%2525.db",
+            "/data/%23%3F%25.db",
+        ),
+        (
+            PurePosixPath("//data/corrections.db"),
+            "file:////data/corrections.db",
+            "//data/corrections.db",
+        ),
+    ],
+)
+def test_sqlite_uri_preserves_absolute_path(
+    library_module: ModuleType, path: PurePath, expected: str, decoded: str
+) -> None:
+    """Keep the host in the path and encode filename syntax exactly once."""
+    uri = library_module._sqlite_file_uri(path)
+    assert uri == expected
+    parsed = urlsplit(uri)
+    assert parsed.scheme == "file"
+    assert parsed.netloc == parsed.query == parsed.fragment == ""
+    assert unquote(parsed.path) == decoded
+    # Exercise the native parser without claiming to open a Windows share.
+    with closing(sqlite3.connect(uri + "?mode=memory", uri=True)) as connection:
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+
+
+@pytest.mark.parametrize(
+    "path", [PureWindowsPath("C:corrections.db"), PurePosixPath("corrections.db")]
+)
+def test_sqlite_uri_requires_an_absolute_path(
+    library_module: ModuleType, path: PurePath
+) -> None:
+    """The caller must resolve drive-relative and ordinary relative filenames."""
+    with pytest.raises(ValueError, match="relative path"):
+        library_module._sqlite_file_uri(path)
+
+
+@pytest.mark.parametrize("as_string", [True, False], ids=["str", "pathlike"])
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "corrections.db",
+        "café #100%23%3F.db",
+        pytest.param(
+            "question?mode=rwc#100%.db",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32", reason="Windows filenames cannot contain ?"
+            ),
+        ),
+    ],
+)
+def test_real_file_modes_creation_and_reopening(
+    library_module: ModuleType, tmp_path: Path, as_string: bool, filename: str
+) -> None:
+    """Intended creation and existing-only updates survive reopen with exact names."""
+    database = tmp_path / "nested café #100%23" / filename
+    target = str(database) if as_string else database
+    library = library_module.Library.__new__(library_module.Library)
+    assert not database.exists()
+    library.create_correction_table(target)
+    library.save_correction_data("R1", 90, (1.25, -2.5), db_path=target)
+    assert database.is_file()
+
+    with closing(library._read_database(target)) as connection:
+        assert connection.execute("SELECT * FROM correction").fetchall() == [
+            ("R1", 90, 1.25, -2.5)
+        ]
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            connection.execute("UPDATE correction SET rotation=270")
+
+    with library._correction_transaction(target) as connection:
+        connection.execute("UPDATE correction SET rotation=180")
+    reopened = library_module.Library.__new__(library_module.Library)
+    assert reopened.get_correction_data("R1", target) == ("R1", 180, 1.25, -2.5)
+
+    with (
+        pytest.raises(RuntimeError, match="abort this update"),
+        reopened._correction_transaction(target) as connection,
+    ):
+        connection.execute("UPDATE correction SET rotation=270")
+        raise RuntimeError("abort this update")
+    assert library.get_correction_data("R1", target) == ("R1", 180, 1.25, -2.5)
+    assert set(database.parent.iterdir()) == {database}
+
+
+@pytest.mark.parametrize("read_only", [True, False], ids=["read", "transaction"])
+@pytest.mark.parametrize("parent_exists", [True, False])
+def test_existing_file_opens_never_create_missing_storage(
+    library_module: ModuleType,
+    tmp_path: Path,
+    read_only: bool,
+    parent_exists: bool,
+) -> None:
+    """Missing storage raises an error and leaves the filesystem untouched."""
+    directory = tmp_path if parent_exists else tmp_path / "missing-directory"
+    target = directory / "missing café #100%23.db"
+    library = library_module.Library.__new__(library_module.Library)
+    if read_only:
+        with pytest.raises(sqlite3.OperationalError):
+            library._read_database(target)
+    else:
+        with (
+            pytest.raises(library_module.CorrectionDataError, match="does not exist"),
+            library._correction_transaction(target),
+        ):
+            pytest.fail("a missing database cannot start a transaction")
+    assert not target.exists()
+    assert directory.exists() == parent_exists
+
+
+@pytest.mark.parametrize("read_only", [True, False], ids=["read", "transaction"])
+def test_deletion_immediately_before_connect_does_not_recreate_database(
+    library_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    read_only: bool,
+) -> None:
+    """SQLite's open mode closes the race after the transaction existence check."""
+    target = tmp_path / "disappearing.db"
+    library = library_module.Library.__new__(library_module.Library)
+    library.create_correction_table(target)
+    original_connect = sqlite3.connect
+    attempts = []
+
+    def delete_then_connect(database: Any, **kwargs: Any) -> sqlite3.Connection:
+        assert target.is_file()
+        target.unlink()
+        attempts.append(database)
+        return original_connect(database, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", delete_then_connect)
+    if read_only:
+        with pytest.raises(sqlite3.OperationalError, match="unable to open"):
+            library._read_database(target)
+    else:
+        with (
+            pytest.raises(library_module.CorrectionDataError, match="unable to open"),
+            library._correction_transaction(target),
+        ):
+            pytest.fail("a deleted database cannot start a transaction")
+    assert len(attempts) == 1
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_mainwindow_correction_recovery.py
+++ b/tests/test_mainwindow_correction_recovery.py
@@ -1,0 +1,631 @@
+"""Exercise correction recovery and generation ordering with real stored data."""
+
+from collections.abc import Iterator
+from contextlib import closing
+import logging
+from pathlib import Path
+import sqlite3
+from types import MethodType, SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from tests.correction_test_support import (
+    fresh_library,
+    make_library,
+    raw_rows,
+    seed_raw,
+)
+from tests.test_corrections_import_export import install_manager_controls
+from tests.test_fabrication_correction_recovery import Point, make_fabrication, read_cpl
+from tests.test_mainwindow_empty_zone_warning import _make_window
+from tests.wx_harness import load_correction_modules, mainwindow_stubs, wx_stubs
+
+
+@pytest.fixture
+def runtime(tmp_path: Path) -> Iterator[SimpleNamespace]:
+    """Keep real window, placement and persistence siblings in one scoped package."""
+    levels = {name: logging.getLogger(name).level for name in ("requests", "urllib3")}
+    package = "mainwindow_correction_recovery_tests"
+    wx = wx_stubs(
+        Dialog=type("Dialog", (), {}),
+        NewIdRef=MagicMock(side_effect=object),
+        BeginBusyCursor=MagicMock(),
+        EndBusyCursor=MagicMock(),
+        IsBusy=MagicMock(return_value=True),
+        MessageBox=MagicMock(),
+        MessageDialog=MagicMock(),
+        PostEvent=MagicMock(),
+    )
+    pcbnew = MagicMock()
+    pcbnew.FromMM = lambda value: value
+    pcbnew.ToMM = lambda value: value
+    pcbnew.wxPoint = Point
+    pcbnew.VECTOR2I = Point
+    replacements = mainwindow_stubs(package, wx=wx, pcbnew=pcbnew)
+    for sibling in ("library", "corrections", "fabrication", "helpers", "events"):
+        replacements.pop(f"{package}.{sibling}", None)
+    try:
+        with load_correction_modules(
+            package=package,
+            wx=wx,
+            pcbnew=pcbnew,
+            names=("mainwindow", "fabrication"),
+            replacements=replacements,
+        ) as modules:
+            yield SimpleNamespace(
+                modules=modules,
+                mainwindow=modules.mainwindow,
+                wx=modules.wx,
+                library=make_library(modules.library, tmp_path),
+            )
+    finally:
+        for name, level in levels.items():
+            logging.getLogger(name).setLevel(level)
+
+
+class StatusLabel:
+    """Retain the visibility and text used by the real readiness handlers."""
+
+    def __init__(self) -> None:
+        self.label = ""
+        self.tooltip = ""
+        self.shown = False
+
+    def SetLabel(self, label: str) -> None:
+        """Store the visible text."""
+        self.label = label
+
+    def GetLabel(self) -> str:
+        """Read the currently visible text."""
+        return self.label
+
+    def SetToolTip(self, tooltip: str) -> None:
+        """Store the tooltip text."""
+        self.tooltip = tooltip
+
+    def Show(self, shown: bool = True) -> None:
+        """Update the visibility state."""
+        self.shown = shown
+
+    def IsShown(self) -> bool:
+        """Read the current visibility state."""
+        return self.shown
+
+
+def _population_window(runtime: SimpleNamespace, library: Any = None) -> Any:
+    """Supply controls and board records while preserving real window methods."""
+    window = object.__new__(runtime.mainwindow.JLCPCBTools)
+    window.library = library or fresh_library(runtime.library)
+    window.scale_factor = 1
+    window.window = object()
+    window.correction_status = StatusLabel()
+    window.Layout = MagicMock()
+    window.partlist_data_model = MagicMock()
+    window.store = MagicMock()
+    window.store.read_all.return_value = [
+        {
+            "reference": reference,
+            "value": "47u",
+            "footprint": "Capacitor_SMD:C_0603",
+            "lcsc": "",
+            "exclude_from_bom": 0,
+            "exclude_from_pos": 0,
+        }
+        for reference in ("C1", "C2")
+    ]
+    footprint = SimpleNamespace(GetLayer=lambda: 0)
+    board = SimpleNamespace(FindFootprintByReference=lambda _reference: footprint)
+    window.pcbnew = SimpleNamespace(GetBoard=lambda: board)
+    window.hide_bom_parts = False
+    window.hide_pos_parts = False
+    window._get_enrichment_status_label = lambda _part: ""
+    return window
+
+
+@pytest.mark.parametrize("entrypoint", ["toolbar", "reference", "package", "name"])
+def test_manager_close_refreshes_recovered_corrections_through_real_constructor(
+    runtime: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    entrypoint: str,
+) -> None:
+    """Each manager entry point replaces unresolved cells after retrying a transfer."""
+    library = runtime.library
+    _write_sql(
+        library.rotationsdb_file,
+        "CREATE TABLE rotation (regex, rotation); "
+        "INSERT INTO rotation VALUES ('C1', 90)",
+    )
+    _write_sql(
+        library.correctionsdb_file,
+        "CREATE TRIGGER reject_insert BEFORE INSERT ON correction "
+        "BEGIN SELECT RAISE(ABORT, 'failed copy'); END",
+    )
+    assert library.migrate_corrections()
+    window = _population_window(runtime)
+    window.populate_footprint_list()
+    assert _displayed_corrections(window) == ["Unresolved", "Unresolved"]
+    _write_sql(library.correctionsdb_file, "DROP TRIGGER reject_insert")
+    install_manager_controls(runtime.modules, library, monkeypatch)
+    monkeypatch.setattr(
+        runtime.wx.Dialog, "ShowModal", lambda _dialog: runtime.wx.ID_OK, raising=False
+    )
+    window.partlist_data_model.AddEntry.reset_mock()
+
+    if entrypoint == "toolbar":
+        window.manage_corrections()
+    else:
+        window.footprint_list = SimpleNamespace(GetSelections=lambda: ["selected"])
+        window.partlist_data_model.get_reference.return_value = "C1"
+        window.partlist_data_model.get_footprint.return_value = "Capacitor_SMD:C_0603"
+        window.partlist_data_model.get_value.return_value = "47u"
+        constant = {
+            "reference": "ID_CONTEXT_MENU_ADD_ROT_BY_REFERENCE",
+            "package": "ID_CONTEXT_MENU_ADD_ROT_BY_PACKAGE",
+            "name": "ID_CONTEXT_MENU_ADD_ROT_BY_NAME",
+        }[entrypoint]
+        event_id = getattr(runtime.mainwindow, constant)
+        window.add_correction(SimpleNamespace(GetId=lambda: event_id))
+
+    assert _displayed_corrections(window) == ["90°, 0.0/0.0 (ref)", "0°, 0.0/0.0"]
+    assert not window.correction_status.IsShown()
+    runtime.wx.MessageBox.assert_not_called()
+
+
+def _generation_window(runtime: SimpleNamespace) -> tuple[SimpleNamespace, list[str]]:
+    """Bind real preflight methods to the established generation test harness."""
+    window, steps = _make_window([])
+    window.library = fresh_library(runtime.library)
+    window.correction_status = StatusLabel()
+    window.Layout = MagicMock()
+    for name in (
+        "read_valid_corrections_for_generation",
+        "update_correction_status",
+    ):
+        setattr(
+            window,
+            name,
+            MethodType(getattr(runtime.mainwindow.JLCPCBTools, name), window),
+        )
+    return window, steps
+
+
+def _displayed_corrections(window: Any) -> list[str]:
+    """Return the correction cells most recently added to the model."""
+    return [
+        invocation.args[0][9]
+        for invocation in window.partlist_data_model.AddEntry.call_args_list
+    ]
+
+
+def _write_sql(path: str, sql: str) -> None:
+    """Commit a historical database state through an independent connection."""
+    with closing(sqlite3.connect(path)) as connection, connection:
+        connection.executescript(sql)
+
+
+def _record_failed_transfer(library: Any) -> None:
+    """Establish known incomplete migration before source-free consumer reads."""
+    _write_sql(
+        library.correctionsdb_file,
+        "CREATE TRIGGER reject_insert BEFORE INSERT ON correction "
+        "BEGIN SELECT RAISE(ABORT, 'failed copy'); END",
+    )
+    assert library.migrate_corrections()
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [("C1", "47u", 0, 0), ("C2", 90, 0, 0)],
+        [("C1", "47u", 0, 0), ("C2", "bad", 0, 0)],
+        [(None, 90, 0, 0)],
+        [("C1", None, 0, 0)],
+        [("C1", 90, None, 0)],
+        [("C1", 90, 0, "inf")],
+        [("[", 90, 0, 0)],
+        [("C1", 90, 0, 0), ("C1", 180, 0, 0)],
+    ],
+)
+def test_invalid_saved_data_keeps_population_accessible_and_unresolved(
+    runtime: SimpleNamespace, rows: list[tuple[object, ...]]
+) -> None:
+    """Bad rows never crash matching or appear as a valid partial correction set."""
+    seed_raw(runtime.library, rows)
+    before = raw_rows(runtime.library)
+    window = _population_window(runtime)
+
+    window.populate_footprint_list()
+
+    assert _displayed_corrections(window) == ["Unresolved", "Unresolved"]
+    assert "active global database" in window.correction_status.GetLabel()
+    assert "Open Corrections Manager" in window.correction_status.GetLabel()
+    assert window.correction_status.IsShown()
+    runtime.wx.MessageBox.assert_not_called()
+    assert raw_rows(runtime.library) == before
+    runtime.wx.PostEvent.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "damage", ["unreadable", "missing_schema", "pending_migration"]
+)
+def test_storage_and_pending_migration_failures_remain_visible(
+    runtime: SimpleNamespace, damage: str
+) -> None:
+    """Unavailable or incomplete storage is unresolved even without invalid rows."""
+    if damage == "unreadable":
+        Path(runtime.library.correctionsdb_file).write_bytes(b"not a SQLite database")
+    elif damage == "missing_schema":
+        _write_sql(runtime.library.correctionsdb_file, "DROP TABLE correction")
+    else:
+        _write_sql(
+            runtime.library.rotationsdb_file,
+            "CREATE TABLE rotation (regex, rotation); INSERT INTO rotation VALUES ('C1', '47u')",
+        )
+        _record_failed_transfer(runtime.library)
+    window = _population_window(runtime)
+
+    window.populate_footprint_list()
+
+    assert _displayed_corrections(window) == ["Unresolved", "Unresolved"]
+    assert window.correction_status.IsShown()
+    details = window.correction_status.tooltip
+    assert str(runtime.library.correctionsdb_file) in details
+    runtime.wx.MessageBox.assert_not_called()
+
+
+def test_refresh_remains_nonmodal_and_only_complete_repair_clears_status(
+    runtime: SimpleNamespace,
+) -> None:
+    """Independent rereads retain warnings until every original bad row is repaired."""
+    seed_raw(runtime.library, [("C1", "47u", 0, 0), ("C2", 90, "bad", 0)])
+    window = _population_window(runtime)
+    for _ in range(2):
+        window.populate_footprint_list()
+        assert window.correction_status.IsShown()
+    assert "47u" not in window.correction_status.tooltip
+    rows = runtime.library.read_correction_data().rows
+    runtime.library.save_correction_data("C1", 180, (0.5, -0.25), rowid=rows[0].rowid)
+    window.library = fresh_library(runtime.library)
+    window.partlist_data_model.AddEntry.reset_mock()
+
+    window.populate_footprint_list()
+
+    assert window.correction_status.IsShown()
+    assert _displayed_corrections(window) == ["Unresolved", "Unresolved"]
+    runtime.library.save_correction_data("C2", -90, (1.25, 2.5), rowid=rows[1].rowid)
+    window.library = fresh_library(runtime.library)
+    window.partlist_data_model.AddEntry.reset_mock()
+
+    window.populate_footprint_list()
+
+    assert _displayed_corrections(window) == [
+        "180°, 0.5/-0.25 (ref)",
+        "-90°, 1.25/2.5 (ref)",
+    ]
+    assert window.correction_status.GetLabel() == ""
+    assert window.correction_status.tooltip == ""
+    assert not window.correction_status.IsShown()
+    runtime.wx.MessageBox.assert_not_called()
+
+
+def test_valid_empty_database_displays_zero_and_clears_prior_issue(
+    runtime: SimpleNamespace,
+) -> None:
+    """An actually empty valid set retains the established zero display."""
+    window = _population_window(runtime)
+    window.correction_status.Show(True)
+
+    window.populate_footprint_list()
+
+    assert _displayed_corrections(window) == ["0°, 0.0/0.0", "0°, 0.0/0.0"]
+    assert not window.correction_status.IsShown()
+
+
+def test_startup_store_population_recovers_invalid_saved_corrections(
+    runtime, monkeypatch
+):
+    """The startup init_store path reaches recovery without losing the part list."""
+    seed_raw(runtime.library, [("C1", "47u", 0, 0)])
+    window = _population_window(runtime)
+    store = window.store
+    monkeypatch.setattr(runtime.mainwindow, "Store", lambda *_args: store)
+    window.project_path = runtime.library.parent.project_path
+    window.start_assembly_enrichment = MagicMock()
+    window.recompute_bom_estimate = MagicMock()
+    window.store = None
+
+    window.init_store()
+
+    assert window.store is store
+    assert _displayed_corrections(window) == ["Unresolved", "Unresolved"]
+    window.start_assembly_enrichment.assert_called_once_with()
+    window.recompute_bom_estimate.assert_called_once_with()
+
+
+def test_inactive_bad_global_database_does_not_affect_active_local(
+    runtime: SimpleNamespace, tmp_path: Path
+) -> None:
+    """Recovery status and generation preflight inspect the selected scope only."""
+    local = make_library(runtime.modules.library, tmp_path / "other", local=True)
+    local.create_correction_table(local.globalcorrectionsdb_file)
+    _write_sql(
+        local.globalcorrectionsdb_file,
+        "INSERT INTO correction VALUES ('C1', '47u', 0, 0)",
+    )
+    local.insert_correction_data("C1", 90, (0.25, -0.5))
+    window = _population_window(runtime, library=local)
+
+    window.populate_footprint_list()
+    corrections = window.read_valid_corrections_for_generation()
+
+    assert _displayed_corrections(window) == ["90°, 0.25/-0.5 (ref)", "0°, 0.0/0.0"]
+    assert [(item.pattern, item.rotation) for item in corrections] == [("C1", 90)]
+    assert local.read_correction_data(local.globalcorrectionsdb_file).issues
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [("C1", "47u", 0, 0)],
+        [("C1", "47u", 0, 0), ("C2", 90, 0, 0)],
+        [("[", 90, 0, 0)],
+        [("C1", 90, 0, None)],
+    ],
+)
+def test_generation_rejects_bad_data_before_all_side_effects(
+    runtime: SimpleNamespace, tmp_path: Path, rows: list[tuple[object, ...]]
+) -> None:
+    """No prompts, fills, checks, hooks, output writes, or counters precede validation."""
+    seed_raw(runtime.library, rows)
+    window, steps = _generation_window(runtime)
+    window.settings["general"]["order_number"] = True
+    artifacts = []
+    for name in (
+        "generate_geber",
+        "generate_excellon",
+        "zip_gerber_excellon",
+        "write_cpl",
+        "generate_bom",
+    ):
+        path = tmp_path / f"{name}.existing"
+        path.write_bytes(b"previous valid output\x00\xff")
+        artifacts.append(path)
+        getattr(window.fabrication, name).side_effect = (
+            lambda *_args, path=path: path.write_bytes(b"overwritten")
+        )
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert steps == ["Validating corrections"]
+    for method in vars(window.fabrication).values():
+        method.assert_not_called()
+    window.run_drc_before_gerber_export.assert_not_called()
+    window.count_order_number_placeholders.assert_not_called()
+    window.build_generate_hook_env.assert_not_called()
+    window.run_generate_hook.assert_not_called()
+    window.store.get_generation_count.assert_not_called()
+    window.store.increment_generation_count.assert_not_called()
+    runtime.wx.MessageDialog.assert_not_called()
+    runtime.wx.MessageBox.assert_called_once()
+    assert "Validating corrections" in runtime.wx.MessageBox.call_args.args[0]
+    assert all(
+        path.read_bytes() == b"previous valid output\x00\xff" for path in artifacts
+    )
+    assert window.generate_button.Enable.call_args_list == [call(False), call(True)]
+    runtime.wx.EndBusyCursor.assert_called_once_with()
+    assert window._current_generation_step == "initialization"
+    assert window.correction_status.IsShown()
+
+
+@pytest.mark.parametrize(
+    "damage", ["unreadable", "missing_schema", "pending_migration"]
+)
+def test_generation_blocks_unavailable_or_unmigrated_storage(
+    runtime: SimpleNamespace, damage: str
+) -> None:
+    """An empty-looking destination cannot permit incomplete fabrication output."""
+    if damage == "unreadable":
+        Path(runtime.library.correctionsdb_file).write_bytes(b"invalid SQLite")
+    elif damage == "missing_schema":
+        _write_sql(runtime.library.correctionsdb_file, "DROP TABLE correction")
+    else:
+        _write_sql(
+            runtime.library.rotationsdb_file,
+            "CREATE TABLE rotation (regex, rotation); INSERT INTO rotation VALUES ('C1', 90)",
+        )
+        _record_failed_transfer(runtime.library)
+    window, steps = _generation_window(runtime)
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert steps == ["Validating corrections"]
+    window.fabrication.write_cpl.assert_not_called()
+    window.fabrication.fill_zones.assert_not_called()
+    window.store.increment_generation_count.assert_not_called()
+    runtime.wx.EndBusyCursor.assert_called_once_with()
+    window.generate_button.Enable.assert_called_with(True)
+
+
+def test_unknown_archive_warnings_keep_healthy_display_and_generation_ready(
+    runtime: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordinary consumers use the ready snapshot without inspecting unknown archives."""
+    runtime.library.insert_correction_data("C1", 90, (0.25, -0.5))
+    Path(runtime.library.rotationsdb_file).write_bytes(b"unreadable archive")
+    assert runtime.library.migrate_corrections() == ()
+    snapshot = fresh_library(runtime.library).read_correction_data()
+    assert snapshot.corrections is not None
+    assert snapshot.warnings
+    inspect_archive = MagicMock(side_effect=AssertionError("unexpected archive read"))
+    monkeypatch.setattr(
+        runtime.modules.library.Library, "_legacy_rotation_rows", inspect_archive
+    )
+    window = _population_window(runtime)
+
+    window.populate_footprint_list()
+
+    assert _displayed_corrections(window) == ["90°, 0.25/-0.5 (ref)", "0°, 0.0/0.0"]
+    assert not window.correction_status.IsShown()
+    generation, steps = _generation_window(runtime)
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(generation)
+    assert steps[0] == "Validating corrections"
+    generation.fabrication.prepare_cpl.assert_called_once_with(snapshot.corrections)
+    generation.fabrication.write_cpl.assert_called_once_with(
+        generation.fabrication.prepare_cpl.return_value
+    )
+    generation.store.increment_generation_count.assert_called_once()
+    inspect_archive.assert_not_called()
+    runtime.wx.MessageBox.assert_not_called()
+
+
+def test_repair_allows_subsequent_generation_and_clears_warning(
+    runtime: SimpleNamespace,
+) -> None:
+    """A failed run leaves controls usable and a repaired reread can generate."""
+    seed_raw(runtime.library, [("C1", "47u", 0, 0)])
+    window, _steps = _generation_window(runtime)
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+    assert window.correction_status.IsShown()
+    row = runtime.library.read_correction_data().rows[0]
+    runtime.library.save_correction_data("C1", -90, (0.5, -0.25), rowid=row.rowid)
+    window.library = fresh_library(runtime.library)
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert not window.correction_status.IsShown()
+    window.fabrication.write_cpl.assert_called_once()
+    window.store.increment_generation_count.assert_called_once()
+    assert runtime.wx.EndBusyCursor.call_count == 2
+
+
+@pytest.mark.parametrize("state_name", ["READY", "NEEDS_REPAIR", "UNAVAILABLE"])
+def test_ordinary_consumers_need_only_aggregate_snapshot_state(
+    runtime: SimpleNamespace, state_name: str
+) -> None:
+    """Display and generation do not require row-level repair diagnostics."""
+    state = getattr(runtime.modules.library.CorrectionState, state_name)
+    ready = state_name == "READY"
+    snapshot = SimpleNamespace(
+        state=state,
+        corrections=() if ready else None,
+        scope="global",
+        db_path=runtime.library.correctionsdb_file,
+    )
+    window = _population_window(runtime)
+    window.library = SimpleNamespace(read_correction_data=lambda: snapshot)
+
+    window.populate_footprint_list()
+
+    assert window.correction_status.IsShown() is not ready
+    if ready:
+        assert window.read_valid_corrections_for_generation() == ()
+        assert _displayed_corrections(window) == ["0°, 0.0/0.0"] * 2
+    else:
+        assert _displayed_corrections(window) == ["Unresolved"] * 2
+        assert ("unavailable" if state_name == "UNAVAILABLE" else "unresolved") in (
+            window.correction_status.GetLabel()
+        )
+        with pytest.raises(ValueError, match="Open Corrections Manager"):
+            window.read_valid_corrections_for_generation()
+
+
+def test_generation_event_keeps_snapshot_for_real_cpl_then_blocks_and_recovers(
+    runtime: SimpleNamespace, tmp_path: Path
+) -> None:
+    """The real generation handler and CPL writer share one snapshot across a run."""
+    runtime.library.save_correction_data("Device", 90, (1, 2))
+    window, _steps = _generation_window(runtime)
+    fabrication = make_fabrication(runtime.modules, window.library, tmp_path)
+    window.fabrication = fabrication
+    matcher = MagicMock(wraps=fabrication._correction_for_footprint)
+    fabrication._correction_for_footprint = matcher
+    for method in (
+        "fill_zones",
+        "generate_geber",
+        "generate_excellon",
+        "zip_gerber_excellon",
+        "generate_bom",
+    ):
+        setattr(fabrication, method, MagicMock(return_value=[]))
+
+    def damage_storage_after_preflight() -> str:
+        """Simulate an external legacy write after the complete snapshot was read."""
+        _write_sql(
+            runtime.library.correctionsdb_file,
+            "UPDATE correction SET rotation='47u'",
+        )
+        for footprint in fabrication.board.Footprints():
+            footprint.GetPosition = lambda: Point(100, 200)
+        return ""
+
+    fabrication.get_part_consistency_warnings = MagicMock(
+        side_effect=damage_storage_after_preflight
+    )
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert [
+        tuple(float(row[field]) for field in ("Mid X", "Mid Y", "Rotation"))
+        for row in read_cpl(fabrication)
+    ] == [(10, -20, 90), (27, -37, 180)]
+    assert matcher.call_count == 2
+    destination = Path(fabrication.get_cpl_csv_path())
+    prior_output = destination.read_bytes()
+    window.store.increment_generation_count.assert_called_once_with()
+    runtime.wx.MessageBox.assert_not_called()
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert destination.read_bytes() == prior_output
+    window.store.increment_generation_count.assert_called_once_with()
+    runtime.wx.MessageBox.assert_called_once()
+    assert window.correction_status.IsShown()
+
+    row = runtime.library.read_correction_data().rows[0]
+    runtime.library.save_correction_data("Device", -90, (0, 0), rowid=row.rowid)
+    fabrication.get_part_consistency_warnings.side_effect = None
+    fabrication.get_part_consistency_warnings.return_value = ""
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert [float(row["Rotation"]) for row in read_cpl(fabrication)] == [270, 0]
+    assert window.store.increment_generation_count.call_count == 2
+    assert not window.correction_status.IsShown()
+    assert runtime.wx.MessageBox.call_count == 1
+
+
+@pytest.mark.parametrize("offset", [1e308, 2147483647.0])
+def test_generation_prepares_placements_before_any_output_or_board_changes(
+    runtime: SimpleNamespace, tmp_path: Path, offset: float
+) -> None:
+    """Unrepresentable correction transforms leave every previous artifact intact."""
+    runtime.library.save_correction_data("Device", 0, (offset, 0))
+    window, steps = _generation_window(runtime)
+    fabrication = make_fabrication(runtime.modules, window.library, tmp_path)
+    window.fabrication = fabrication
+    destination = Path(fabrication.get_cpl_csv_path())
+    destination.write_bytes(b"previous complete CPL\x00\xff")
+    later_steps = (
+        "fill_zones",
+        "generate_geber",
+        "generate_excellon",
+        "zip_gerber_excellon",
+        "generate_bom",
+        "get_part_consistency_warnings",
+    )
+    for method in later_steps:
+        setattr(fabrication, method, MagicMock(return_value=[]))
+
+    runtime.mainwindow.JLCPCBTools.generate_fabrication_data(window)
+
+    assert steps == ["Validating corrections", "Preparing placement data"]
+    for method in later_steps:
+        getattr(fabrication, method).assert_not_called()
+    window.run_drc_before_gerber_export.assert_not_called()
+    window.run_generate_hook.assert_not_called()
+    window.store.increment_generation_count.assert_not_called()
+    assert destination.read_bytes() == b"previous complete CPL\x00\xff"
+    assert "placement" in runtime.wx.MessageBox.call_args.args[0].lower()
+    assert window.generate_button.Enable.call_args_list == [call(False), call(True)]

--- a/tests/test_mainwindow_empty_zone_warning.py
+++ b/tests/test_mainwindow_empty_zone_warning.py
@@ -1,6 +1,7 @@
 """Tests for empty-zone warnings during fabrication-data generation."""
 
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,7 +29,10 @@ def mainwindow_module():
     return module, module.wx
 
 
-def _make_window(empty_pours, fill_zones=None):
+def _make_window(
+    empty_pours: list[str],
+    fill_zones: Optional[bool] = None,  # noqa: UP045
+) -> tuple[SimpleNamespace, list[str]]:
     """Build the smallest object needed by generate_fabrication_data()."""
     fabrication = SimpleNamespace(
         get_part_consistency_warnings=MagicMock(return_value=""),
@@ -36,7 +40,8 @@ def _make_window(empty_pours, fill_zones=None):
         generate_geber=MagicMock(),
         generate_excellon=MagicMock(),
         zip_gerber_excellon=MagicMock(),
-        generate_cpl=MagicMock(),
+        prepare_cpl=MagicMock(return_value=()),
+        write_cpl=MagicMock(),
         generate_bom=MagicMock(),
     )
     settings = {"general": {}, "gerber": {}}
@@ -56,6 +61,12 @@ def _make_window(empty_pours, fill_zones=None):
         build_generate_hook_env=MagicMock(return_value={}),
         run_generate_hook=MagicMock(return_value=True),
         report_generation_step=MagicMock(),
+        library=SimpleNamespace(
+            read_correction_data=MagicMock(return_value=SimpleNamespace(corrections=()))
+        ),
+    )
+    window.read_valid_corrections_for_generation = (
+        lambda: window.library.read_correction_data().corrections
     )
     window.layer_selection.GetSelection.return_value = 0
     window.layer_selection.GetString.return_value = "Auto"

--- a/tests/test_mainwindow_stale_footprints.py
+++ b/tests/test_mainwindow_stale_footprints.py
@@ -9,6 +9,7 @@ requiring a GUI event loop.
 
 from itertools import count
 import types
+from typing import Any
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -53,14 +54,18 @@ class _Pcbnew:
         return self.board
 
 
-def _window(*, footprints, selections=()):
+def _window(*, footprints: dict[str, object], selections: tuple[int, ...] = ()) -> Any:
     """Build the shared state surface used by main-window action handlers."""
     window = object.__new__(JLCPCBTools)
     window.pcbnew = _Pcbnew(_Board(footprints))
     window.store = MagicMock()
     window.library = MagicMock()
     window.library.get_part_details.return_value = {}
-    window.library.get_all_correction_data.return_value = []
+    window.library.read_correction_data.return_value = types.SimpleNamespace(
+        corrections=(), state=mainwindow.CorrectionState.READY
+    )
+    window.correction_status = MagicMock()
+    window.Layout = MagicMock()
     window.partlist_data_model = MagicMock()
     window.footprint_list = MagicMock()
     window.footprint_list.GetSelections.return_value = list(selections)

--- a/tests/test_wx_harness.py
+++ b/tests/test_wx_harness.py
@@ -1,0 +1,291 @@
+"""Verify import lifetimes and explicit wx behavior used by GUI regressions."""
+
+import importlib
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Optional
+
+import pytest
+
+from tests import wx_harness
+
+
+def test_correction_runtime_flags_have_no_false_membership() -> None:
+    """A confirmation style cannot accidentally include the error icon bit."""
+    with wx_harness.load_correction_modules() as runtime:
+        wx = runtime.wx
+        style = wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
+        assert style & wx.ICON_ERROR == 0
+        assert wx.NOT_FOUND == -1
+
+
+def test_real_correction_siblings_share_model_events_and_gui() -> None:
+    """Real storage and manager imports use one model class and event factory."""
+    with wx_harness.load_correction_modules(names=("events",)) as runtime:
+        assert runtime.library.Correction is runtime.data.Correction
+        assert (
+            runtime.corrections.PopulateFootprintListEvent
+            is runtime.events.PopulateFootprintListEvent
+        )
+        assert runtime.library.wx is runtime.corrections.wx is runtime.wx
+        assert (
+            importlib.import_module(f"{runtime.package_name}.events") is runtime.events
+        )
+        package = runtime.package_name
+    assert not any(
+        name == package or name.startswith(package + ".") for name in sys.modules
+    )
+
+
+@pytest.fixture
+def source_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Provide independent modules whose imports expose duplicate identities."""
+    monkeypatch.setattr(wx_harness, "ROOT", tmp_path)
+    (tmp_path / "first.py").write_text(
+        "import wx\nclass Token: pass\n"
+        "def deferred():\n    from . import second\n    return second\n"
+    )
+    (tmp_path / "second.py").write_text(
+        "from .first import Token\nimport wx\nimport pcbnew\n"
+    )
+    (tmp_path / "broken.py").write_text(
+        "from . import second\nraise RuntimeError('broken import')\n"
+    )
+    return tmp_path
+
+
+def test_siblings_keep_class_wx_and_runtime_identity_until_scope_exit(
+    source_tree: Path,
+) -> None:
+    """Deferred imports during the test see exactly the already loaded modules."""
+    package = "_harness_identity"
+    replacements = wx_harness.wx_stubs()
+    pcbnew = wx_harness.module("pcbnew")
+    replacements["pcbnew"] = pcbnew
+    with wx_harness.load_siblings(package, ("first", "second"), replacements) as loaded:
+        assert loaded["first"] is importlib.import_module(f"{package}.first")
+        assert loaded["first"].deferred() is loaded["second"]
+        assert loaded["second"].Token is loaded["first"].Token
+        assert loaded["first"].wx is loaded["second"].wx is replacements["wx"]
+        assert loaded["first"].wx.dataview is replacements["wx.dataview"]
+        assert loaded["second"].pcbnew is pcbnew
+    assert not any(
+        name == package or name.startswith(package + ".") for name in sys.modules
+    )
+
+
+@pytest.mark.parametrize("failure", [None, "body", "import"])
+def test_siblings_restore_prior_modules_and_remove_transitive_imports(
+    source_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Optional[str],  # noqa: UP045
+) -> None:
+    """Both import errors and test-body failures restore the complete namespace."""
+    package = "_harness_restoration"
+    previous = {
+        package: wx_harness.module(package),
+        f"{package}.first": wx_harness.module(f"{package}.first"),
+        f"{package}.preserved": wx_harness.module(f"{package}.preserved"),
+        "wx": wx_harness.module("wx"),
+        "pcbnew": wx_harness.module("pcbnew"),
+    }
+    for name, value in previous.items():
+        monkeypatch.setitem(sys.modules, name, value)
+    replacements = wx_harness.wx_stubs()
+    replacements["pcbnew"] = wx_harness.module("pcbnew")
+    names = ("first", "broken") if failure == "import" else ("first",)
+
+    def exercise() -> None:
+        with wx_harness.load_siblings(package, names, replacements) as loaded:
+            loaded["first"].deferred()
+            assert sys.modules[f"{package}.first"] is not previous[f"{package}.first"]
+            if failure == "body":
+                raise RuntimeError("broken body")
+
+    if failure:
+        with pytest.raises(RuntimeError, match=f"broken {failure}"):
+            exercise()
+    else:
+        exercise()
+    for name, value in previous.items():
+        assert sys.modules[name] is value
+    assert f"{package}.second" not in sys.modules
+    assert f"{package}.broken" not in sys.modules
+
+
+def test_siblings_respect_supplied_package_and_sibling_replacements(
+    source_tree: Path,
+) -> None:
+    """A dependency intentionally replaced by a fixture is not imported again."""
+    package = "_harness_replacement"
+    stubs = wx_harness.package_stubs(package)
+    stubs.update(wx_harness.wx_stubs())
+    supplied = wx_harness.module(f"{package}.second", sentinel=object())
+    stubs[f"{package}.second"] = supplied
+    with wx_harness.load_siblings(package, ("first", "second"), stubs) as loaded:
+        assert sys.modules[package] is stubs[package]
+        assert loaded["second"] is supplied
+        assert loaded["first"].deferred() is supplied
+
+
+def test_existing_one_shot_loader_releases_stubs_before_return(
+    source_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing callers keep their module reference without a persistent scope."""
+    package = "_harness_one_shot"
+    prior_wx = wx_harness.module("wx")
+    monkeypatch.setitem(sys.modules, "wx", prior_wx)
+    replacements = wx_harness.package_stubs(package)
+    replacements.update(wx_harness.wx_stubs())
+    loaded = wx_harness.load(package, "first", replacements)
+    assert loaded.wx is replacements["wx"]
+    assert sys.modules["wx"] is prior_wx
+    assert package not in sys.modules
+    assert f"{package}.first" not in sys.modules
+
+
+@pytest.mark.parametrize("failure", [None, "body", "import"])
+def test_reused_package_restores_child_bindings_and_reloads_next_scope(
+    source_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Optional[str],  # noqa: UP045
+) -> None:
+    """Reusing a supplied parent cannot retain stale imported child objects."""
+    package = "_harness_reused"
+    replacements = wx_harness.package_stubs(package)
+    replacements.update(wx_harness.wx_stubs())
+    replacements["pcbnew"] = wx_harness.module("pcbnew")
+    parent = replacements[package]
+    original_first = wx_harness.module(f"{package}.first")
+    original_second = wx_harness.module(f"{package}.second", Token=object())
+    parent.first = original_first
+    parent.second = original_second
+    parent.unrelated = object()
+    original_bindings = dict(vars(parent))
+    monkeypatch.setitem(sys.modules, package, parent)
+    monkeypatch.setitem(sys.modules, original_first.__name__, original_first)
+    monkeypatch.setitem(sys.modules, original_second.__name__, original_second)
+    names = ("first", "broken") if failure == "import" else ("first",)
+    first_scope = []
+
+    def exercise() -> None:
+        with wx_harness.load_siblings(package, names, replacements) as loaded:
+            first_scope.append(loaded["first"])
+            assert loaded["first"].deferred().Token is loaded["first"].Token
+            if failure == "body":
+                raise RuntimeError("broken body")
+
+    if failure:
+        with pytest.raises(RuntimeError, match=f"broken {failure}"):
+            exercise()
+    else:
+        exercise()
+    assert vars(parent) == original_bindings
+    assert sys.modules[original_first.__name__] is original_first
+    assert sys.modules[original_second.__name__] is original_second
+    assert not hasattr(parent, "broken")
+    with wx_harness.load_siblings(package, ("first",), replacements) as loaded:
+        assert loaded["first"].deferred().Token is loaded["first"].Token
+        assert all(loaded["first"] is not earlier for earlier in first_scope)
+    assert vars(parent) == original_bindings
+
+
+def test_nested_distinct_packages_restore_outer_deferred_imports_and_wx(
+    source_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inner fixture cannot replace the outer fixture's deferred dependencies."""
+    unrelated = wx_harness.module("_harness_unrelated")
+    monkeypatch.setitem(sys.modules, unrelated.__name__, unrelated)
+    outer = wx_harness.wx_stubs()
+    outer["pcbnew"] = wx_harness.module("pcbnew")
+    inner = wx_harness.wx_stubs()
+    inner["pcbnew"] = wx_harness.module("pcbnew")
+    with wx_harness.load_siblings("_harness_outer", ("first",), outer) as loaded_outer:
+        with wx_harness.load_siblings(
+            "_harness_inner", ("first",), inner
+        ) as loaded_inner:
+            assert loaded_inner["first"].deferred().wx is inner["wx"]
+            assert sys.modules[unrelated.__name__] is unrelated
+        assert sys.modules["wx"] is outer["wx"]
+        assert sys.modules["pcbnew"] is outer["pcbnew"]
+        assert loaded_outer["first"].deferred().wx is outer["wx"]
+        assert sys.modules[unrelated.__name__] is unrelated
+    assert sys.modules[unrelated.__name__] is unrelated
+
+
+@pytest.mark.parametrize("failure", [False, True])
+def test_preloaded_wx_children_cannot_replace_scoped_event_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: bool,
+) -> None:
+    """Even an environment with wx already imported uses the intended event stub."""
+    foreign_event = object()
+    prior = {
+        "wx.lib": wx_harness.module("wx.lib"),
+        "wx.lib.newevent": wx_harness.module(
+            "wx.lib.newevent", NewEvent=lambda: (foreign_event, object())
+        ),
+    }
+    for name, value in prior.items():
+        monkeypatch.setitem(sys.modules, name, value)
+
+    def exercise() -> None:
+        with wx_harness.load_correction_modules(names=("events",)) as runtime:
+            assert runtime.events.MessageEvent is not foreign_event
+            if failure:
+                raise RuntimeError("broken body")
+
+    if failure:
+        with pytest.raises(RuntimeError, match="broken body"):
+            exercise()
+    else:
+        exercise()
+    for name, value in prior.items():
+        assert sys.modules[name] is value
+
+
+def test_explicit_wx_event_factory_replacement_is_preserved() -> None:
+    """Namespace isolation preserves deliberate wx child replacements."""
+    supplied_event = object()
+    wx = wx_harness.wx_stubs(Dialog=type("Dialog", (), {}))
+    wx["wx.lib"] = wx_harness.module("wx.lib", __path__=[])
+    wx["wx.lib.newevent"] = wx_harness.module(
+        "wx.lib.newevent", NewEvent=lambda: (supplied_event, object())
+    )
+    with wx_harness.load_correction_modules(wx=wx, names=("events",)) as runtime:
+        assert runtime.events.MessageEvent is supplied_event
+        assert runtime.wx.lib is wx["wx.lib"]
+        assert runtime.wx.lib.newevent is wx["wx.lib.newevent"]
+
+
+def test_one_shot_event_loader_also_isolates_preloaded_wx_children(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Events prepared for mainwindow stubs cannot use a foreign native factory."""
+    foreign_event = object()
+    prior = wx_harness.module(
+        "wx.lib.newevent", NewEvent=lambda: (foreign_event, object())
+    )
+    monkeypatch.setitem(sys.modules, prior.__name__, prior)
+    stubs = wx_harness.package_stubs("_harness_one_shot_events")
+    stubs.update(wx_harness.wx_stubs())
+    loaded = wx_harness.load("_harness_one_shot_events", "events", stubs)
+    assert loaded.MessageEvent is not foreign_event
+    assert sys.modules[prior.__name__] is prior
+
+
+def test_fake_wx_flags_are_distinct_and_missing_callables_are_errors() -> None:
+    """Strict stubs cannot silently accept an unimplemented native operation."""
+    stubs = wx_harness.wx_stubs()
+    wx = stubs["wx"]
+    flags = [wx.OK, wx.CANCEL, wx.ICON_ERROR, wx.ICON_WARNING, wx.ICON_QUESTION]
+    assert len(set(flags)) == len(flags)
+    assert all(flag > 0 and flag & (flag - 1) == 0 for flag in flags)
+    assert wx.NOT_FOUND == -1
+    for name in ("MessageBox", "TextCtrl", "SetValue", "__unexpected__"):
+        with pytest.raises(AttributeError, match=name):
+            getattr(wx, name)
+    assert isinstance(stubs["wx.dataview"], ModuleType)

--- a/tests/wx_harness.py
+++ b/tests/wx_harness.py
@@ -10,17 +10,23 @@ Stubs installed through :func:`temporary_modules` are removed again afterwards,
 which keeps one test file's fakes from becoming another's surprise.
 """
 
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
+from enum import Enum
+import importlib
 import importlib.util
 from itertools import count
 import logging
 from pathlib import Path
 import sys
 import types
+from typing import Any, Optional
+from unittest.mock import MagicMock
 
 ROOT = Path(__file__).parent.parent
 
 _MISSING = object()
+_CORRECTION_PACKAGES = count()
 
 
 def module(name, **symbols):
@@ -31,13 +37,62 @@ def module(name, **symbols):
 
 
 @contextmanager
-def temporary_modules(replacements):
-    """Install import stubs temporarily and restore prior modules afterward."""
-    previous = {name: sys.modules.get(name, _MISSING) for name in replacements}
+def temporary_modules(
+    replacements: Mapping[str, types.ModuleType], *, namespaces: Iterable[str] = ()
+) -> Iterator[None]:
+    """Restore scoped module entries and supplied packages' child bindings."""
+    roots = tuple(namespaces)
+
+    def in_namespace(name: str) -> bool:
+        return any(name == root or name.startswith(root + ".") for root in roots)
+
+    def child_bindings(name: str, symbols: Mapping[str, Any]) -> set[str]:
+        return {
+            key
+            for key, value in symbols.items()
+            if isinstance(value, types.ModuleType) and value.__name__ == f"{name}.{key}"
+        }
+
+    names = set(replacements) | {name for name in sys.modules if in_namespace(name)}
+    previous = {name: sys.modules.get(name, _MISSING) for name in names}
+    packages = {
+        name: (value, dict(vars(value)))
+        for name, value in replacements.items()
+        if in_namespace(name) and "__path__" in vars(value)
+    }
+    for name, (parent, symbols) in packages.items():
+        for key in child_bindings(name, symbols):
+            vars(parent).pop(key, None)
+    for name in names:
+        if in_namespace(name):
+            sys.modules.pop(name, None)
     sys.modules.update(replacements)
+    for name, value in replacements.items():
+        parent_name, _, attribute = name.rpartition(".")
+        if parent_name in packages:
+            setattr(packages[parent_name][0], attribute, value)
     try:
         yield
     finally:
+        for name, (parent, symbols) in packages.items():
+            imported_children = {
+                child[len(name) + 1 :]
+                for child in sys.modules
+                if child.startswith(name + ".") and "." not in child[len(name) + 1 :]
+            }
+            keys = (
+                imported_children
+                | child_bindings(name, vars(parent))
+                | child_bindings(name, symbols)
+            )
+            for key in keys:
+                if key in symbols:
+                    vars(parent)[key] = symbols[key]
+                else:
+                    vars(parent).pop(key, None)
+        for name in tuple(sys.modules):
+            if in_namespace(name):
+                sys.modules.pop(name, None)
         for name, restored in previous.items():
             if restored is _MISSING:
                 sys.modules.pop(name, None)
@@ -72,9 +127,11 @@ class FakeWxModule(types.ModuleType):
         return value
 
 
-def wx_stubs(*, submodules=("dataview", "adv"), **symbols):
+def wx_stubs(
+    *, submodules: Iterable[str] = ("dataview", "adv"), **symbols: Any
+) -> dict[str, types.ModuleType]:
     """Return ``{name: module}`` for a fake ``wx`` and the requested submodules."""
-    wx = FakeWxModule("wx", **symbols)
+    wx = FakeWxModule("wx", **{"NOT_FOUND": -1, **symbols})
     wx.__path__ = []
     stubs = {"wx": wx}
     for submodule in submodules:
@@ -96,19 +153,93 @@ def package_stubs(package, submodules=()):
     return stubs
 
 
-def load(package, name, replacements):
+def load(
+    package: str, name: str, replacements: Mapping[str, types.ModuleType]
+) -> types.ModuleType:
     """Load ``<name>.py`` from the repo root as ``package.name`` under the stubs."""
     module_name = f"{package}.{name}"
     spec = importlib.util.spec_from_file_location(module_name, ROOT / f"{name}.py")
     assert spec is not None and spec.loader is not None
     loaded = importlib.util.module_from_spec(spec)
     loaded.__package__ = package
-    with temporary_modules({**replacements, module_name: loaded}):
+    namespaces = ("wx",) if "wx" in replacements else ()
+    with temporary_modules(
+        {**replacements, module_name: loaded}, namespaces=namespaces
+    ):
         spec.loader.exec_module(loaded)
     return loaded
 
 
-def mainwindow_stubs(package, *, wx=None, pcbnew=None, **overrides):
+@contextmanager
+def load_siblings(
+    package: str,
+    names: Iterable[str],
+    replacements: Mapping[str, types.ModuleType],
+) -> Iterator[dict[str, types.ModuleType]]:
+    """Keep real siblings and their dependencies registered for the whole scope.
+
+    Explicit replacements take precedence over real imports. A fresh synthetic
+    parent is provided unless the caller supplies one, so real package startup
+    never runs. All prior entries under the package are restored even if an
+    import or the calling test raises; transitive and deferred siblings created
+    inside the scope are removed.
+    """
+    stubs = {**package_stubs(package), **replacements}
+    namespaces = (package, "wx") if "wx" in replacements else (package,)
+    with temporary_modules(stubs, namespaces=namespaces):
+        loaded = {name: importlib.import_module(f"{package}.{name}") for name in names}
+        yield loaded
+
+
+@contextmanager
+def load_correction_modules(
+    *,
+    package: Optional[str] = None,  # noqa: UP045
+    wx: Optional[Mapping[str, types.ModuleType]] = None,  # noqa: UP045
+    pcbnew: Optional[types.ModuleType] = None,  # noqa: UP045
+    names: Iterable[str] = (),
+    replacements: Optional[Mapping[str, types.ModuleType]] = None,  # noqa: UP045
+) -> Iterator[types.SimpleNamespace]:
+    """Compose real correction siblings with explicit, scoped GUI substitutes.
+
+    Additional siblings share the same package, wx object, events, and correction
+    classes. Callers can supply their own wx and pcbnew controls and replace any
+    other dependencies; none are removed until the calling fixture exits.
+    """
+    package_name = package or f"_correction_tests_{next(_CORRECTION_PACKAGES)}"
+    stubs = (
+        dict(wx)
+        if wx is not None
+        else wx_stubs(
+            Dialog=type("Dialog", (), {}),
+            PostEvent=MagicMock(),
+            MessageBox=MagicMock(),
+            MessageDialog=MagicMock(),
+            NOT_FOUND=-1,
+        )
+    )
+    if pcbnew is not None:
+        stubs["pcbnew"] = pcbnew
+    stubs.update(replacements or {})
+    siblings = tuple(
+        dict.fromkeys(("library", "corrections", "correction_data", *names))
+    )
+    with load_siblings(package_name, siblings, stubs) as loaded:
+        yield types.SimpleNamespace(
+            **loaded,
+            data=loaded["correction_data"],
+            wx=stubs["wx"],
+            package_name=package_name,
+        )
+
+
+def mainwindow_stubs(
+    package: str,
+    *,
+    wx: Optional[Mapping[str, types.ModuleType]] = None,  # noqa: UP045
+    pcbnew: Optional[types.ModuleType] = None,  # noqa: UP045
+    **overrides: Mapping[str, Any],
+) -> dict[str, types.ModuleType]:
     """Return every module ``mainwindow.py`` imports, stubbed.
 
     Defaults behave like the real thing where a caller is likely to depend on a
@@ -171,6 +302,9 @@ def mainwindow_stubs(package, *, wx=None, pcbnew=None, **overrides):
             "LibraryState": types.SimpleNamespace(
                 INITIALIZED=object(), UPDATE_NEEDED=object()
             ),
+            "CorrectionState": Enum(
+                "CorrectionState", ("READY", "NEEDS_REPAIR", "UNAVAILABLE")
+            ),
         },
         "partdetails": {"PartDetailsDialog": object},
         "partmapper": {"PartMapperManagerDialog": object},
@@ -182,8 +316,10 @@ def mainwindow_stubs(package, *, wx=None, pcbnew=None, **overrides):
     }
     symbols.update(overrides)
     stubs.update(
-        {f"{package}.{suffix}": module(f"{package}.{suffix}", **values)
-         for suffix, values in symbols.items()}
+        {
+            f"{package}.{suffix}": module(f"{package}.{suffix}", **values)
+            for suffix, values in symbols.items()
+        }
     )
     return stubs
 


### PR DESCRIPTION
Importing a malformed correction CSV could persist values such as `47u`, then crash the plugin when corrections reloaded or the project reopened. Validate complete input before atomic writes, keep older invalid records repairable, and check a complete correction snapshot and its placements before fabrication starts.

Fixes #531.

### Changes

- Make `Correction` an immutable validated value with shared storage, CSV, editor, and display adapters. Retain both compiled regex forms and share suffix-first reference/value/footprint matching between the list and CPL. Each included footprint is matched once.
- Preserve original invalid database records for repair. Guard manager edits, deletes, and replacements against concurrent record changes inside the write transaction; retain entered text when an operation must be retried.
- Keep legacy inspection out of ordinary reads. Preserve existing destination patterns, then rotations-archive priority over parts archives and initial defaults. Record completed examination, retain known pending transfers across reopening, and report unreadable unknown archives as nonblocking warnings.
- Make optional initial-download scheduling failures warnings. Preserve source archives, atomic transfers and completion records, resumable initial downloads, and completed migrations that do not replay over user deletions. Correct UNC URI handling at both database-open boundaries.
- Prepare all placement rows before generation side effects, reporting unrepresentable coordinates without overwriting previous output. Emit the prepared rows without rereading the board or matching again.

### Acceptance evidence

| Requirement | Evidence |
| --- | --- |
| Malformed imports cannot poison storage | Real SQLite and production import/manager workflows cover `47u`, numeric and regex boundaries, supported historical/current CSV formats, physical line diagnostics, duplicate policies, full-batch rejection, rollback, repair, and reopening. |
| Repair affects the selected and approved records | Constructor/handler regressions cover deleted and reused row IDs, same-row edits, raw SQLite type changes, and changed/added/removed replacement conflicts. Dirty inputs retain their original expected record. Failed actions refresh displayed rows; explicit reselection accepts current data. |
| Display and CPL use the same usable values | Immutable construction/replacement and serializer tests remain. Large-rule tests purge Python's regex cache and require no compilation during matching. Actual CPL/list workflows cover suffix-first ranking, target priority, ties, zeros, no match, both layers, offsets, and one selection per included footprint. |
| Placement failures precede output changes | Real exporters cover extreme finite offsets, final coordinate boundaries, and valid corrections that cancel a large origin-relative intermediate. Existing CPL bytes remain intact and absent files remain absent on failure. Production generation-handler tests stop before fill/hooks/Gerber/drill/archive steps. |
| One generation stays coherent; the next sees fresh data | The real generation/CPL workflow changes storage and board positions after preflight, verifies the exact prepared output and match count, blocks the next invalid generation before side effects, then verifies recovery after repair. |
| Migration does not disable unrelated healthy corrections | Tests require source-free snapshots and read-only settled startup. Missing/empty/no-table sources are terminal. Unknown archives warn; known incomplete transfers remain blocking across reopening and source loss. Optional thread-start failures preserve usable corrections through startup, manager retry, and committed scope changes. |
| Migration preserves data and precedence | Real transactions cover source priority, established repairs, malformed within-source records, rollback and completion failures, interrupted seeding, concurrent download ownership, changed library selection, and canonical path aliases. NULL/BLOB metadata keys cannot crash recovery or discard pending diagnostics. |
| Path and framework assumptions have explicit evidence | Portable SQLite URI tests exercise UNC/localhost identity, escaping, read-only/existing-only modes, missing files, and deletion races. Stateful wx doubles exercise actual manager constructors and handlers; authoritative wx/KiCad source supports selection and coordinate contracts. |

### Simplification and review

The review revision before the #812 rebase, compared with `2a54dec`, has **12 fewer production Python lines**. Regression tests add **212 lines** and documentation adds three; the full tracked revision is therefore **203 lines larger**.

The reduction removes redundant manager selection/row/state fields, manual multi-selection handling, an unused private matcher wrapper, duplicate constructor/rotation logic, an unused migration argument, and repeated metadata reads and completion/scheduler handling. Repeated test setup was consolidated; a weaker mocked generation test was replaced by the stronger real-output workflow. Distinct recovery cases were retained.

Review included a parent acceptance trace, an independent requirements-first audit, and an independent final patch review. Findings about source aliases, malformed metadata keys, final versus intermediate coordinate bounds, selection events, and in-flight download ownership were reconciled with regression coverage. Review revisions are folded into the original implementation commit.

### Validation and limits

Rebased onto upstream `main` at `0ad15dc` after #812 landed. An independent review and `git range-diff` confirm the original correction patch is unchanged. The full suite includes the four new database-cleanup tests from #812.

- Existing repository `myenv`: **1,282 tests passed**, no exclusions. Repository-wide Ruff lint, formatting and Python 3.9 syntax checks for all 19 PR Python files plus both incoming #812 files, annotations on all 115 new/modified revision functions, and whitespace checks passed.
- Configured Ruff, formatting, pyupgrade, and markdownlint commit hooks passed. Final committed files exactly match the reviewed and tested bytes; local `AGENTS.md` and `myenv` remain excluded.
- Tests use Python 3.12, real SQLite and CSV/CPL files, production constructors/handlers, and simulated wx/pcbnew objects. The installed KiCad Python conversion helper was also exercised without loading native KiCad.
- Native wx creation was attempted in `myenv` but unavailable because that interpreter lacks Framework/display access. Native KiCad, Windows/SMB, and Python 3.9 runtime execution are not claimed; no build or alternate environment was used.
- The original issue CSV was unavailable. Older versions also did not record whether absent patterns were deleted, renamed, or never imported; first migration cannot reconstruct that provenance. Completed migrations preserve later deletions, and explicitly restored data can be imported through supported CSV formats.
