### PR TITLE
fix(ui): keep BOM and POS filters available without selection

### DIFF
--- a/mainwindow.py
+++ b/mainwindow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 # pyright: reportMissingImports=false, reportMissingModuleSource=false
-# ruff: noqa: I001
+# ruff: noqa: I001, UP045
 
 from collections.abc import Iterable, Sequence
 from contextlib import contextmanager, suppress
@@ -1788,8 +1788,8 @@ class JLCPCBTools(wx.Frame):
             # cause pcbnew to refresh the board with the changes to the selected footprint(s)
             self.pcbnew.Refresh()
 
-    def enable_part_specific_toolbar_buttons(self, state):
-        """Control the state of all the buttons that relate to parts in toolbar on the right side."""
+    def enable_part_specific_toolbar_buttons(self, state: bool) -> None:
+        """Enable toolbar actions that operate on selected footprints."""
         for button in (
             ID_SELECT_PART,
             ID_REMOVE_LCSC_NUMBER,
@@ -1797,8 +1797,6 @@ class JLCPCBTools(wx.Frame):
             ID_TOGGLE_BOM,
             ID_TOGGLE_POS,
             ID_PART_DETAILS,
-            ID_HIDE_BOM,
-            ID_HIDE_POS,
         ):
             self.right_toolbar.EnableTool(button, state)
 

--- a/tests/test_mainwindow_filters.py
+++ b/tests/test_mainwindow_filters.py
@@ -48,11 +48,13 @@ def _toolbar(*_args: Any, **_kwargs: Any) -> MagicMock:
     return toolbar
 
 
-@pytest.fixture
-def open_window(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[..., Any]]:
-    """Construct the dialog with stateful selection, tool bindings and visible rows."""
+@pytest.fixture(params=[True, False], ids=["reset-notifies-selection", "silent-reset"])
+def open_window(
+    monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
+) -> Iterator[Callable[..., Any]]:
+    """Construct the window with both native model-reset notification behaviors."""
     layout_support._after.clear()
-    bind_dialog = layout_support._Dialog.Bind
+    bind_window = mainwindow.JLCPCBTools.Bind
 
     def bind(
         window: Any,
@@ -64,13 +66,13 @@ def open_window(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[..., Any]]
         if event_type == mainwindow.wx.EVT_TOOL:
             window._bindings[event_type, source.GetId()] = handler
         else:
-            bind_dialog(window, event_type, handler, **kwargs)
+            bind_window(window, event_type, handler, **kwargs)
 
-    monkeypatch.setattr(layout_support._Dialog, "Bind", bind)
+    monkeypatch.setattr(mainwindow.JLCPCBTools, "Bind", bind)
     monkeypatch.setattr(mainwindow.wx, "ToolBar", _toolbar)
     monkeypatch.setattr(mainwindow.wx, "PostEvent", MagicMock(), raising=False)
 
-    def open_dialog(references: Optional[list[str]] = None) -> Any:  # noqa: UP045
+    def open_main_window(references: Optional[list[str]] = None) -> Any:  # noqa: UP045
         model = MagicMock()
         monkeypatch.setattr(
             mainwindow,
@@ -122,10 +124,11 @@ def open_window(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[..., Any]]
             selection_handler(MagicMock())
 
         def clear_rows() -> None:
+            had_selection = bool(selections)
             rows.clear()
-            if selections:
-                # Model reset can notify deselection; state changes before dispatch.
-                selections.clear()
+            selections.clear()
+            # Native model reset may clear selection without notifying the handler.
+            if had_selection and request.param:
                 selection_handler(MagicMock())
 
         def click(tool_id: int) -> None:
@@ -145,7 +148,7 @@ def open_window(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[..., Any]]
             window=window, rows=rows, parts=parts, select=select, click=click
         )
 
-    yield open_dialog
+    yield open_main_window
     layout_support._after.clear()
 
 
@@ -214,7 +217,9 @@ def test_last_visible_selected_row_can_be_hidden_and_restored(
     ui.click(tool)
     assert not ui.rows
     assert ui.window.footprint_list.GetSelectedItemsCount() == 0
-    assert not any(ui.window.right_toolbar.tools[tool].enabled for tool in PART_ACTIONS)
+    assert all(
+        ui.window.right_toolbar.tools[filter_id].enabled for filter_id in FILTERS
+    )
 
     ui.click(tool)
 

--- a/tests/test_mainwindow_filters.py
+++ b/tests/test_mainwindow_filters.py
@@ -1,0 +1,240 @@
+"""Selection-independent table filters through real constructor and event handlers."""
+
+from collections.abc import Callable, Iterator
+from copy import deepcopy
+import sqlite3
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from . import test_window_layout as layout_support
+
+mainwindow = layout_support.mainwindow
+FILTERS = (mainwindow.ID_HIDE_BOM, mainwindow.ID_HIDE_POS)
+PART_ACTIONS = (
+    mainwindow.ID_SELECT_PART,
+    mainwindow.ID_REMOVE_LCSC_NUMBER,
+    mainwindow.ID_TOGGLE_BOM_POS,
+    mainwindow.ID_TOGGLE_BOM,
+    mainwindow.ID_TOGGLE_POS,
+    mainwindow.ID_PART_DETAILS,
+)
+
+
+def _toolbar(*_args: Any, **_kwargs: Any) -> MagicMock:
+    """Retain tool state and parent availability as independent native properties."""
+    toolbar = MagicMock()
+    toolbar.available = True
+    toolbar.tools = {}
+
+    def add(tool_id: int, label: str, *_args: Any) -> MagicMock:
+        tool = MagicMock()
+        tool.enabled, tool.checked, tool.label = True, False, label
+        tool.GetId.return_value = tool_id
+        tool.SetLabel.side_effect = lambda label: setattr(tool, "label", label)
+        toolbar.tools[tool_id] = tool
+        return tool
+
+    toolbar.AddTool.side_effect = toolbar.AddCheckTool.side_effect = add
+    toolbar.Enable.side_effect = lambda enabled: setattr(toolbar, "available", enabled)
+    toolbar.EnableTool.side_effect = lambda tool_id, enabled: setattr(
+        toolbar.tools[tool_id], "enabled", enabled
+    )
+    toolbar.ToggleTool.side_effect = lambda tool_id, checked: setattr(
+        toolbar.tools[tool_id], "checked", checked
+    )
+    return toolbar
+
+
+@pytest.fixture
+def open_window(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[..., Any]]:
+    """Construct the dialog with stateful selection, tool bindings and visible rows."""
+    layout_support._after.clear()
+    bind_dialog = layout_support._Dialog.Bind
+
+    def bind(
+        window: Any,
+        event_type: Any,
+        handler: Callable,
+        source: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        if event_type == mainwindow.wx.EVT_TOOL:
+            window._bindings[event_type, source.GetId()] = handler
+        else:
+            bind_dialog(window, event_type, handler, **kwargs)
+
+    monkeypatch.setattr(layout_support._Dialog, "Bind", bind)
+    monkeypatch.setattr(mainwindow.wx, "ToolBar", _toolbar)
+    monkeypatch.setattr(mainwindow.wx, "PostEvent", MagicMock(), raising=False)
+
+    def open_dialog(references: Optional[list[str]] = None) -> Any:  # noqa: UP045
+        model = MagicMock()
+        monkeypatch.setattr(
+            mainwindow,
+            "PartListDataModel",
+            MagicMock(
+                columns=layout_support.datamodel.PartListDataModel.columns,
+                return_value=model,
+            ),
+        )
+        window = layout_support._open_main(monkeypatch, {})
+        parts = [
+            {
+                "reference": reference,
+                "value": "10k",
+                "footprint": "R_0603",
+                "lcsc": "",
+                "exclude_from_bom": bom,
+                "exclude_from_pos": pos,
+            }
+            for reference, bom, pos in (
+                ("R1", 0, 0),
+                ("R2", 1, 0),
+                ("R3", 0, 1),
+                ("R4", 1, 1),
+            )
+            if references is None or reference in references
+        ]
+        window.store = SimpleNamespace(read_all=lambda: parts)
+        window.library.read_correction_data = lambda: SimpleNamespace(corrections=())
+        footprints = {part["reference"]: MagicMock() for part in parts}
+        for footprint in footprints.values():
+            footprint.GetLayer.return_value = 0
+        window.pcbnew.GetBoard().FindFootprintByReference.side_effect = footprints.get
+        window.pcbnew.GetCurrentSelection.return_value = []
+        selections: list[str] = []
+        rows: dict[str, list[Any]] = {}
+        table = window.footprint_list
+        table.GetSelections.side_effect = lambda: list(selections)
+        table.GetSelectedItemsCount.side_effect = lambda: len(selections)
+        selection_handler = next(
+            call.args[1]
+            for call in table.Bind.call_args_list
+            if call.args[0] == mainwindow.dv.EVT_DATAVIEW_SELECTION_CHANGED
+        )
+
+        def select(*references: str) -> None:
+            assert set(references) <= rows.keys()
+            selections[:] = references
+            selection_handler(MagicMock())
+
+        def clear_rows() -> None:
+            rows.clear()
+            if selections:
+                # Model reset can notify deselection; state changes before dispatch.
+                selections.clear()
+                selection_handler(MagicMock())
+
+        def click(tool_id: int) -> None:
+            toolbar = window.right_toolbar
+            tool = toolbar.tools[tool_id]
+            assert toolbar.available and tool.enabled, "Filter is disabled"
+            tool.checked = not tool.checked
+            window._bindings[mainwindow.wx.EVT_TOOL, tool_id](
+                SimpleNamespace(IsChecked=lambda: tool.checked)
+            )
+
+        model.RemoveAll.side_effect = clear_rows
+        model.AddEntry.side_effect = lambda row: rows.update({row[0]: row})
+        model.get_reference.side_effect = lambda item: item
+        window.populate_footprint_list()
+        return SimpleNamespace(
+            window=window, rows=rows, parts=parts, select=select, click=click
+        )
+
+    yield open_dialog
+    layout_support._after.clear()
+
+
+def test_filters_available_on_open_reopen_and_selection_changes(
+    open_window: Callable[..., Any],
+) -> None:
+    """Opening and selecting zero, one or multiple rows never disables filters."""
+    for _ in range(2):
+        ui = open_window()
+        toolbar = ui.window.right_toolbar
+        assert not ui.window.hide_bom_parts and not ui.window.hide_pos_parts
+        assert set(ui.rows) == {"R1", "R2", "R3", "R4"}
+        assert all(toolbar.tools[tool].enabled for tool in FILTERS)
+        assert not any(toolbar.tools[tool].enabled for tool in PART_ACTIONS)
+        for references in (("R1",), ("R1", "R2"), ()):
+            ui.select(*references)
+            assert all(toolbar.tools[tool].enabled for tool in FILTERS)
+            assert all(
+                toolbar.tools[tool].enabled == bool(references) for tool in PART_ACTIONS
+            )
+        for tool in FILTERS:
+            ui.click(tool)
+        assert set(ui.rows) == {"R1"}
+        ui.window.Close()
+
+
+@pytest.mark.parametrize("first", FILTERS)
+def test_filters_combine_without_selection_or_changing_exclusions(
+    open_window: Callable[..., Any],
+    first: int,
+) -> None:
+    """Both filter orders produce the union of exclusions and restore original rows."""
+    ui = open_window()
+    before = deepcopy(ui.parts)
+    second = next(tool for tool in FILTERS if tool != first)
+    single_filter_rows = {
+        mainwindow.ID_HIDE_BOM: {"R1", "R3"},
+        mainwindow.ID_HIDE_POS: {"R1", "R2"},
+    }
+    for tool, expected in (
+        (first, single_filter_rows[first]),
+        (second, {"R1"}),
+        (first, single_filter_rows[second]),
+        (second, {"R1", "R2", "R3", "R4"}),
+    ):
+        ui.click(tool)
+        assert set(ui.rows) == expected
+        assert ui.parts == before
+        assert ui.window.footprint_list.GetSelectedItemsCount() == 0
+        for tool_id, suffix in zip(FILTERS, ("BOM", "POS")):
+            button = ui.window.right_toolbar.tools[tool_id]
+            hidden = getattr(ui.window, f"hide_{suffix.lower()}_parts")
+            assert button.checked == hidden
+            assert button.label == f"{'Show' if hidden else 'Hide'} excluded {suffix}"
+
+
+@pytest.mark.parametrize("tool", FILTERS)
+def test_last_visible_selected_row_can_be_hidden_and_restored(
+    open_window: Callable[..., Any],
+    tool: int,
+) -> None:
+    """An empty filtered table keeps its Show control reachable after deselection."""
+    ui = open_window(["R4"])
+    before = deepcopy(ui.parts)
+    ui.select("R4")
+    ui.click(tool)
+    assert not ui.rows
+    assert ui.window.footprint_list.GetSelectedItemsCount() == 0
+    assert not any(ui.window.right_toolbar.tools[tool].enabled for tool in PART_ACTIONS)
+
+    ui.click(tool)
+
+    assert set(ui.rows) == {"R4"}
+    assert ui.parts == before
+
+
+def test_storage_failure_still_disables_toolbar_until_recovery(
+    open_window: Callable[..., Any],
+) -> None:
+    """Selection-independent filters respect the separate whole-toolbar failure state."""
+    ui = open_window()
+    ui.window._set_project_storage_error(sqlite3.OperationalError("database is locked"))
+    assert not ui.window.right_toolbar.available
+    assert not ui.rows
+    ui.select()
+    assert not ui.window.right_toolbar.available
+
+    ui.window._set_project_storage_error(None)
+
+    assert ui.window.right_toolbar.available
+    assert all(ui.window.right_toolbar.tools[tool].enabled for tool in FILTERS)
+    assert not any(ui.window.right_toolbar.tools[tool].enabled for tool in PART_ACTIONS)


### PR DESCRIPTION
Hide excluded BOM and Hide excluded POS were disabled whenever no table row was selected. Keep both view filters enabled independently of selection so excluded rows can be shown again from an empty table.

Only the filters are removed from the selection-controlled toolbar group. The existing selection-event handling for footprint actions and the whole-toolbar disable for unavailable project storage are unchanged. A targeted Ruff exemption retains Python 3.9-compatible optional annotations.

The branch is rebased onto upstream `main` at `7dee28b`. The regression fixture intercepts `JLCPCBTools.Bind`, so it supports the main window's `wx.Frame` base. Every filter scenario runs with both notifying and silent model resets, with the fake selection cleared in either case.

Acceptance evidence:

| Behavior | Evidence |
| --- | --- |
| Filters work with zero, one, or multiple selected rows and after explicit deselection | Constructor and bound-handler regressions with stateful controls; native macOS Frame probe checks actual toolbar enable state. Explicit selection-event tests also verify footprint-action enablement. |
| BOM and POS filters work separately and together | Regressions cover both activation orders and verify visible rows, labels, and checked state. The native macOS probe exercises both filters and a combined sequence through dispatched toolbar events. |
| Hiding the last selected row still allows restoring it | Both filters remain enabled and restore rows whether model reset dispatches a selection event or stays silent. Native macOS controls also pass this workflow. |
| Filtering leaves exclusion values unchanged | Tests compare fixture BOM/POS exclusion flags before and after filtering. |
| Reopening with filters previously active starts with all rows visible | Constructor regression and native macOS probe verify the existing reset-on-open behavior. |
| Storage failure still disables the toolbar | Regression and native macOS checks inject a storage error; regression coverage also checks toolbar recovery. |

Validation:

- **1,932 tests passed:** `python -m pytest -q`. This includes **12 filter regression cases**, covering both reset-notification behaviors.
- The rebased branch reproduced the five reported fixture `KeyError` failures before the binding fix. The original filter regressions and native probe had reproduced selection-dependent disabling before the production fix.
- Ruff check, Ruff format check, and `git diff --check` passed. The feedback-fix commit passed Ruff, formatting, and pyupgrade hooks. The original production commit skipped pyupgrade's unrelated rewrites of pre-existing annotations.
- Native macOS verification passed with wxPython 4.3.1 / wxWidgets 3.3.3 using the actual Frame constructor, data model, table, and toolbar with fixture board/store data and dispatched wx events.

Platform limit and existing behavior: model reset does not guarantee a selection-change event. The [wx model documentation](https://wxpython.org/Phoenix/docs/html/wx.dataview.DataViewModel.html), [generic control source](https://github.com/wxWidgets/wxWidgets/blob/v3.3.1/src/generic/datavgen.cpp#L3143), and [GTK source](https://github.com/wxWidgets/wxWidgets/blob/v3.3.1/src/gtk/dataview.cpp) support testing silent resets. Footprint-action buttons can remain enabled after a silent reset until a later selection event; that pre-existing behavior is outside this filter fix. Automatic disabling after native model clearing was observed only in the tested macOS Cocoa run.

Acceptance tracing, independent requirements/platform review, and final patch review are complete. Windows/GTK behavior was source-inspected, not natively executed. Live KiCad integration, physical clicks, and real database persistence were not exercised. Temporary probe tooling is outside the repository.
