### PR TITLE
Fix Generate doing nothing on KiCad builds made with SWIG 4.5 (SwigPyIterator.next() removed)

### DIFF
--- a/footprint_helpers.py
+++ b/footprint_helpers.py
@@ -1,5 +1,6 @@
 """Helpers for reading and mutating KiCad footprint and board state."""
 
+from collections.abc import Iterator
 import re
 from typing import Any, Optional
 
@@ -72,6 +73,19 @@ def get_valid_footprints(board):
         if re.match(r"[\w\d-]+", fp.GetReference()):
             footprints.append(fp)
     return footprints
+
+
+def iter_board_items(container: Any) -> Iterator[Any]:
+    """Yield the concrete board items held by a pcbnew container."""
+    try:
+        items = list(container)
+    except AttributeError:
+        items = []
+        for index in range(len(container)):
+            item = container[index]
+            cast = getattr(item, "Cast", None)
+            items.append(cast() if callable(cast) else item)
+    return iter(items)
 
 
 def get_bit(value, bit):

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -65,6 +65,7 @@ from .footprint_helpers import (
     get_exclude_from_pos,
     get_is_dnp,
     find_lcsc_assignment_text,
+    iter_board_items,
     set_lcsc_value,
     toggle_exclude_from_bom,
     toggle_exclude_from_pos,
@@ -1831,7 +1832,7 @@ class JLCPCBTools(wx.Dialog):
     def count_order_number_placeholders(self):
         """Count the JLC order/serial number placeholders."""
         count = 0
-        for drawing in self.pcbnew.GetBoard().GetDrawings():
+        for drawing in iter_board_items(self.pcbnew.GetBoard().Drawings()):
             if drawing.IsOnLayer(kicad_pcbnew.F_SilkS) or drawing.IsOnLayer(
                 kicad_pcbnew.B_SilkS
             ):
@@ -2053,7 +2054,12 @@ class JLCPCBTools(wx.Dialog):
             if self.settings.get("general", {}).get("order_number"):
                 placeholder_count = count
             else:
-                placeholder_count = self.count_order_number_placeholders()
+                # Only the generation hooks need the count here, but a failure
+                # must still be attributed to this step rather than the last one.
+                placeholder_count = self.run_generation_step(
+                    "Counting order/serial placeholders",
+                    self.count_order_number_placeholders,
+                )
 
             current_generation_count = self.store.get_generation_count()
             pre_hook_env = self.build_generate_hook_env(

--- a/standalone_impl.py
+++ b/standalone_impl.py
@@ -100,7 +100,7 @@ class BoardStub:
         """Get a list of footprints that match a reference."""
         return Footprint_Stub(reference, "stub", 100)
 
-    def GetDrawings(self):
+    def Drawings(self):
         """Return board drawings.
 
         Standalone mode has no real drawing geometry, so expose an empty list.

--- a/tests/wx_harness.py
+++ b/tests/wx_harness.py
@@ -285,6 +285,7 @@ def mainwindow_stubs(
             "get_is_dnp": lambda _footprint: False,
             "get_lcsc_value": lambda _footprint: "",
             "find_lcsc_assignment_text": lambda _footprint: None,
+            "iter_board_items": iter,
             "set_lcsc_value": lambda *_args, **_kwargs: None,
             "toggle_exclude_from_bom": lambda _footprint: None,
             "toggle_exclude_from_pos": lambda _footprint: None,


### PR DESCRIPTION

# Bug descriprion

On KiCad builds generated with SWIG 4.5.0 (Arch `kicad 10.0.5-3` from 2026-08-28 onwards), clicking **Generate** does nothing.

SWIG 4.5.0 dropped `SwigPyIterator.next()` together with the rest of its Python 2 support (swig/swig#3201). KiCad's own SWIG interface adds a hand-written `__iter__` to the `DRAWINGS`, `TRACKS` and `VECTOR_SHAPEPTR` wrappers so it can `Cast()` every `BOARD_ITEM` to its concrete type, and that code still calls `it.next()`. 

On these builds iterating `board.Drawings()` and `board.GetDrawings()` raise:

```
  File "/usr/lib/python3.14/site-packages/pcbnew.py", line 22180, in GetDrawings
    def GetDrawings(self):            return list(self.Drawings())
  File "/usr/lib/python3.14/site-packages/pcbnew.py", line 13555, in __iter__
    item = it.next()  # throws StopIteration when iterator reached the end.
AttributeError: 'SwigPyIterator' object has no attribute 'next'
```

`Footprints()`, `Zones()` and `Pads()` are not affected, they go through SWIG's stock iterator.

The plugin hits this in `count_order_number_placeholders()`, which runs on every Generate. The call sits outside any `try`, so the exception escapes the wx event handler and is not shown in the built-in log console.

# Changes

- `footprint_helpers.iter_board_items(container)`: iterate normally, and if that raises the `AttributeError`, fall back to `len()` which still works.
- `mainwindow.count_order_number_placeholders()` iterates `board.Drawings()` through that helper instead of calling `GetDrawings()`. `Drawings()` is the C++ method the `GetDrawings()` wrapper itself calls and exists on every KiCad version the plugin supports.
- The hook-only placeholder count in `generate_fabrication_data()` now runs inside `run_generation_step("Counting order/serial placeholders", ...)`, so a failure there is reported against the right step.
- `standalone_impl.BoardStub` exposes `Drawings()` instead of `GetDrawings()`, and the test harness stub for `footprint_helpers` gained the new symbol so the existing mainwindow tests keep loading.

# Testing
- Test suite suite: 1579 passed, 17 warnings.
- Tested on 6 of our internal KiCad projects, generation is now fixed on machines with newer KiCad versions.

Alexandru Lucaci
Alacrity Education

