### PR TITLE
corrections: a Delete all button (fixes #787)

### DIFF
--- a/corrections.py
+++ b/corrections.py
@@ -241,6 +241,14 @@ class CorrectionManagerDialog(wx.Dialog):
             HighResWxSize(parent.window, wx.Size(150, -1)),
             0,
         )
+        self.delete_all_button = wx.Button(
+            self,
+            wx.ID_ANY,
+            "Delete all",
+            wx.DefaultPosition,
+            HighResWxSize(parent.window, wx.Size(150, -1)),
+            0,
+        )
         self.update_button = wx.Button(
             self,
             wx.ID_ANY,
@@ -268,6 +276,7 @@ class CorrectionManagerDialog(wx.Dialog):
 
         self.save_button.Bind(wx.EVT_BUTTON, self.save_correction)
         self.delete_button.Bind(wx.EVT_BUTTON, self.delete_correction)
+        self.delete_all_button.Bind(wx.EVT_BUTTON, self.delete_all_corrections)
         self.update_button.Bind(wx.EVT_BUTTON, self.download_correction_data)
         self.import_button.Bind(wx.EVT_BUTTON, self.import_corrections_dialog)
         self.export_button.Bind(wx.EVT_BUTTON, self.export_corrections_dialog)
@@ -287,6 +296,14 @@ class CorrectionManagerDialog(wx.Dialog):
             )
         )
         self.delete_button.SetBitmapMargins((2, 0))
+
+        self.delete_all_button.SetBitmap(
+            loadBitmapScaled(
+                "mdi-trash-can-outline.png",
+                self.parent.scale_factor,
+            )
+        )
+        self.delete_all_button.SetBitmapMargins((2, 0))
 
         self.update_button.SetBitmap(
             loadBitmapScaled(
@@ -335,6 +352,7 @@ class CorrectionManagerDialog(wx.Dialog):
         tool_sizer = wx.BoxSizer(wx.VERTICAL)
         tool_sizer.Add(self.save_button, 0, wx.ALL, 5)
         tool_sizer.Add(self.delete_button, 0, wx.ALL, 5)
+        tool_sizer.Add(self.delete_all_button, 0, wx.ALL, 5)
         tool_sizer.AddStretchSpacer()
         tool_sizer.Add(self.update_button, 0, wx.ALL, 5)
         tool_sizer.Add(self.import_button, 0, wx.ALL, 5)
@@ -382,6 +400,8 @@ class CorrectionManagerDialog(wx.Dialog):
             self.delete_button.Enable(True)
         else:
             self.delete_button.Enable(False)
+
+        self.delete_all_button.Enable(self.corrections_list.GetItemCount() > 0)
 
     def _clear_selection(self) -> None:
         """Forget the stored row identity without changing unsaved input fields."""
@@ -599,6 +619,41 @@ class CorrectionManagerDialog(wx.Dialog):
                 self.selected_record.rowid,
                 db_path=self.selection_db_path,
                 expected_record=self.selected_record,
+            )
+        except CorrectionDataError as error:
+            self._show_error("Correction Delete Error", error)
+            self.populate_corrections_list(preserve_inputs=True)
+            return False
+        self._clear_selection()
+        self.populate_corrections_list()
+        wx.PostEvent(self.parent, PopulateFootprintListEvent())
+        return True
+
+    def delete_all_corrections(self, *_: object) -> bool:
+        """Empty the active correction database, after naming what will go."""
+        count = self.corrections_list.GetItemCount()
+        if count == 0:
+            return False
+        if self._uses_global_corrections():
+            scope = "the global corrections database"
+            recovery = "Update downloads the shared rules again."
+        else:
+            scope = "this board's local corrections database"
+            recovery = "The global corrections database is not affected."
+        noun = "rule" if count == 1 else "rules"
+        dialog = wx.MessageDialog(
+            self,
+            f"Delete all {count} correction {noun}?",
+            "Delete all corrections",
+            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+        )
+        # Rules the user wrote themselves come back only from an Export.
+        dialog.ExtendedMessage = f"This empties {scope}. {recovery}"
+        if dialog.ShowModal() != wx.ID_YES:
+            return False
+        try:
+            self.parent.library.delete_all_corrections(
+                db_path=self.correction_snapshot.db_path
             )
         except CorrectionDataError as error:
             self._show_error("Correction Delete Error", error)

--- a/library.py
+++ b/library.py
@@ -807,6 +807,20 @@ class Library:
                 )
             con.execute("DELETE FROM correction WHERE rowid = ?", (rowid,))
 
+    def delete_all_corrections(
+        self,
+        db_path: Optional[DatabasePath] = None,  # noqa: UP045
+    ) -> int:
+        """Empty the correction table, keeping the table, and report the row count.
+
+        The table itself is what marks a board as carrying its own corrections,
+        so dropping it would silently move the board back onto the global rules
+        rather than leaving it with none.
+        """
+        target = db_path if db_path is not None else self.correctionsdb_file
+        with self._correction_transaction(target) as con:
+            return con.execute("DELETE FROM correction").rowcount
+
     def update_correction_data(
         self, regex: object, rotation: object, offset: object
     ) -> None:

--- a/tests/test_corrections_import_export.py
+++ b/tests/test_corrections_import_export.py
@@ -141,6 +141,10 @@ class CorrectionList:
         """Capture a displayed original correction row."""
         self.rows.append(values)
 
+    def GetItemCount(self) -> int:
+        """Report the displayed row count the way wx does."""
+        return len(self.rows)
+
     def SelectRow(self, index: int) -> None:
         """Select a row, optionally dispatching synchronous wx events."""
         if self.selected != index:
@@ -1552,3 +1556,78 @@ def test_empty_corrections_export_header_and_remain_ready(
     assert path.read_text() == '"Pattern","Rotation","Offset X","Offset Y"\n'
     assert fresh_library(library).get_all_correction_data() == ()
     modules.wx.MessageBox.assert_not_called()
+
+
+def test_delete_all_empties_the_active_database_after_confirmation(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Confirming removes every rule and leaves no stale edit target behind."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (1, 2))
+    library.insert_correction_data("R2", 180, (0, 0))
+    dialog.populate_corrections_list()
+    select(dialog, 0)
+    assert dialog.selected_record is not None
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_YES
+
+    assert dialog.delete_all_corrections() is True
+
+    assert raw_rows(library) == []
+    assert dialog.corrections_list.rows == []
+    assert dialog.selected_record is None
+    assert "2 correction rules" in modules.wx.MessageDialog.call_args.args[1]
+    assert modules.wx.MessageDialog.call_args.args[3] & modules.wx.NO_DEFAULT
+
+
+def test_delete_all_declined_leaves_every_rule_in_place(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """The question must be answerable with no, since the wipe is not undoable."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (1, 2))
+    dialog.populate_corrections_list()
+    before = raw_rows(library)
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_NO
+
+    assert dialog.delete_all_corrections() is False
+
+    assert raw_rows(library) == before
+    assert "1 correction rule?" in modules.wx.MessageDialog.call_args.args[1]
+
+
+def test_delete_all_says_which_database_it_empties(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """Scope decides both the warning and the recovery route offered with it."""
+    modules, library, dialog = setup_manager
+    library.insert_correction_data("R1", 90, (1, 2))
+    dialog.populate_corrections_list()
+    modules.wx.MessageDialog.return_value.ShowModal.return_value = modules.wx.ID_NO
+
+    dialog.delete_all_corrections()
+    assert "global corrections database" in (
+        modules.wx.MessageDialog.return_value.ExtendedMessage
+    )
+    assert "Update downloads" in modules.wx.MessageDialog.return_value.ExtendedMessage
+
+    library.switch_to_global_correction_database(False)
+    dialog.populate_corrections_list()
+    dialog.delete_all_corrections()
+    message = modules.wx.MessageDialog.return_value.ExtendedMessage
+    assert "board's local corrections database" in message
+    assert "global corrections database is not affected" in message
+
+
+def test_delete_all_is_offered_only_while_there_is_something_to_delete(
+    setup_manager: tuple[SimpleNamespace, Any, Any],
+) -> None:
+    """An empty list makes the button meaningless, so it must not invite a click."""
+    modules, library, dialog = setup_manager
+    dialog.populate_corrections_list()
+    assert dialog.delete_all_button.enabled is False
+    assert dialog.delete_all_corrections() is False
+    modules.wx.MessageDialog.assert_not_called()
+
+    library.insert_correction_data("R1", 90, (1, 2))
+    dialog.populate_corrections_list()
+    assert dialog.delete_all_button.enabled is True

--- a/tests/test_library_corrections.py
+++ b/tests/test_library_corrections.py
@@ -2481,3 +2481,59 @@ def test_safe_typed_schema_preserves_numeric_patterns_and_large_rotations(
     assert correction_values(fresh_library(library)) == [
         ("123", exact_rotation, (0.125, -0.5))
     ]
+
+
+def test_delete_all_corrections_empties_the_table_without_dropping_it(library):
+    """Emptying the rules must leave the table that marks the storage as present."""
+    library.insert_correction_data("R1", 90, (1, 2))
+    library.insert_correction_data("R2", 180, (0, 0))
+
+    assert library.delete_all_corrections() == 2
+
+    assert raw_rows(library) == []
+    # The table surviving is what keeps a board on its own corrections.
+    assert execute(
+        library.correctionsdb_file,
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='correction'",
+    )
+    snapshot = fresh_library(library).read_correction_data()
+    assert snapshot.corrections == ()
+    assert snapshot.issues == ()
+
+
+def test_delete_all_corrections_on_an_empty_table_reports_nothing_deleted(library):
+    """An empty database is already in the requested state, not an error."""
+    assert library.delete_all_corrections() == 0
+    assert raw_rows(library) == []
+
+
+def test_delete_all_corrections_only_empties_the_named_database(modules, tmp_path):
+    """A board-local wipe must leave the shared global rules untouched."""
+    library = make_library(modules.library, tmp_path, local=True)
+    library.insert_correction_data("LOCAL", 90, (1, 2))
+    global_path = library.globalcorrectionsdb_file
+    library.create_correction_table(global_path)
+    execute(
+        global_path,
+        "INSERT INTO correction (regex, rotation, offset_x, offset_y) VALUES ('GLOBAL', 270, 0, 0)",
+    )
+
+    assert library.delete_all_corrections(db_path=library.localcorrectionsdb_file) == 1
+
+    assert raw_rows(library) == []
+    assert [
+        row[1] for row in execute(global_path, "SELECT rowid, regex FROM correction")
+    ] == ["GLOBAL"]
+
+
+def test_delete_all_corrections_rolls_back_when_the_write_is_aborted(modules, library):
+    """A refused delete must leave every rule in place rather than a partial wipe."""
+    library.insert_correction_data("R1", 90, (1, 2))
+    library.insert_correction_data("explode", 180, (0, 0))
+    before = raw_rows(library)
+    install_abort_trigger(library.correctionsdb_file, operation="DELETE")
+
+    with pytest.raises(modules.data.CorrectionDataError):
+        library.delete_all_corrections()
+
+    assert raw_rows(library) == before


### PR DESCRIPTION
Fixes #787.

Rebased onto #816. That PR rewrote the same functions this one touched, and in doing so answered part of the original branch and closed off another part, so what remains here is smaller than what was first proposed — see **What changed after #816** at the bottom.

Switching a board to a local corrections database copies every global rule (about 60 after the first-run download), and the only way back to none of them is to delete the rows one at a time.

### Delete all

A new **Delete all** button under Delete empties the active corrections database. It asks first, naming the row count and which database is affected:

- Global scope: *"This empties the global corrections database. Update downloads the shared rules again."*
- Board-local scope: *"This empties this board's local corrections database. The global corrections database is not affected."*

Update only brings back the shared rules — anything you wrote yourself is recoverable only from an Export, which is why the prompt defaults to No.

The button is enabled from the row count rather than from a selection, since it does not need one.

`Library.delete_all_corrections(db_path=None)` deletes the rows but keeps the table, because an existing `correction` table is what marks a board as using a local database — dropping it would quietly move the board back onto the global rules instead of leaving it with none. It goes through `_correction_transaction` like every other write, so a refused delete leaves every rule in place, and it takes the path the manager already resolved rather than re-deriving the active scope.

### Tests

Real SQLite through `tests/correction_test_support.make_library` and the real dialog through `tests/test_corrections_import_export.manager()`: the wipe and its row count, an empty database being a no-op rather than an error, a board-local wipe leaving the global rules intact, rollback when the write is refused, the confirmation text and its `NO_DEFAULT`, declining, the scope-dependent wording, and the button being disabled while the list is empty. Full suite: 1380 passed.

### What changed after #816

- **Multi-row delete is not in this branch.** #816 rebuilt the manager around a single `selected_record`, with `expected_record` concurrency guards per row, and set the list to `style=wx.dataview.DV_SINGLE`. The original branch's premise was that the list is `DV_MULTIPLE`. That is a question about the selection model rather than a rebase, so it is worth settling on its own rather than smuggling it in behind a Delete all button. Happy to open it separately if multi-select is wanted back.
- **The reselect-after-Save fix is obsolete.** `populate_corrections_list(selected=(kind, rowid))` already survives the synchronous `DeleteAllItems()` selection event on wxOSX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
