### PR TITLE
Use a regular frame for the JLCPCB Tools window

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -138,8 +138,8 @@ class KicadProvider:
         return kicad_pcbnew
 
 
-class JLCPCBTools(wx.Dialog):
-    """JLCPCBTools main dialog."""
+class JLCPCBTools(wx.Frame):
+    """JLCPCBTools main application window."""
 
     def __init__(
         self,
@@ -153,15 +153,17 @@ class JLCPCBTools(wx.Dialog):
         self.store: Optional[Store] = None
         while not wx.GetApp():
             time.sleep(1)
-        wx.Dialog.__init__(
+        wx.Frame.__init__(
             self,
             parent,
             id=wx.ID_ANY,
             title=f"JLCPCB Tools [ {getVersion()} ]",
             pos=wx.DefaultPosition,
             size=wx.Size(1300, 800),
-            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+            style=wx.DEFAULT_FRAME_STYLE,
         )
+        # Host the form on a wx.Panel to retain tab navigation and native colours.
+        self.content_panel = wx.Panel(self)
         self.pcbnew = kicad_provider.get_pcbnew()
         self.window = wx.GetTopLevelParent(self)
         self.SetSize(HighResWxSize(self.window, wx.Size(1300, 800)))
@@ -238,7 +240,7 @@ class JLCPCBTools(wx.Dialog):
         # ---------------------------------------------------------------------
 
         self.upper_toolbar = wx.ToolBar(
-            self,
+            self.content_panel,
             wx.ID_ANY,
             wx.DefaultPosition,
             wx.Size(1300, -1),
@@ -333,7 +335,7 @@ class JLCPCBTools(wx.Dialog):
 
         # An explicit width overrides GTK's content-based minimum size.
         self.right_toolbar = wx.ToolBar(
-            self,
+            self.content_panel,
             wx.ID_ANY,
             wx.DefaultPosition,
             wx.DefaultSize,
@@ -466,7 +468,7 @@ class JLCPCBTools(wx.Dialog):
         table_sizer.SetMinSize(HighResWxSize(self.window, wx.Size(-1, 600)))
 
         self.footprint_list = dv.DataViewCtrl(
-            self,
+            self.content_panel,
             style=wx.BORDER_THEME | dv.DV_ROW_LINES | dv.DV_VERT_RULES | dv.DV_MULTIPLE,
         )
 
@@ -592,7 +594,7 @@ class JLCPCBTools(wx.Dialog):
         # --------------------- Bottom Logbox and Gauge -----------------------
         # ---------------------------------------------------------------------
         self.logbox = wx.TextCtrl(
-            self,
+            self.content_panel,
             wx.ID_ANY,
             wx.EmptyString,
             wx.DefaultPosition,
@@ -601,7 +603,7 @@ class JLCPCBTools(wx.Dialog):
         )
         self.logbox.SetMinSize(HighResWxSize(self.window, wx.Size(-1, 150)))
         self.gauge = wx.Gauge(
-            self,
+            self.content_panel,
             wx.ID_ANY,
             100,
             wx.DefaultPosition,
@@ -616,7 +618,7 @@ class JLCPCBTools(wx.Dialog):
         # ---------------------------------------------------------------------
 
         self.bom_widget = BomEstimatorWidget(
-            self,
+            self.content_panel,
             window=self.window,
             board_count=self.bom_estimator_board_count,
             force_standard=self.bom_estimator_force_standard,
@@ -639,8 +641,8 @@ class JLCPCBTools(wx.Dialog):
 
         # This status must exist before init_data() first populates the list.
         # Invalid stored corrections remain repairable through the manager.
-        self.correction_status = wx.StaticText(self, label="")
-        self.project_storage_status = wx.StaticText(self, label="")
+        self.correction_status = wx.StaticText(self.content_panel, label="")
+        self.project_storage_status = wx.StaticText(self.content_panel, label="")
         self.project_storage_status.Hide()
         self.correction_status.Hide()
 
@@ -668,7 +670,10 @@ class JLCPCBTools(wx.Dialog):
         layout.Add(self.logbox, 0, wx.ALL | wx.EXPAND, 5)
         layout.Add(self.gauge, 0, wx.ALL | wx.EXPAND, 5)
 
-        self.SetSizer(layout)
+        self.content_panel.SetSizer(layout)
+        frame_layout = wx.BoxSizer(wx.VERTICAL)
+        frame_layout.Add(self.content_panel, 1, wx.EXPAND)
+        self.SetSizer(frame_layout)
         self.Layout()
         self.bom_widget.set_visible(self.bom_estimator_show)
         self.Layout()
@@ -745,6 +750,14 @@ class JLCPCBTools(wx.Dialog):
         )
 
         self.init_data()
+
+    def Layout(self) -> bool:
+        """Lay out the form after resizing or changing the visible controls."""
+        result = wx.Frame.Layout(self)
+        panel = getattr(self, "content_panel", None)
+        if panel:
+            panel.Layout()
+        return result
 
     def init_data(self, *, download_if_missing: bool = True) -> None:
         """Initialize the library and populate the main window."""
@@ -887,7 +900,7 @@ class JLCPCBTools(wx.Dialog):
             self._clear_catalog_views()
 
     def quit_dialog(self, *_: object) -> None:
-        """Destroy dialog on close."""
+        """Save layout and destroy the frame and its child windows on close."""
         logger = logging.getLogger(__name__)
         logger.info("quit_dialog()")
         layout_ready = getattr(self, "_layout_ready", False)
@@ -915,8 +928,6 @@ class JLCPCBTools(wx.Dialog):
                     root.removeHandler(self.logging_handler1)
                 with suppress(AttributeError):
                     root.removeHandler(self.logging_handler2)
-                if self.IsModal():
-                    self.EndModal(0)
                 self.Destroy()
 
     def init_library(self) -> None:

--- a/tests/part_preferences_test_support.py
+++ b/tests/part_preferences_test_support.py
@@ -23,7 +23,7 @@ def mainwindow(monkeypatch: pytest.MonkeyPatch) -> Iterator[types.ModuleType]:
     stubs = mainwindow_stubs(
         package,
         wx=wx_stubs(
-            Dialog=type("Dialog", (), {}),
+            Frame=type("Frame", (), {}),
             NewIdRef=lambda: next(ids),
             PostEvent=MagicMock(),
         ),

--- a/tests/test_mainwindow_correction_recovery.py
+++ b/tests/test_mainwindow_correction_recovery.py
@@ -30,6 +30,7 @@ def runtime(tmp_path: Path) -> Iterator[SimpleNamespace]:
     package = "mainwindow_correction_recovery_tests"
     wx = wx_stubs(
         Dialog=type("Dialog", (), {}),
+        Frame=type("Frame", (), {}),
         NewIdRef=MagicMock(side_effect=object),
         BeginBusyCursor=MagicMock(),
         EndBusyCursor=MagicMock(),

--- a/tests/test_mainwindow_empty_zone_warning.py
+++ b/tests/test_mainwindow_empty_zone_warning.py
@@ -17,7 +17,7 @@ def mainwindow_module():
     module = load_mainwindow(
         _PACKAGE,
         wx=wx_stubs(
-            Dialog=type("Dialog", (), {}),
+            Frame=type("Frame", (), {}),
             NewIdRef=MagicMock(side_effect=object),
             BeginBusyCursor=MagicMock(),
             EndBusyCursor=MagicMock(),

--- a/tests/test_mainwindow_part_details.py
+++ b/tests/test_mainwindow_part_details.py
@@ -12,7 +12,7 @@ _ids = count(1)
 mainwindow = load_mainwindow(
     "mainwindow_part_details_tests",
     wx=wx_stubs(
-        Dialog=type("Dialog", (), {}),
+        Frame=type("Frame", (), {}),
         NewIdRef=lambda: next(_ids),
     ),
 )

--- a/tests/test_mainwindow_stale_footprints.py
+++ b/tests/test_mainwindow_stale_footprints.py
@@ -21,7 +21,7 @@ _ids = count(1)
 mainwindow = load_mainwindow(
     "mainwindow_stale_footprint_tests",
     wx=wx_stubs(
-        Dialog=type("Dialog", (), {}),
+        Frame=type("Frame", (), {}),
         NewIdRef=lambda: next(_ids),
         PostEvent=lambda *_args, **_kwargs: None,
     ),

--- a/tests/test_settings_persistence.py
+++ b/tests/test_settings_persistence.py
@@ -11,7 +11,7 @@ from .wx_harness import load_mainwindow, wx_stubs
 
 mainwindow = load_mainwindow(
     "settings_persistence_tests",
-    wx=wx_stubs(Dialog=type("Dialog", (), {}), NewIdRef=lambda: 1),
+    wx=wx_stubs(Frame=type("Frame", (), {}), NewIdRef=lambda: 1),
 )
 JLCPCBTools = mainwindow.JLCPCBTools
 

--- a/tests/test_stock_concern_controller.py
+++ b/tests/test_stock_concern_controller.py
@@ -105,7 +105,7 @@ def workflow() -> Iterator[types.SimpleNamespace]:
         posted: list[tuple[Any, Any]] = []
         idle: list[Any] = []
         wx = wx_stubs(
-            Dialog=type("Dialog", (), {}),
+            Frame=type("Frame", (), {}),
             NewIdRef=lambda: 1,
             PostEvent=lambda window, event: posted.append((window, event)),
             CallAfter=lambda callback: idle.append(callback),

--- a/tests/test_window_layout.py
+++ b/tests/test_window_layout.py
@@ -59,11 +59,24 @@ class _Display:
         )
 
 
-class _Dialog:
+class _TopLevelWindow:
     """Dispatch bound events and retain the state read by the real handlers."""
 
-    def __init__(self, *_args: Any, size: tuple = (1400, 800), **_kwargs: Any) -> None:
+    def __init__(
+        self,
+        *_args: Any,
+        size: tuple = (1400, 800),
+        style: int = 0,
+        title: str = "",
+        **_kwargs: Any,
+    ) -> None:
         self._size = size
+        self._style = style
+        self._title = title
+        self._parent = _args[0] if _args else None
+        self._children: list[Any] = []
+        if isinstance(self._parent, _TopLevelWindow):
+            self._parent._children.append(self)
         self.display_index = 0
         self.scale_factor = getattr(_args[0], "scale_factor", 2) if _args else 2
         self._destroyed = False
@@ -73,16 +86,13 @@ class _Dialog:
         self.IsMaximized = MagicMock(return_value=False)
         self.IsIconized = MagicMock(return_value=False)
         self.IsFullScreen = MagicMock(return_value=False)
-        self.IsModal = MagicMock(return_value=False)
-        self.EndModal = MagicMock(side_effect=self._end_modal)
         self.FromDIP = lambda value: _scale(value, self.scale_factor)
         self.ToDIP = lambda value: _scale(value, 1 / self.scale_factor)
         for name in (
-            "SetAcceleratorTable SetSizer SetSizeHints Layout Centre Destroy"
+            "SetAcceleratorTable SetSizer SetSizeHints Centre Destroy"
         ).split():
             setattr(self, name, MagicMock())
         self.Destroy.side_effect = lambda: setattr(self, "_destroyed", True)
-        self.Layout.side_effect = self._layout
 
     def __bool__(self) -> bool:
         return not self._destroyed
@@ -90,9 +100,17 @@ class _Dialog:
     def Bind(self, event: Any, handler: Callable, *_args: Any, **_kwargs: Any) -> None:
         self._bindings[event] = handler
 
-    def _end_modal(self, _result: int) -> None:
-        assert self.IsModal(), "EndModal is invalid for a modeless dialog"
-        self.IsModal.return_value = False
+    def GetWindowStyleFlag(self) -> int:
+        return self._style
+
+    def GetParent(self) -> Any:
+        return self._parent
+
+    def GetTitle(self) -> str:
+        return self._title
+
+    def SetTitle(self, title: str) -> None:
+        self._title = title
 
     def _set_size(self, size: tuple) -> None:
         self._size = tuple(size)
@@ -102,8 +120,13 @@ class _Dialog:
 
     def _layout(self) -> None:
         self._laid_out = True
+        for child in self._children:
+            if isinstance(child, _Panel):
+                child._size = self._size
+            elif getattr(child, "_is_table", False):
+                child.client_width = self._size[0] - 80
         for name in ("part_list", "footprint_list"):
-            if hasattr(self, name):
+            if hasattr(self, name) and not isinstance(self, _Frame):
                 # Table borders and surrounding layout consume client space.
                 getattr(self, name).client_width = self._size[0] - 80
 
@@ -117,6 +140,36 @@ class _Dialog:
 
     def Close(self) -> None:
         self.emit(_wx["wx"].EVT_CLOSE)
+
+
+class _Frame(_TopLevelWindow):
+    """A normal frame deliberately has no dialog-only modal operations."""
+
+    def Layout(self) -> bool:
+        self._layout()
+        return True
+
+
+class _Panel(_TopLevelWindow):
+    """Retain the content area separately from the frame's outer layout."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.Layout = MagicMock(side_effect=self._layout)
+
+
+class _Dialog(_TopLevelWindow):
+    """Child dialogs retain their distinct modal API."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.Layout = MagicMock(side_effect=self._layout)
+        self.IsModal = MagicMock(return_value=False)
+        self.EndModal = MagicMock(side_effect=self._end_modal)
+
+    def _end_modal(self, _result: int) -> None:
+        assert self.IsModal(), "EndModal is invalid for a modeless dialog"
+        self.IsModal.return_value = False
 
 
 def _column(model_column: int, width: int, title: str = "Column") -> MagicMock:
@@ -215,6 +268,8 @@ def _clear_callbacks() -> Iterator[None]:
 
 _wx = wx_stubs(
     Dialog=_Dialog,
+    Frame=_Frame,
+    Panel=_Panel,
     Display=_Display,
     Size=_Size,
     DefaultPosition=None,
@@ -234,6 +289,14 @@ _wx = wx_stubs(
             "StaticBoxSizer ScrolledWindow AcceleratorEntry AcceleratorTable"
         ).split()
     },
+)
+_wx["wx"].DEFAULT_FRAME_STYLE = (
+    _wx["wx"].CAPTION
+    | _wx["wx"].MINIMIZE_BOX
+    | _wx["wx"].MAXIMIZE_BOX
+    | _wx["wx"].RESIZE_BORDER
+    | _wx["wx"].CLOSE_BOX
+    | _wx["wx"].SYSTEM_MENU
 )
 _wx["wx.adv"].BitmapComboBox = MagicMock()
 _wx["wx.dataview"].PyDataViewModel = object
@@ -325,6 +388,7 @@ def _open_selector(
 
         monkeypatch.setattr(_Dialog, "__init__", init_without_dip)
     monkeypatch.setattr(partselector.dv.DataViewCtrl, "return_value", control)
+    monkeypatch.setattr(partselector.dv.DataViewCtrl, "side_effect", None)
     if not real_search:
         monkeypatch.setattr(partselector.PartSelectorDialog, "search", MagicMock())
 
@@ -362,6 +426,14 @@ def _open_main(
 ) -> Any:
     control = _control(scale=2, client_width=0, stretch=True)
     monkeypatch.setattr(mainwindow.dv.DataViewCtrl, "return_value", control)
+
+    def create_table(parent: Any, *_args: Any, **_kwargs: Any) -> MagicMock:
+        control._is_table = True
+        control.GetParent.return_value = parent
+        parent._children.append(control)
+        return control
+
+    monkeypatch.setattr(mainwindow.dv.DataViewCtrl, "side_effect", create_table)
 
     def load_settings(window: Any) -> None:
         window.settings = json.loads(json.dumps(settings))
@@ -608,6 +680,54 @@ def test_selector_spacer_preserves_query_fields_row_alignment_and_sorting(
     assert selector.part_list.GetColumns()[-2].sortable
 
 
+def test_main_constructor_creates_a_normal_frame_with_window_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Create a regular application window with standard window controls."""
+    window = _open_main(monkeypatch, {})
+
+    assert isinstance(window, _Frame)
+    assert not isinstance(window, _Dialog)
+    assert not hasattr(window, "IsModal")
+    assert not hasattr(window, "EndModal")
+    assert window.GetTitle() == "JLCPCB Tools [ test ]"
+    assert window.GetWindowStyleFlag() == _wx["wx"].DEFAULT_FRAME_STYLE
+    for flag in ("MINIMIZE_BOX", "MAXIMIZE_BOX", "RESIZE_BORDER", "CLOSE_BOX"):
+        assert window.GetWindowStyleFlag() & getattr(_wx["wx"], flag)
+
+
+def test_main_form_controls_share_a_panel_and_follow_frame_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Frame forms require a panel, whose layout must follow outer size changes."""
+    factories = [
+        mainwindow.wx.ToolBar,
+        mainwindow.wx.TextCtrl,
+        mainwindow.wx.Gauge,
+        mainwindow.wx.StaticText,
+        mainwindow.BomEstimatorWidget,
+    ]
+    first_calls = [factory.call_count for factory in factories]
+    window = _open_main(monkeypatch, {})
+
+    panel = window.content_panel
+    assert isinstance(panel, _Panel)
+    assert panel.GetParent() is window
+    assert window.footprint_list.GetParent() is panel
+    for factory, first_call in zip(factories, first_calls):
+        calls = factory.call_args_list[first_call:]
+        assert calls
+        assert all(call.args[0] is panel for call in calls)
+    assert window.footprint_list.GetClientSize()[0] == window.GetSize()[0] - 80
+    panel.Layout.reset_mock()
+    window._size = (3000, 2000)
+
+    window.Layout()
+
+    panel.Layout.assert_called_once()
+    assert window.footprint_list.GetClientSize()[0] == 2920
+
+
 def test_main_constructor_restores_semantic_widths(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -632,11 +752,9 @@ def test_main_constructor_restores_semantic_widths(
 
 
 @pytest.mark.parametrize("selector_open", [False, True])
-@pytest.mark.parametrize("modal", [False, True])
 def test_parent_close_saves_both_layouts_once_before_destroy(
     monkeypatch: pytest.MonkeyPatch,
     selector_open: bool,
-    modal: bool,
 ) -> None:
     """Persist both windows before either destruction with one synchronous write."""
     window = _open_main(
@@ -646,7 +764,6 @@ def test_parent_close_saves_both_layouts_once_before_destroy(
             "mainwindow": {"column_widths": {"FP_COL": 90}},
         },
     )
-    window.IsModal.return_value = modal
     footprint = _column_by_title(window.footprint_list, "Footprint")
     footprint.SetWidth(240)
     issue_widths = {"BOM_COL": 110, "POS_COL": 90}
@@ -678,7 +795,6 @@ def test_parent_close_saves_both_layouts_once_before_destroy(
     else:
         assert snapshots[1:] == ["parent destroyed"]
     assert window._part_selector is None
-    assert window.EndModal.call_count == int(modal)
     reopened = _open_main(monkeypatch, snapshots[0])
     for key, width in issue_widths.items():
         assert snapshots[0]["mainwindow"]["column_widths"][key] == width
@@ -708,7 +824,6 @@ def test_incomplete_main_constructor_closes_without_overwriting_saved_layout(
     assert window.settings["mainwindow"] == saved_layout
     window.save_settings.assert_not_called()
     window.Destroy.assert_called_once()
-    window.EndModal.assert_not_called()
 
 
 def test_older_wx_preserves_widths_and_size_without_dip_methods(
@@ -775,7 +890,6 @@ def test_save_failure_still_destroys_windows_and_clears_selector(
         assert owner._part_selector is None
     if window is not None:
         window.Destroy.assert_called_once()
-        window.EndModal.assert_not_called()
 
 
 @pytest.mark.parametrize("fail_at", ["before_controls", "during_restore"])
@@ -1059,8 +1173,6 @@ def test_unexpected_persistence_failure_cannot_strand_windows(
         None if close_path == "main" else _open_selector(monkeypatch, {}, parent=window)
     )
     owner = window if window is not None else selector.parent
-    if window is not None:
-        window.IsModal.return_value = failure == "serialization"
     if failure == "capture":
         control = window.footprint_list if window is not None else selector.part_list
         control.GetColumns.side_effect = RuntimeError("layout capture failed")
@@ -1077,23 +1189,20 @@ def test_unexpected_persistence_failure_cannot_strand_windows(
         assert owner._part_selector is None
     if window is not None:
         window.Destroy.assert_called_once()
-        assert window.EndModal.call_count == int(failure == "serialization")
     if failure == "serialization":
         assert (tmp_path / "settings.json").read_bytes() == previous
         assert [path.name for path in tmp_path.iterdir()] == ["settings.json"]
 
 
-def test_selector_capture_failure_also_destroys_its_modal_parent(
+def test_selector_capture_failure_also_destroys_its_parent_frame(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A child close failure cannot skip the parent's modal-loop teardown."""
+    """A child close failure cannot skip the main frame's teardown."""
     window = _open_main(monkeypatch, {})
-    window.IsModal.return_value = True
     selector = _open_selector(monkeypatch, {}, parent=window)
     selector.part_list.GetColumns.side_effect = RuntimeError("layout capture failed")
     with pytest.raises(RuntimeError, match="layout capture failed"):
         window.Close()
     assert window._part_selector is None
     selector.Destroy.assert_called_once()
-    window.EndModal.assert_called_once_with(0)
     window.Destroy.assert_called_once()

--- a/tests/test_window_layout.py
+++ b/tests/test_window_layout.py
@@ -1,7 +1,7 @@
 """Regression coverage for persisted layouts through dialog lifecycle events."""
 
 from collections.abc import Callable, Iterator, Sequence
-from dataclasses import replace
+from dataclasses import dataclass, replace
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -59,6 +59,41 @@ class _Display:
         )
 
 
+@dataclass
+class _SizerItem:
+    child: Any
+    proportion: int
+    flag: int
+    border: int
+
+
+class _Sizer:
+    """Retain sizer membership without reproducing native layout calculations."""
+
+    def __init__(self, orientation: int, *_args: Any) -> None:
+        self.orientation = orientation
+        self.items: list[_SizerItem] = []
+        self.min_size: Optional[tuple] = None
+
+    def Add(
+        self, child: Any, proportion: int = 0, flag: int = 0, border: int = 0
+    ) -> _SizerItem:
+        item = _SizerItem(child, proportion, flag, border)
+        self.items.append(item)
+        return item
+
+    def SetMinSize(self, size: tuple) -> None:
+        self.min_size = size
+
+    def contains(self, child: Any) -> bool:
+        return any(
+            item.child is child
+            or isinstance(item.child, _Sizer)
+            and item.child.contains(child)
+            for item in self.items
+        )
+
+
 class _TopLevelWindow:
     """Dispatch bound events and retain the state read by the real handlers."""
 
@@ -75,6 +110,7 @@ class _TopLevelWindow:
         self._title = title
         self._parent = _args[0] if _args else None
         self._children: list[Any] = []
+        self._sizer: Optional[_Sizer] = None
         if isinstance(self._parent, _TopLevelWindow):
             self._parent._children.append(self)
         self.display_index = 0
@@ -88,9 +124,7 @@ class _TopLevelWindow:
         self.IsFullScreen = MagicMock(return_value=False)
         self.FromDIP = lambda value: _scale(value, self.scale_factor)
         self.ToDIP = lambda value: _scale(value, 1 / self.scale_factor)
-        for name in (
-            "SetAcceleratorTable SetSizer SetSizeHints Centre Destroy"
-        ).split():
+        for name in ("SetAcceleratorTable SetSizeHints Centre Destroy").split():
             setattr(self, name, MagicMock())
         self.Destroy.side_effect = lambda: setattr(self, "_destroyed", True)
 
@@ -112,6 +146,12 @@ class _TopLevelWindow:
     def SetTitle(self, title: str) -> None:
         self._title = title
 
+    def SetSizer(self, sizer: Optional[_Sizer]) -> None:
+        self._sizer = sizer
+
+    def GetSizer(self) -> Optional[_Sizer]:
+        return self._sizer
+
     def _set_size(self, size: tuple) -> None:
         self._size = tuple(size)
         if getattr(self, "_laid_out", False):
@@ -123,7 +163,11 @@ class _TopLevelWindow:
         for child in self._children:
             if isinstance(child, _Panel):
                 child._size = self._size
-            elif getattr(child, "_is_table", False):
+            elif (
+                getattr(child, "_is_table", False)
+                and self._sizer is not None
+                and self._sizer.contains(child)
+            ):
                 child.client_width = self._size[0] - 80
         for name in ("part_list", "footprint_list"):
             if hasattr(self, name) and not isinstance(self, _Frame):
@@ -270,6 +314,8 @@ _wx = wx_stubs(
     Dialog=_Dialog,
     Frame=_Frame,
     Panel=_Panel,
+    BoxSizer=_Sizer,
+    StaticBoxSizer=_Sizer,
     Display=_Display,
     Size=_Size,
     DefaultPosition=None,
@@ -285,8 +331,8 @@ _wx = wx_stubs(
     **{
         name: MagicMock()
         for name in (
-            "Timer StaticText TextCtrl Button ComboBox CheckBox BoxSizer ToolBar Gauge "
-            "StaticBoxSizer ScrolledWindow AcceleratorEntry AcceleratorTable"
+            "Timer StaticText TextCtrl Button ComboBox CheckBox ToolBar Gauge "
+            "ScrolledWindow AcceleratorEntry AcceleratorTable"
         ).split()
     },
 )
@@ -726,6 +772,38 @@ def test_main_form_controls_share_a_panel_and_follow_frame_layout(
 
     panel.Layout.assert_called_once()
     assert window.footprint_list.GetClientSize()[0] == 2920
+
+
+def test_main_form_sizer_is_attached_to_panel_inside_frame_sizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the table in the panel's form and the panel in the frame's sizer."""
+    window = _open_main(monkeypatch, {})
+    panel = window.content_panel
+    form_sizer = panel.GetSizer()
+    frame_sizer = window.GetSizer()
+
+    assert isinstance(form_sizer, _Sizer)
+    assert isinstance(frame_sizer, _Sizer)
+    assert form_sizer is not frame_sizer
+    assert form_sizer.orientation == _wx["wx"].VERTICAL
+    assert frame_sizer.orientation == _wx["wx"].VERTICAL
+    assert len(frame_sizer.items) == 1
+    panel_item = frame_sizer.items[0]
+    assert panel_item.child is panel
+    assert panel_item.proportion > 0
+    assert panel_item.flag & _wx["wx"].EXPAND
+
+    table_items = [
+        item
+        for item in form_sizer.items
+        if isinstance(item.child, _Sizer) and item.child.contains(window.footprint_list)
+    ]
+    assert len(table_items) == 1
+    table_item = table_items[0]
+    assert table_item.proportion > 0
+    assert table_item.flag & _wx["wx"].EXPAND
+    assert table_item.child.contains(window.right_toolbar)
 
 
 def test_main_constructor_restores_semantic_widths(


### PR DESCRIPTION
JLCPCB Tools opened as a `wx.Dialog`, which macOS treated as an auxiliary panel and omitted from the Window menu. Use a regular `wx.Frame` with standard window controls so the main plugin window participates in normal window management.

Host the form controls on a `wx.Panel` to preserve keyboard navigation and native background styling. Forward layout updates to the panel and remove dialog-only main-window teardown. Child dialogs retain their existing lifecycle, and saved layout keys/formats are unchanged. The implementation applies across platforms.

Rebased onto upstream `main` at `66b2c59`, retaining its updated `init_data` signature. The stock workflow fixture now supplies `wx.Frame`. Layout doubles retain distinct sizers, their children, and window attachments; constructor coverage verifies the form belongs to the panel and the frame expands that panel.

Validation on the rebased branch through `bdbf67f`:

- All **1,891 tracked tests passed**, including localhost download fixtures. Ruff 0.11.4 check and format check passed for all nine changed files; the patch passes `git diff --check`. Modified test files also parse with Python 3.9 grammar.
- GitHub CI on `bdbf67f` also passed: tests, Ruff, markdownlint, and deadcode.
- Before the stock fixture fix, its two modules produced 23 passes and 44 `AttributeError: Frame` errors. Afterward, all 67 pass.
- In isolated source copies, the previous 85 layout tests passed with the form attached to the frame, the frame-to-panel connection omitted, or the entire wrapper sizer removed. The new regression rejects each at the missing attachment/member assertion. It also rejects sharing the outer/form sizer and removing the panel's expansion flag. All 86 layout tests pass with correct wiring. These checks protect explicit sizer topology; wx.Frame can automatically size a sole child without an outer sizer.
- Acceptance tracing, an independent review from the original requirements and feedback, and final patch/commit review found no additional defects.

| Requirement | Evidence |
| --- | --- |
| Main window appears in the Window menu | A fresh native macOS shell probe found a regular native window listed while either fixture window was active; closing removed its entry. The original before-change probe found an `NSPanel` absent from the menu. |
| Form layout and keyboard navigation survive the conversion | Stateful constructor tests verify frame/panel/form attachments and nested table membership. A fresh full constructor with native controls and in-memory fixture data passed panel sizing, table resizing, and programmatic tab navigation checks. |
| Toolbar and timer events reach their handlers | Fresh native command events sent through both toolbars reached the frame handlers across the panel. A real BOM timer applied the changed board count. This checks event routing, not physical toolbar clicks. |
| Child windows remain usable and close with their parent | Fresh native generic modeless/modal child fixtures completed their lifecycle and were destroyed with the frame. Existing tests exercise production selector and Part Details paths with wx doubles. |
| Close/reopen preserves layout and handles persistence errors | Constructor/handler tests cover both layouts saving once, semantic width restoration, incomplete construction followed by close, and capture/save/serialization failures. The native full-window fixture retained an edited width after reopening with in-memory settings. |

Native probes used wxPython 4.3.1 / wxWidgets 3.3.3 with fixture board/settings data outside KiCad. They bypass project/catalog initialization and do not verify the bundled KiCad runtime or actual database operations. Manual follow-up remains: Window-menu selection, minimize/restore and close shortcuts inside KiCad, actual Settings/Part Selector interaction, and Windows/Linux native behavior.

The local commit hook was bypassed because it points to another Python installation and `pre_commit`/`pyupgrade` are unavailable in the prescribed environment. Pytest and Ruff were run directly in that environment; pyupgrade was not run.
