### PR TITLE
Keep settings.json when PCM updates the package

### DIFF
--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -21,6 +21,9 @@
     "resources": {
         "homepage": "https://github.com/bouni/kicad-jlcpcb-tools"
     },
+    "keep_on_update": [
+        "plugins/[^/]*/settings\\.json$"
+    ],
     "versions": [{
         "version": "VERSION_HERE",
         "status": "testing",


### PR DESCRIPTION
PCM's update path calls `deletePackageDirectories()` with the regexes from the package's `keep_on_update`. With none declared, that call is a plain recursive `Rmdir`:

```cpp
// pcm/pcm_task_manager.cpp
if( aKeep.empty() )
    d.Rmdir( wxPATH_RMDIR_RECURSIVE );
```

So every update has deleted the whole plugin directory and brought the plugin back with default settings.

This declares `settings.json` as kept. One field, no code change.

### Scope

Only the archive's own metadata is built from this template, so this covers **install-from-zip** immediately: `installFromFile()` parses the metadata out of the zip it is handed. An update driven from a **repository listing** uses the metadata that listing carries, so `bouni-kicad-repository` (and the KiCad addons metadata repo) need to pick the field up separately for the PCM "Update" button to honour it. I could not tell from this repo whether those regenerate from the archive metadata.

### Not in this PR

The same delete also removes the parts catalog, the global corrections database and the footprint mappings, all of which live under the plugin directory by default. A follow-up covers the two user-owned databases; the catalog is a larger question, since `check_library()` only tests it for existence and size and it carries no schema version.

### Verification

`keep_on_update` regexes are matched against the path relative to the 3rdparty root with `/` separators, via `wxRegEx::Matches` (a search, not an anchored match). Checked that the pattern matches `.../plugins/<pkg>/settings.json` with or without a leading separator, and does not match `default_settings.json`, anything under `jlcpcb/`, or the resources icon. `create_pcm_archive.sh` still emits valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)