### PR TITLE
fix(fabrication): export decimal CPL coordinates (#769)

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -461,8 +461,12 @@ class Fabrication:
                         part["reference"],
                         part["value"],
                         part["footprint"],
-                        ToMM(position.x),
-                        ToMM(position.y) * -1,
+                        # Fixed-point millimetres follow JLCPCB's exporter:
+                        # https://github.com/JLCPCB/jlcpcb-eagle/blob/master/ulps/jlcpcb_smta_exporter.ulp
+                        # Six decimals preserve KiCad's 1 nm internal resolution:
+                        # https://docs.kicad.org/doxygen/base__units_8h.html
+                        f"{ToMM(position.x):.6f}",
+                        f"{ToMM(position.y) * -1:.6f}",
                         self.fix_rotation(fp),
                         "top" if fp.GetLayer() == 0 else "bottom",
                     ]

--- a/tests/test_fabrication_cpl_format.py
+++ b/tests/test_fabrication_cpl_format.py
@@ -1,4 +1,4 @@
-"""Keep CPL coordinates in decimal millimetres for GitHub issue #769."""
+"""Keep CPL coordinates in decimal millimetres."""
 
 import csv
 from pathlib import Path

--- a/tests/test_fabrication_cpl_format.py
+++ b/tests/test_fabrication_cpl_format.py
@@ -1,0 +1,143 @@
+"""Keep CPL coordinates in decimal millimetres for GitHub issue #769."""
+
+import csv
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from .wx_harness import load, module, package_stubs
+
+
+class Point:
+    """Represent KiCad's integer nanometre coordinates."""
+
+    def __init__(self, x, y):
+        self.x = int(x)
+        self.y = int(y)
+
+    def __sub__(self, other):
+        """Subtract the board auxiliary origin."""
+        return Point(self.x - other.x, self.y - other.y)
+
+
+@pytest.fixture
+def generate_cpl(tmp_path):
+    """Run the real exporter with KiCad substitutes and temporary output."""
+    package = "_cpl_format_test"
+    stubs = package_stubs(package)
+    stubs["pcbnew"] = MagicMock(
+        ToMM=lambda value: value / 1_000_000,
+        FromMM=lambda value: round(value * 1_000_000),
+        wxPoint=Point,
+        VECTOR2I=Point,
+    )
+    helpers = f"{package}.footprint_helpers"
+    stubs[helpers] = module(helpers, get_is_dnp=lambda footprint: False)
+    fabrication_module = load(package, "fabrication", stubs)
+
+    def generate(position, *, layer=0, origin=(0, 0), offset=(0, 0)):
+        """Return the CSV rows after actual origin and correction calculations."""
+        footprint = SimpleNamespace(
+            GetReference=lambda: "R1",
+            GetValue=lambda: "10k",
+            GetFPID=lambda: SimpleNamespace(GetLibItemName=lambda: "R_0603"),
+            GetLayer=lambda: layer,
+            GetOrientation=lambda: SimpleNamespace(AsDegrees=lambda: 0),
+            Pads=lambda: [],
+            GetPosition=lambda: Point(*position),
+        )
+        board = SimpleNamespace(
+            GetFileName=lambda: str(tmp_path / "board.kicad_pcb"),
+            GetDesignSettings=lambda: SimpleNamespace(
+                GetAuxOrigin=lambda: Point(*origin)
+            ),
+            Footprints=lambda: [footprint],
+        )
+        part = {
+            "reference": "R1",
+            "value": "10k",
+            "footprint": "R_0603",
+            "exclude_from_pos": 0,
+            "lcsc": "C123",
+        }
+        parent = SimpleNamespace(
+            settings={},
+            library=SimpleNamespace(
+                get_all_correction_data=lambda: [("R1", 0, offset)]
+            ),
+            store=SimpleNamespace(get_part=lambda reference: part),
+        )
+        fabrication = fabrication_module.Fabrication(parent, board)
+        fabrication.generate_cpl()
+        with Path(fabrication.get_cpl_csv_path()).open(newline="") as stream:
+            return list(csv.DictReader(stream))
+
+    return generate
+
+
+@pytest.mark.parametrize(
+    "coordinate,expected_x,expected_y,layer",
+    [
+        (0, "0.000000", "-0.000000", 0),
+        (1, "0.000001", "0.000001", 0),
+        (-1, "-0.000001", "-0.000001", 31),
+        (5, "0.000005", "0.000005", 0),
+        (-5, "-0.000005", "-0.000005", 31),
+        (50, "0.000050", "0.000050", 0),
+        (-50, "-0.000050", "-0.000050", 31),
+        (99, "0.000099", "0.000099", 0),
+        (-99, "-0.000099", "-0.000099", 31),
+        (100, "0.000100", "0.000100", 0),
+        (-100, "-0.000100", "-0.000100", 31),
+        (101, "0.000101", "0.000101", 0),
+        (-101, "-0.000101", "-0.000101", 31),
+        (12_345_678, "12.345678", "12.345678", 0),
+        (-12_345_678, "-12.345678", "-12.345678", 31),
+    ],
+)
+def test_cpl_coordinates_use_decimal_millimetres(
+    generate_cpl, coordinate, expected_x, expected_y, layer
+):
+    """Preserve nanometre precision and Y inversion without exponent notation."""
+    rows = generate_cpl((coordinate, -coordinate), layer=layer)
+
+    assert rows == [
+        {
+            "Designator": "R1",
+            "Val": "10k",
+            "Package": "R_0603",
+            "Mid X": expected_x,
+            "Mid Y": expected_y,
+            "Rotation": "0" if layer == 0 else "180",
+            "Layer": "top" if layer == 0 else "bottom",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "position,origin,offset",
+    [
+        pytest.param(
+            (10_000_005, 19_999_995),
+            (10_000_000, 20_000_000),
+            (0, 0),
+            id="auxiliary-origin",
+        ),
+        pytest.param(
+            (1_000_005, -2_000_005),
+            (0, 0),
+            (-1, 2),
+            id="position-correction",
+        ),
+    ],
+)
+def test_cpl_formats_coordinates_after_transforms(
+    generate_cpl, position, origin, offset
+):
+    """Origin subtraction and position correction can leave tiny residuals."""
+    rows = generate_cpl(position, origin=origin, offset=offset)
+
+    assert rows[0]["Mid X"] == "0.000005"
+    assert rows[0]["Mid Y"] == "0.000005"


### PR DESCRIPTION
Small CPL coordinates currently reach csv.writer as floats, so 0.000005 mm is exported as 5e-06. Issue #769 reports that JLCPCB interprets the mantissa as the coordinate, moving the component by millimetres.

Format Mid X and Mid Y with six decimal places after position corrections and Y inversion. This prevents exponent notation while preserving KiCad's one-nanometre coordinate resolution.

Fixes https://github.com/Bouni/kicad-jlcpcb-tools/issues/769

Evidence:
- [JLCPCB CPL requirements](https://jlcpcb.com/help/article/pick-place-file-for-pcb-assembly) specify centroid coordinates in millimetres.
- [JLCPCB's EAGLE exporter](https://github.com/JLCPCB/jlcpcb-eagle/blob/master/ulps/jlcpcb_smta_exporter.ulp) writes decimal coordinates using %5.2f.
- [KiCad's coordinate units](https://docs.kicad.org/doxygen/base__units_8h.html) establish the precision retained by six decimal places in millimetres.

The JLCPCB examples support decimal formatting; they do not prescribe six decimal places or document exponent parsing. The exporter defect is reproduced locally; a live JLCPCB upload was not performed.

Validation:
- Tests-first commit: new regression module produced 13 expected failures and 4 passing controls before the fix.
- Full pytest suite after the fix: 467 passed; 5 file-manager tests could not start their localhost HTTP server inside the sandbox. Rerunning common/test_filemgr.py with localhost access passed all 10 tests, covering all 472 suite cases across the two runs.
- Ruff check and Ruff format --check passed for both changed files.
- git diff --check and commit hooks passed.

The history contains a tests-only commit followed by the two-line production fix.
