### PR TITLE
Use classification enum in store enrichment query

### DIFF
--- a/common/test_store_pad_filter.py
+++ b/common/test_store_pad_filter.py
@@ -260,6 +260,7 @@ def test_get_assembly_enrichment_targets_uses_or_logic(tmp_path):
                 ("R5", "22k", "C5", "SMT", 3),
                 ("R6", "4k7", "C6", "SMT", "bad"),
                 ("R7", "1k", "C7", "SMT", 2),
+                ("R8", "2k2", "C8", "SMT", 1),
             ],
         )
         cur.commit()

--- a/store.py
+++ b/store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sqlite3
 from typing import Union
 
+from .bom_estimation.assembly_mode import ComponentProductType
 from .footprint_helpers import (
     get_exclude_from_bom,
     get_exclude_from_pos,
@@ -292,13 +293,14 @@ class Store:
 
     def get_assembly_enrichment_targets(self, references=None) -> dict:
         """Get references grouped by LCSC that still need assembly process enrichment."""
+        product_types = ",".join(str(member.value) for member in ComponentProductType)
         query = (
             "SELECT reference, lcsc FROM part_info "
             "WHERE lcsc IS NOT NULL AND lcsc != '' "
             "AND ("
             "assembly_process IS NULL OR assembly_process = '' "
             "OR component_product_type IS NULL "
-            "OR component_product_type NOT IN (0, 1, 2)"
+            f"OR component_product_type NOT IN ({product_types})"
             ")"
         )
         params = []


### PR DESCRIPTION
## Summary

Addresses [the review feedback from @z2amiller on #804](https://github.com/Bouni/kicad-jlcpcb-tools/pull/804#issuecomment-5556125432).

- Derive the recognized classification values in the store enrichment query from `ComponentProductType`, replacing the remaining hard-coded `NOT IN (0, 1, 2)` list.
- Use enum `.value` integers, preserving the existing SQL behavior and storage format.
- Extend the existing enrichment-selection test with a fully enriched Economic Only (`1`) part. The test already covers recognized `0` and `2`, plus missing and invalid classifications.

Two files, four additions and one deletion. Production and test changes are in separate commits. No schema, UI, or pricing-policy changes.

## Validation

- All 455 tracked tests passed, including the localhost HTTP-server tests.
- Ruff lint and formatting checks passed for both changed files.
- `git diff --check` passed.

Checks ran directly in the existing `myenv`. Local pre-commit hooks were bypassed because they use separate Python environments.