### PR TITLE
Keep the user-owned databases when PCM updates the package

### DIFF
--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -21,6 +21,9 @@
     "resources": {
         "homepage": "https://github.com/bouni/kicad-jlcpcb-tools"
     },
+    "keep_on_update": [
+        "plugins/[^/]*/settings\\.json$"
+    ],
     "versions": [{
         "version": "VERSION_HERE",
         "status": "testing",

--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -22,7 +22,9 @@
         "homepage": "https://github.com/bouni/kicad-jlcpcb-tools"
     },
     "keep_on_update": [
-        "plugins/[^/]*/settings\\.json$"
+        "plugins/[^/]*/settings\\.json$",
+        "plugins/[^/]*/jlcpcb/corrections\\.db$",
+        "plugins/[^/]*/jlcpcb/mappings\\.db$"
     ],
     "versions": [{
         "version": "VERSION_HERE",

--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -22,9 +22,9 @@
         "homepage": "https://github.com/bouni/kicad-jlcpcb-tools"
     },
     "keep_on_update": [
-        "plugins/[^/]*/settings\\.json$",
-        "plugins/[^/]*/jlcpcb/corrections\\.db$",
-        "plugins/[^/]*/jlcpcb/mappings\\.db$"
+        "plugins/[^/]+/settings\\.json$",
+        "plugins/[^/]+/jlcpcb/corrections\\.db$",
+        "plugins/[^/]+/jlcpcb/mappings\\.db$"
     ],
     "versions": [{
         "version": "VERSION_HERE",


### PR DESCRIPTION
Follow-up to #822 — **stacked on it**, so this PR shows two commits until that one merges. The commit to review here is `36d3651`.

The recursive delete described in #822 does not only take `settings.json`. It removes everything under the plugin's `jlcpcb/` directory, which is where the global corrections database and the footprint mappings live:

| File | What it holds |
|---|---|
| `jlcpcb/corrections.db` | global corrections, remote-fetched and hand-added |
| `jlcpcb/mappings.db` | footprint mappings — also the store #809 keeps under its original name |

Both are data the user built up by hand, and neither comes back by re-downloading anything. On one local KiCad 9.0 install this directory was 4.9 GB, nearly all of it catalog — but the part that hurts to lose is the few hundred KB of corrections and mappings.

### The parts catalog is deliberately excluded

It is large, it is re-downloadable, and `check_library()` only tests it for existence and non-zero size. The catalog's `meta` table carries `last_update`/`size`/`partcount` but no schema version, so a stale catalog carried across a schema change would be loaded happily and fail at query time. Keeping it wants a version check first, which is a separate conversation.

### The legacy sources are excluded too

`rotations.db` and `corrections/cpl_rotations_db.csv` are also deleted today, and both were considered:

- **`rotations.db`** stopped being the store in `f9ef06f` (2025-03-23), first shipped in **2025.04.02**. Any install that has launched the plugin since then has already run `migrate_corrections_from_rotation()` and has a populated `corrections.db`, leaving `rotations.db` inert. The remaining window — same KiCad major/minor since before that release, plugin never updated since — is real but small, and since `2a545bd` a missing `corrections.db` auto-fetches the upstream corrections table on first run, so those installs come back populated rather than empty. Only hand-added local corrections from an install untouched for 17 months would be lost.
- **`cpl_rotations_db.csv`** has not been the store since `d24e35d` (2021-11-25) and is renamed to `.backup` on import.

Carrying either would mean a permanent line in the package metadata implying support for a file format the code only reads during a one-time migration. Happy to add them back if you would rather be thorough.

### Worth flagging for future schema changes

`create_correction_table()` and `create_mapping_table()` use `CREATE TABLE IF NOT EXISTS` with no column-level migration. Once these files start surviving updates, a future schema change to either will need an `ALTER` path of the kind `Store.ensure_part_info_columns()` already uses for the project database. The existing forward migrations (`migrate_corrections`, `migrate_mappings`) only fire when the database is missing or empty, so they will not cover a column addition.

### Verification

Confirmed the patterns match `corrections.db` and `mappings.db` under `plugins/<pkg>/jlcpcb/`, and do **not** match `current-parts-fts5.db`, the `.zip.NNN` download chunks, `default_settings.json`, or plugin source files. `create_pcm_archive.sh` still emits valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)